### PR TITLE
Remove GET /api/items.json endpoint

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
     load_and_authorize_resource :item, parent: false
 
     resource_description do
-      short 'List, create, update and delete items.'
+      short 'Get, create, update and delete items.'
       formats ['json']
       error 401, "Unauthorized"
       error 404, "Not Found"
@@ -36,15 +36,7 @@ module Api::V1
       end
     end
 
-    api :GET, '/v1/items', "List all items"
-    param :ids, Array, of: Integer, desc: "Filter by item ids e.g. ids = [1,2,3,4]"
-    def index
-      @items = @items.with_eager_load # this maintains security
-      @items = @items.find(params[:ids].split(",")) if params[:ids].present?
-      render json: @items, each_serializer: serializer
-    end
-
-    api :GET, '/v1/item/1', "List an item"
+    api :GET, '/v1/item/1', "Get an item"
     def show
       render json: @item, serializer: serializer
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace "api" do
     namespace "v1", defaults: { format: "json" } do
-      resources :items
+      resources :items, except: [:index]
       post "auth/signup" => "authentication#signup"
       post "auth/verify" => "authentication#verify"
       post "auth/send_pin" => "authentication#send_pin"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,4 @@
-  # encoding: UTF-8
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/spec/controllers/api/v1/items_controller_spec.rb
+++ b/spec/controllers/api/v1/items_controller_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe Api::V1::ItemsController, type: :controller do
 
   subject { JSON.parse(response.body) }
 
-  describe "GET items" do
-    before { generate_and_set_token(user) }
-    it "return serialized items", :show_in_doc do
-      pending "error in postgres_ext-serializers but not currently used"
-      2.times{ create(:item, offer: offer) }
-      get :index
-      expect(response.status).to eq(200)
-      expect( subject['items'].length ).to eq(2)
-    end
-  end
-
   describe "GET item" do
     before { generate_and_set_token(user) }
     it "return serialized item", :show_in_doc do


### PR DESCRIPTION
I've removed the GET index on items because this wasn't working and it was confusing to API consumers. Use /offers/1.json instead to get the full item detail for each offer.
