### PR TITLE
Assign reviewer

### DIFF
--- a/app/models/concerns/push_updates.rb
+++ b/app/models/concerns/push_updates.rb
@@ -17,11 +17,9 @@ module PushUpdates
     type = self.class.name
     object = {}
 
-    if operation == :create
-      object[type] = serializer
-    elsif operation == :update
+    if operation == :create || operation == :update
       object[type] = {id:self.id}
-      self.changed
+      self.attributes.keys
         .find_all{|i| serializer.respond_to?(i) || serializer.respond_to?(i.sub('_id', ''))}
         .map{|i| i.to_sym}
         .each{|i| object[type][i] = self[i]}

--- a/app/models/concerns/push_updates.rb
+++ b/app/models/concerns/push_updates.rb
@@ -17,9 +17,11 @@ module PushUpdates
     type = self.class.name
     object = {}
 
-    if operation == :create || operation == :update
+    if operation == :create
+      object[type] = serializer
+    elsif operation == :update
       object[type] = {id:self.id}
-      self.attributes.keys
+      self.changed
         .find_all{|i| serializer.respond_to?(i) || serializer.respond_to?(i.sub('_id', ''))}
         .map{|i| i.to_sym}
         .each{|i| object[type][i] = self[i]}

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -45,10 +45,16 @@ class Item < ActiveRecord::Base
     event :submit do
       transition :draft => :submitted
     end
+
+    after_transition on: [:accept, :reject], do: :assign_reviewer
   end
 
   def self.update_saleable
     update_all(saleable: true)
+  end
+
+  def assign_reviewer
+    offer.reviewed_by || offer.start_review(User.current_user)
   end
 
   private

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -42,4 +42,20 @@ RSpec.describe Item, type: :model do
       end
     end
   end
+
+  describe "Instance Methods" do
+    let!(:offer) { create :offer, state: "submitted" }
+    let!(:item)  { create :item, offer: offer }
+    let!(:reviewer) { create :user, :reviewer }
+    before { User.current_user = reviewer }
+
+    describe "assign_reviewer" do
+      it "should update all items of offer" do
+        expect{
+          item.accept
+        }.to change(offer, :reviewed_by).to(reviewer)
+        expect(offer.state).to eq("under_review")
+      end
+    end
+  end
 end


### PR DESCRIPTION
When reviewer started reviewing items of offer by accepting or rejecting it, then assign him as a reviewer for that item's offer.