### PR TITLE
Refactored token authentication to make it more modular

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,11 @@
 class ApplicationController < ActionController::API
 
   include CanCan::ControllerAdditions
+  include TokenValidatable
+
+  rescue_from CanCan::AccessDenied, with: :access_denied
 
   before_action :set_locale
-  before_action :validate_token
   helper_method :current_user
 
   private
@@ -22,96 +24,16 @@ class ApplicationController < ActionController::API
 
   def current_user
     @current_user ||= begin
-      if token_header == 'undefined'
-        nil
-      else
-        otp_secret_key = token['otp_secret_key']
-        User.find_all_by_otp_secret_key(otp_secret_key).first
-      end
+      token.valid? ? User.find_all_by_otp_secret_key( token.otp_secret_key ).first : nil
     end
   end
 
-  def token_header
-    authorization_token = request.headers['Authorization'].try(:sub, "Bearer","")
-    authorization_token.present? ? authorization_token.try(:split, ' ').try(:last) : "undefined"
-  end
-
-  def token
-    decode_session_token(token_header)
-  end
-
-  def validate_token
-    unless token_header.blank? || token_header == "undefined"
-      validate_authenticity_of_token(token)
+  def access_denied
+    if request.format.json?
+      throw(:warden, {status: :unauthorized, message: I18n.t('warden.unauthorized'), value: false})
     else
-      throw(:warden, {status: :unauthorized,
-       message: I18n.t('warden.token_invalid'), value: false})
+      render(file: "#{Rails.root}/public/403.#{I18n.locale}.html", status: 403, layout: false)
     end
-  end
-
-  # Generate an encoded Json Web Token to send to client app
-  # on successful completion of the authentication process
-  def generate_enc_session_token(user_mobile, user_otp_skey)
-    cur_time = Time.now
-    JWT.encode({"iat" => cur_time.to_i,
-      "iss" => jwt_config['issuer'],
-      "exp" => (cur_time + 14.days).to_i,
-      "mobile"  => user_mobile,
-      "otp_secret_key"  => user_otp_skey},
-      jwt_config['secret_key'],
-      jwt_config['hmac_sha_algo'])
-  end
-
-  # Decode the json web token when we receive it from the client
-  # before proceeding ahead
-  def decode_session_token(token)
-    begin
-      JWT.decode(token, jwt_config['secret_key'], jwt_config['hmac_sha_algo'])
-    rescue JWT::DecodeError
-      throw(:warden, {status: :unauthorized, message: I18n.t('warden.token_invalid'), value: false})
-    end
-  end
-
-  # Is the JWT token is authentic? If authentic then allow to login
-  # exp should be in the future
-  # iat should be in the past
-  # Time.now should not be more than 14 days, that means time.now and
-  # exp should not be equal
-  def validate_authenticity_of_token(jwt_decoded_json)
-    unless (jwt_decoded_json.all? &:blank?)
-      cur_time = Time.now
-      iat_time = Time.at(jwt_decoded_json["iat"])
-      exp_time = Time.at(jwt_decoded_json["exp"])
-      case cur_time.present?
-        when (iat_time < cur_time && exp_time >= cur_time && iat_time < exp_time) == true
-          {message: I18n.t('warden.token_valid'), status: :ok , value: true}
-        when iat_time > cur_time == true
-          throw(:warden, {status: :forbidden,
-            message: I18n.t('warden.token_invalid'), value: false})
-        when exp_time < cur_time == true
-          throw(:warden, {status: :forbidden,
-            message: I18n.t('warden.token_expired'), value: false})
-        when iat_time < exp_time == true
-          throw(:warden, {status: :forbidden,
-            message: I18n.t('warden.token_invalid'), value: false})
-        else
-          throw(:warden, {status: :unauthorized,
-            message: I18n.t('warden.token_invalid'), value: false})
-      end
-    else
-      throw(:warden, {status: :unauthorized,
-        message: I18n.t('warden.token_invalid'), value: false})
-    end
-  end
-
-  def jwt_config
-    Rails.application.secrets.jwt
-  end
-
-  # When CanCan denys access, this is what it will do
-  rescue_from CanCan::AccessDenied do |exception|
-    throw(:warden, {status: :unauthorized, message: I18n.t('warden.unauthorized'), value: false}) if request.format.json?
-    render(file: "#{Rails.root}/public/403.#{I18n.locale}.html", status: 403, layout: false) if request.format.html?
   end
 
 end

