### PR TITLE
Remove objects like item_type or district from serialization of objects ...

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -17,8 +17,7 @@ class Offer < ActiveRecord::Base
 
   scope :with_eager_load, -> {
     includes ( [:created_by, :reviewed_by, { delivery: [:schedule, :contact] }, { messages: :sender },
-      { items: [:item_type, :rejection_reason, :donor_condition, :images,
-               { messages: :sender }, { packages: :package_type }] }
+      { items: [:images, :packages, { messages: :sender }] }
     ])
   }
 

--- a/app/serializers/api/v1/address_serializer.rb
+++ b/app/serializers/api/v1/address_serializer.rb
@@ -5,7 +5,6 @@ module Api::V1
     attributes :id, :street, :flat, :building, :district_id, :addressable_id,
       :addressable_type
 
-    has_one :district, serializer: DistrictSerializer
   end
 
 end

--- a/app/serializers/api/v1/item_serializer.rb
+++ b/app/serializers/api/v1/item_serializer.rb
@@ -4,15 +4,12 @@ module Api::V1
     embed :ids, include: true
 
     attributes :id, :donor_description, :state, :offer_id, :reject_reason,
-      :saleable, :created_at, :updated_at, :image_identifiers,
-      :favourite_image, :rejection_comments
+      :saleable, :created_at, :updated_at, :image_identifiers, :item_type_id,
+      :favourite_image, :rejection_comments, :donor_condition_id, :rejection_reason_id
 
     has_many :packages, serializer: PackageSerializer
     has_many :messages, serializer: MessageSerializer
     has_many :images,   serializer: ImageSerializer
-    has_one  :rejection_reason, serializer: RejectionReasonSerializer
-    has_one  :item_type, serializer: ItemTypeSerializer
-    has_one  :donor_condition, serializer: DonorConditionSerializer
 
     def image_identifiers
       object.images.map(&:image_id).join(",")

--- a/app/serializers/api/v1/package_serializer.rb
+++ b/app/serializers/api/v1/package_serializer.rb
@@ -5,9 +5,8 @@ module Api::V1
 
     attributes :id, :quantity, :length, :width, :height, :notes,
       :item_id, :state, :received_at, :rejected_at,
-      :created_at, :updated_at
+      :created_at, :updated_at, :package_type_id
 
-    has_one :package_type, serializer: ItemTypeSerializer
   end
 
 end


### PR DESCRIPTION
...that reference them because a full list is already loaded in Ember on start
