### PR TITLE
GCW-362 in push-updates, send required details of sender and avoid associated details

### DIFF
--- a/app/models/concerns/push_updates.rb
+++ b/app/models/concerns/push_updates.rb
@@ -35,10 +35,15 @@ module PushUpdates
     offer = send(:offer)
     donor_channel = (offer.nil? || offer.try(:cancelled?)) ? [] :
       Channel.user_id(offer.created_by_id)
-    channel = Channel.staff + donor_channel
-    user = Api::V1::UserSerializer.new(current_user, {user_summary: false})
+    user = Api::V1::UserSerializer.new(current_user, {user_summary: true})
     data = {item:object, sender:user, operation:operation}
     collapse_key = offer.nil? ? nil : "offer" + offer.id.to_s
-    PushService.new.send_update_store(channel, data, collapse_key)
+    service.send_update_store(donor_channel, data, collapse_key)
+    user.options[:user_summary] = false
+    service.send_update_store(Channel.staff, data, collapse_key)
+  end
+
+  def service
+    PushService.new
   end
 end

--- a/app/models/concerns/push_updates.rb
+++ b/app/models/concerns/push_updates.rb
@@ -16,7 +16,6 @@ module PushUpdates
 
     exclude_relationships = {exclude: self.class.reflections.keys.map(&:to_sym)}
     serializer = "Api::V1::#{self.class}Serializer".constantize.new(self, exclude_relationships)
-    user = Api::V1::UserSerializer.new(current_user)
     type = self.class.name
     object = {}
 
@@ -37,6 +36,7 @@ module PushUpdates
     donor_channel = (offer.nil? || offer.try(:cancelled?)) ? [] :
       Channel.user_id(offer.created_by_id)
     channel = Channel.staff + donor_channel
+    user = Api::V1::UserSerializer.new(current_user, {user_summary: false})
     data = {item:object, sender:user, operation:operation}
     collapse_key = offer.nil? ? nil : "offer" + offer.id.to_s
     PushService.new.send_update_store(channel, data, collapse_key)

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -11,13 +11,13 @@ module Api::V1
     has_one :address, serializer: AddressSerializer
 
     def include_attribute?
-      User.current_user.try(:permission).try(:present?)
+      (@options[:user_summary].blank? ? true : @options[:user_summary]) &&
+      (User.current_user.try(:staff?) || User.current_user == id)
     end
     alias_method :include_address?, :include_attribute?
     alias_method :include_mobile?, :include_attribute?
     alias_method :include_last_connected?, :include_attribute?
     alias_method :include_last_disconnected?, :include_attribute?
-
   end
 
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -11,8 +11,8 @@ module Api::V1
     has_one :address, serializer: AddressSerializer
 
     def include_attribute?
-      (@options[:user_summary].blank? ? true : @options[:user_summary]) &&
-      (User.current_user.try(:staff?) || User.current_user == id)
+      return !@options[:user_summary] unless @options[:user_summary].nil?
+      (User.current_user.try(:staff?) || User.current_user.try(:id) == id)
     end
     alias_method :include_address?, :include_attribute?
     alias_method :include_mobile?, :include_attribute?

--- a/spec/models/concerns/push_updates_spec.rb
+++ b/spec/models/concerns/push_updates_spec.rb
@@ -3,20 +3,23 @@ require 'rails_helper'
 describe Offer do
   let(:user) {create :user}
   before {User.current_user = user}
-  let(:offer) {create :offer}
+  let(:offer) {
+    offer = create :offer
+    allow(offer).to receive(:service).and_return(service)
+    offer
+  }
+  let(:service) {PushService.new}
 
   it 'update - only changed properties are included' do
-    expect_any_instance_of(PushService).to receive(:send_update_store) do |service, channel, data, collapse_key|
+    expect(service).to receive(:send_update_store).at_least(:once) do |channel, data, collapse_key|
       expect(data[:item]['Offer'].to_json).to eq("{\"id\":#{offer.id},\"notes\":\"New test note\"}")
-      expect(data[:sender].to_json.include?("mobile")).to eq(false)
-      expect(data[:sender].to_json.include?("address")).to eq(false)
     end
     offer.notes = 'New test note'
     offer.update_client_store(:update)
   end
 
   it 'update - foreign key property changes are handled' do