--- a/app/controllers/concerns/token_validatable.rb
+++ b/app/controllers/concerns/token_validatable.rb
@@ -1,0 +1,21 @@
+module TokenValidatable
+
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :validate_token
+  end
+
+  private
+
+  def validate_token
+    unless token.valid?
+      throw(:warden, { status: :unauthorized, message: token.errors.full_messages.join, value: false })
+    end
+  end
+
+  def token
+    @token ||= Token.new( bearer: request.headers['Authorization'] )
+  end
+
+end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,0 +1,86 @@
+#
+# A class to handle JWT token encode/decode/verification
+#
+# Initialize token with request header e.g. Token.new( bearer: request.headers['Authorization'] )
+# Call token.valid? and token.errors
+# E.g. throw(:warden, { status: :unauthorized, message: token.errors.full_messages.join, value: false }) unless token.valid?
+
+class Token
+
+  include ::ActiveModel::Validations
+
+  validate :token_validation
+
+  def initialize(options = {})
+    @bearer = options[:bearer] || '' # "Bearer zxcasdqwesdfsdfqwe"
+  end
+
+  def otp_secret_key
+    token['otp_secret_key']
+  end
+
+  # Generate an encoded Json Web Token to send to client app
+  # on successful completion of the authentication process
+  # options = { "mobile" => "12345678" }
+  def generate(options = {})
+    now = Time.now
+    options.merge!({
+      "iat"            => now.to_i,
+      "iss"            => issuer,
+      "exp"            => (now + 14.days).to_i,
+      "otp_secret_key" => header
+    })
+    JWT.encode(options.stringify_keys, secret_key, hmac_sha_algo)
+  end
+
+  def header
+    @header ||= @bearer.sub("Bearer ","")
+  end
+
+  private
+
+  # Decode the json web token when we receive it from the client
+  def token
+    @token ||= JWT.decode(header, secret_key, hmac_sha_algo)
+  end
+
+  # Is the JWT token is authentic?
+  # - exp should be in the future
+  # - iat should be in the past
+  # Time.now should not be more than 14 days, that means time.now and
+  # exp should not be equal
+  def token_validation
+    if !header.blank? && !(token.all? &:blank?)
+      cur_time = Time.now
+      iat_time = Time.at(token["iat"])
+      exp_time = Time.at(token["exp"])
+      if exp_time < cur_time
+        errors.add(:base, I18n.t('token.expired'))
+      elsif !(iat_time < cur_time && iat_time < exp_time)
+        errors.add(:base, I18n.t('token.invalid'))
+      end
+    else
+      errors.add(:base, I18n.t('token.invalid'))
+    end
+  rescue JWT::DecodeError
+    Rails.logger.info("JWT::DecodeError - could not decode JWT token")
+    errors.add(:base, I18n.t('token.invalid'))
+  end
+
+  def jwt_config
+    Rails.application.secrets.jwt
+  end
+
+  def secret_key
+    jwt_config['secret_key']
+  end
+
+  def hmac_sha_algo
+    jwt_config['hmac_sha_algo']
+  end
+
+  def issuer
+    jwt_config['issuer']
+  end
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,14 +2,14 @@
 en:
   success: Success
   warden:
-    token_invalid: Invalid token
-    token_expired: Expired token
-    token_valid: Valid token
     unauthorized: You are not authorized to take this action.
   auth:
     pin_sent: A pin has been sent to your mobile device.
     mobile_required: Please provide a mobile number.
     mobile_exists: Mobile number already exists.
     mobile_doesnot_exist: Mobile number does not exist.
+  token:
+    invalid: Invalid token
+    expired: Expired token
   twilio:
     sms_verification_pin: Your pin is %{pin} and will expire by %{expiry}.

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,15 +1,15 @@
 ---
-zh-tw:
+en:
   success: Success
   warden:
-    token_invalid: Invalid token
-    token_expired: Expired token
-    token_valid: Valid token
     unauthorized: You are not authorized to take this action.
   auth:
     pin_sent: A pin has been sent to your mobile device.
     mobile_required: Please provide a mobile number.
     mobile_exists: Mobile number already exists.
     mobile_doesnot_exist: Mobile number does not exist.
+  token:
+    invalid: Invalid token
+    expired: Expired token
   twilio:
     sms_verification_pin: Your pin is %{pin} and will expire by %{expiry}.

--- a/spec/controllers/api/v1/authentication_controller_spec.rb
+++ b/spec/controllers/api/v1/authentication_controller_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
     let!(:user) {create(:user_with_specifics)}
     let!(:pin) {user.auth_tokens.recent_auth_token[:otp_code]}
     let!(:token) {user.auth_tokens.recent_auth_token[:otp_secret_key]}
-    let!(:jwt_token) {
-      controller.send(:generate_enc_session_token,user.mobile,token)
-    }
     let!(:mobile_no){ "+919930001948" }
 
     it 'verifies mobile exists' do
@@ -44,25 +41,27 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
         post :verify, format: 'json', token: token, pin: pin
         expect(response.message).to eq("OK")
         expect(response.status).to eq(200)
-        expect(controller.send(:generate_enc_session_token , user.mobile, token)).not_to be nil
-      end
-
-      it 'decode encoded token should have valid data' do
-        login_as(user)
-        cur_time = Time.now
-        decoded_token = controller.send(:decode_session_token , jwt_token)
-        expect(decoded_token["mobile"]).to eq(user.mobile)
-        expect(decoded_token["otp_secret_key"]).to eq(user.friendly_token)
-        expect(decoded_token["iss"]).to eq(Rails.application.secrets.jwt['issuer'])
-        expect(decoded_token["exp"]).to be > cur_time.to_i
-        expect(decoded_token["iat"]).to be <= cur_time.to_i
       end
     end
 
-    context "should retrieve details using OTP secret token" do
-      it 'should resend pin for a valid secret token' do
-        login_as(user)
-        request.env['HTTP_AUTHORIZATION'] = "Bearer #{token}"
+    context "resend" do
+      it 'should search_by_token if token is valid' do
+        allow(controller.send(:token)).to receive(:valid?).and_return(true)
+        expect(controller).to receive(:search_by_token)
+        get :resend
+      end
+      it 'should search_by_mobile if token is not valid' do
+        allow(controller.send(:token)).to receive(:valid?).and_return(false)
+        expect(controller).to receive(:search_by_mobile)
+        get :resend
+      end
+    end
+
+    context "search_by_token" do
+
+      it 'should resend pin if token is valid' do
+        allow(controller.send(:token)).to receive(:valid?).and_return(true)
+        allow(controller.send(:token)).to receive(:header).and_return(token)
         VCR.use_cassette "user OTP secret token" do
           get :resend
         end
@@ -70,29 +69,20 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
         expect(JSON.parse(response.body)["message"]).to eq(I18n.t('auth.pin_sent'))
       end
 
-      it 'should not resend pin for a token is empty' do
-        login_as(user)
-        request.env['HTTP_AUTHORIZATION'] = "  Bearer    "
-        get :resend
-        expect(request.env["warden.options"][:message][:text]).to eq("Mobile number does not exist.")
-        expect(request.env["warden.options"][:message][:token]).to eq("")
-        expect(response.status_message.downcase).to eq("unauthorized")
+      it 'should not resend pin if token is not valid' do
+        allow(controller.send(:token)).to receive(:valid?).and_return(false)
+        expect{ controller.send(:search_by_token) }.to throw_symbol(:warden)
       end
 
-      it 'should not resend pin as secret token is not in autherized ' do
-        login_as(user)
-        request.env['HTTP_AUTHORIZATION'] = "Bearer  xr2ysdkj12kkjs2"
-        VCR.use_cassette "user OTP secret token" do
-          get :resend
-        end
-        expect(request.env["warden.options"][:message][:token]).to eq("")
-        expect(request.env["warden.options"][:message][:text]).to eq(I18n.t("auth.mobile_required"))
+      it 'should not resend pin if secret token does not exist' do
+        allow(controller.send(:token)).to receive(:valid?).and_return(true)
+        allow(User).to receive(:find_all_by_otp_secret_key).and_return([])
+        expect{ controller.send(:search_by_token) }.to throw_symbol(:warden)
       end
     end
 
-    context "should retrieve details using mobile" do
-      it 'should resend pin for a valid mobile' do
-        login_as user
+    context "search_by_mobile" do
+      it 'should resend pin if mobile is valid' do
         VCR.use_cassette "valid user with verified mobile" do
           get :resend, format: 'json', mobile: '+919930001948'
         end
@@ -101,18 +91,15 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
       end
 
       it 'should not send pin to an invalid mobile' do
-        login_as user
         VCR.use_cassette "valid user with verified mobile" do
           get :resend, format: 'json', mobile: '+919930001949'
         end
         expect(request.env["warden.options"][:message][:mobile_exist]).to be false
         expect(request.env["warden.options"][:message][:token]).to eql("")