-    expect_any_instance_of(PushService).to receive(:send_update_store) do |service, channel, data, collapse_key|
+    expect(service).to receive(:send_update_store).at_least(:once) do |channel, data, collapse_key|
       expect(data[:item]['Offer'].to_json).to eq("{\"id\":#{offer.id},\"reviewed_by_id\":#{user.id}}")
     end
     offer.reviewed_by_id = user.id
@@ -29,5 +32,34 @@ describe Offer do
     ActiveRecord::Base.descendants.find_all{|m| m.ancestors.include?(PushUpdates)}.each do |m|
       expect(m.new.respond_to?(:offer, include_private)).to be(true), "#{m.name} is missing offer property"
     end
+  end
+
+  it 'should not include private reviewer details when sending to donor' do
+    User.current_user = create :user, :reviewer
+    json_checked = false
+    expect(service).to receive(:send_update_store).at_least(:once) do |channel, data, collapse_key|
+      if !channel.include?("reviewer")
+        expect(data[:sender].to_json.include?("mobile")).to eq(false)
+        expect(data[:sender].to_json.include?("address")).to eq(false)
+        json_checked = true
+      end
+    end
+    offer.notes = 'New test note'
+    offer.update_client_store(:update)
+    expect(json_checked).to eq(true)
+  end
+
+  it 'should include private donor details when sending to reviewer' do
+    json_checked = false
+    expect(service).to receive(:send_update_store).at_least(:once) do |channel, data, collapse_key|
+      if channel.include?("reviewer")
+        expect(data[:sender].to_json.include?("mobile")).to eq(true)
+        expect(data[:sender].to_json.include?("address")).to eq(true)
+        json_checked = true
+      end
+    end
+    offer.notes = 'New test note'
+    offer.update_client_store(:update)
+    expect(json_checked).to eq(true)
   end
 end

--- a/spec/models/concerns/push_updates_spec.rb
+++ b/spec/models/concerns/push_updates_spec.rb
@@ -8,6 +8,8 @@ describe Offer do
   it 'update - only changed properties are included' do
     expect_any_instance_of(PushService).to receive(:send_update_store) do |service, channel, data, collapse_key|
       expect(data[:item]['Offer'].to_json).to eq("{\"id\":#{offer.id},\"notes\":\"New test note\"}")
+      expect(data[:sender].to_json.include?("mobile")).to eq(false)
+      expect(data[:sender].to_json.include?("address")).to eq(false)
     end
     offer.notes = 'New test note'
     offer.update_client_store(:update)

--- a/spec/serializers/api/v1/user_serializer_spec.rb
+++ b/spec/serializers/api/v1/user_serializer_spec.rb
@@ -16,10 +16,23 @@ describe Api::V1::OfferSerializer do
       expect(donor_json['user']['created_at'].to_date).
         to eql(donor.created_at.to_date)
 
-      expect(donor_json['user']['mobile']).to eql(nil)
-      expect(donor_json['addresses']).to eql(nil)
-      expect(donor_json['user']['last_connected']).to eql(nil)
-      expect(donor_json['user']['last_disconnected']).to eql(nil)
+      expect(donor_json['user']['mobile']).to eql(donor.mobile)
+      expect(donor_json['addresses'][0]['id']).to eql(donor.address.id)
+      expect(
+        donor_json['user']['last_connected'].to_date
+      ).to eql(donor.last_connected.to_date)
+      expect(
+        donor_json['user']['last_disconnected'].to_date
+      ).to eql(donor.last_disconnected.to_date)
+    end
+
+    let(:admin_serializer) { Api::V1::UserSerializer.new(admin) }
+    let(:admin_json) { JSON.parse(admin_serializer.to_json) }
+    it "doesn't include private reviewer data" do
+      expect(admin_json['user']['mobile']).to eql(nil)
+      expect(admin_json['addresses']).to eql(nil)
+      expect(admin_json['user']['last_connected']).to eql(nil)
+      expect(admin_json['user']['last_disconnected']).to eql(nil)
     end
   end
 


### PR DESCRIPTION
Hi @mcm-ham 

Can you please review this changes? 

Thanks.