+        expect(request.env["warden.options"][:message][:text]).to eql(I18n.t("auth.mobile_doesnot_exist"))
         expect(response.status_message.downcase).to eq("unauthorized")
       end
     end
 
-    it 'verified OTP and generate the secret token' do
-      user
-    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,20 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
   describe "ApplicationController" do
-    #------------------------------------------------------------------------
-    let!(:user) {create(:user_with_specifics)}
-    let!(:pin) {user.auth_tokens.recent_auth_token[:otp_code]}
-    let!(:token) {user.auth_tokens.recent_auth_token[:otp_secret_key]}
-
-    let!(:jwt_token) {
-      controller.send(:generate_enc_session_token,user.mobile,token)}
-
-    let!(:set_jwt_auth_header){
-      request.env['HTTP_AUTHORIZATION'] = "Bearer #{jwt_token}" }
-
-    let!(:authorized_jwt_token){
-      set_jwt_auth_header.try(:sub, "Bearer","").try(:split, ' ').try(:last) }
-    #------------------------------------------------------------------------
 
     context "set_locale" do
       it "should set locale to zh-tw" do
@@ -31,17 +17,6 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
 
-    context 'token header' do
-      it 'has validate authorization header set' do
-        request.headers['Authorization'] = "Bearer  s2xtqb5mspzg4rq7"
-        expect(controller.send(:token_header)).to eq("s2xtqb5mspzg4rq7")
-      end
-      it 'had empty authorization header' do
-        request.headers['Authorization'] = "Bearer   "
-        expect(controller.send(:token_header)).to eq("undefined")
-      end
-    end
-
     context 'verify warden' do
       it 'warden object' do
         expect(controller.send(:warden)).to eq(request.env["warden"])
@@ -52,44 +27,5 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
 
-    context 'validate JWT token' do
-      it 'should be present' do
-        login_as(user)
-        expect(controller.send(:token_header)).not_to be_blank
-      end
-
-      it 'should be decoded by encoding key' do
-        login_as(user)
-        cur_time = Time.now.to_i
-        token_header_value = controller.send(:token_header)
-        jwt_decoded_json = controller.send(:decode_session_token, token_header_value)
-
-        expect(jwt_decoded_json["iat"]).to be <= cur_time
-        expect(jwt_decoded_json["iss"]).to eq(Rails.application.secrets.jwt['issuer'])
-        expect(jwt_decoded_json["exp"]).to be > cur_time
-        expect(jwt_decoded_json["mobile"]).to eq(user.mobile)
-        expect(jwt_decoded_json["otp_secret_key"]).to eq(user.friendly_token)
-      end
-
-      it 'should not be decoded by encoding key' do
-        login_as(user)
-        token_header_value = controller.send(:token_header).sub("e","x")
-        expect{controller.send(:decode_session_token, token_header_value)}.to throw_symbol(:warden)
-      end
-
-      it 'should be authenitic token' do
-        login_as(user)
-        token_header_value = controller.send(:token_header)
-        jwt_decoded_json = controller.send(:decode_session_token, token_header_value)
-        expect((controller.send(:validate_authenticity_of_token,
-          jwt_decoded_json))[:message]).to eq(I18n.t('warden.token_valid'))
-      end
-
-      it 'should be valid authenitic token' do
-        login_as(user)
-        expect((controller.send(:validate_token))[:message]).to eq(I18n.t('warden.token_valid'))
-      end
-
-    end
   end
 end

--- a/spec/controllers/concerns/token_validatable_spec.rb
+++ b/spec/controllers/concerns/token_validatable_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+class TokenValidatableFakeController < ActionController::Base
+  include TokenValidatable
+end
+
+describe TokenValidatableFakeController do
+
+  let(:token) { Token.new }
+  before { expect(Token).to receive(:new).and_return(token) }
+
+  it "should successfully validate a good token" do
+    expect(token).to receive(:valid?).and_return(true)
+    subject.send(:validate_token)
+  end
+
+  it "should throw unauthorized error if token validation fails" do
+    expect(token).to receive(:valid?).and_return(false)
+    expect{ subject.send(:validate_token) }.to throw_symbol(:warden)
+  end
+
+end

--- a/spec/factories/tokens.rb
+++ b/spec/factories/tokens.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :jwt_token, class: Token do
+    ignore do
+      token
+    end
+    initialize_with { new({ bearer: generate(:bearer) }) }
+  end
+end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe Token, :type => :model do
+
+  let(:token)  { Token.new(bearer: bearer) }
+  let(:bearer) { "Bearer test token" }
+
+  context "initialization" do
+    it "with valid bearer" do
+      expect(token.instance_variable_get('@bearer')).to eql(bearer)
+    end
+  end
+
+  context "generate" do
+    it "with no extra parameters" do
+      expect(JWT).to receive(:encode) do |args, secret_key, hmac_sha_algo|
+        expect( args['otp_secret_key'] ).to eql( token.header )
+        expect( args['iss'] ).to eql( Rails.application.secrets.jwt['issuer'] )
+        expect( secret_key ).to eql( Rails.application.secrets.jwt['secret_key'] )
+        expect( hmac_sha_algo  ).to eql( Rails.application.secrets.jwt['hmac_sha_algo'] )
+      end
+      token.generate
+    end
+    it "with extra parameters to encode" do
+      expect(JWT).to receive(:encode) do |args, secret_key, hmac_sha_algo|
+        expect( args['mobile'] ).to eql( '12345678' )
+      end
+      token.generate( mobile: '12345678' )
+    end
+  end
+
+  context "header" do
+    it "should truncate 'Bearer '" do
+      expect(token.header).to eql( bearer.sub('Bearer ', '') )
+    end
+  end
+
+  context "token" do
+
+    it "should call JWT.decode" do
+      expect(JWT).to receive(:decode).with(token.header, token.send(:secret_key), token.send(:hmac_sha_algo))
+      token.send(:token)
+    end
+  end
+
+  context "token_validation" do
+
+    let(:now) { Time.now }
+    let(:iat) { now.to_i }
+    let(:exp) { (now + 14.days).to_i }
+    let(:token_hash) { {'iat' => iat, 'exp' => exp} }
+    before{ allow(token).to receive(:token).and_return(token_hash) }
+
+    context "with valid token" do
+      it { expect(token).to be_valid }
+    end
+
+    context "with empty header" do
+      before{ allow(token).to receive(:header).and_return('') }
+      it{ expect(token).to_not be_valid }
+    end
+
+    context "with expired token" do
+      let(:exp) { (now - 1.day).to_i }
+      it do
+        expect(token).to_not be_valid
+        expect(token.errors.full_messages.join).to eql(I18n.t('token.expired'))
+      end
+    end
+
+    context "with iat in future" do
+      let(:iat) { (now + 1.day).to_i }
+      it do
+        expect(token).to_not be_valid
+        expect(token.errors.full_messages.join).to eql(I18n.t('token.invalid'))
+      end
+    end
+
+    context "with expiry before iat" do
+      let(:iat) { (exp + 1.day).to_i }
+      it do
+        expect(token).to_not be_valid
+        expect(token.errors.full_messages.join).to eql(I18n.t('token.invalid'))
+      end
+    end
+
+  end
+
+  context "jwt_config" do
+    let(:conf) { {config: true} }
+    before{ allow(Rails.application.secrets).to receive(:jwt).and_return(conf) }
+    it{ expect(token.send(:jwt_config)).to eql(conf) }
+  end
+
+  context "configuration" do
+    before{ allow(token).to receive(:jwt_config).and_return({ 'secret_key' => '123456', 'hmac_sha_algo' => 'SECURE', 'issuer' => 'ME' }) }
+    it{ expect( token.send(:secret_key) ).to eql( '123456' ) }
+    it{ expect( token.send(:hmac_sha_algo) ).to eql( 'SECURE' ) }
+    it{ expect( token.send(:issuer) ).to eql( 'ME' ) }
+  end
+
+end


### PR DESCRIPTION
Refactored some of the token authentication code.

Main refactoring points:
- Moved token methods from `application_controller.rb` to concerns module
- Created PORO `Token` class - a token should be able to handle it's own internal state
- Used `ActiveModel::Validations` to perform token validation
- Refactored validation method using errors architecture
- Moved test code according to above refactoring

Key points:
- Controllers should deal with logic and flow. if valid? do X else do Y. No need to perform token encode/decode/validation inside controllers
- Use model classes to deal with internal logic decode / encode / validation. When they deal with their own internal logic, the rest of the app can ignore it and just assume it works.
- Controller testing becomes much easier as it is about what goes where and can just assume a token exists.

This isn't ready for a merge yet. Need to do some final testing, but I'd love it if you could take a look at what I've done and provide feedback / comments. Thanks!. /cc @shivanibhanwal 
