### PR TITLE
GCW 411 inbound calls active numbers routing to Offer's private thread subscribers

### DIFF
--- a/app/controllers/api/v1/twilio_controller.rb
+++ b/app/controllers/api/v1/twilio_controller.rb
@@ -1,5 +1,5 @@
 require "twilio-ruby"
-require "goodcity/redis_store"
+require "goodcity/redis"
 
 module Api::V1
   class TwilioController < Api::V1::ApiController
@@ -174,7 +174,7 @@ module Api::V1
     end
 
     def redis
-      @redis ||= Goodcity::RedisStore.new.init
+      @redis ||= Goodcity::Redis.new
     end
 
   end

--- a/app/controllers/api/v1/twilio_controller.rb
+++ b/app/controllers/api/v1/twilio_controller.rb
@@ -97,8 +97,11 @@ module Api::V1
     end
 
     def accept_call
-      redis_storage("twilio_donor_#{params['donor_id']}", params['mobile'])
-      offline_worker.update(activity_sid: activity_sid('Idle'))
+      unless redis.get("twilio_donor_#{params['donor_id']}")
+        redis_storage("twilio_donor_#{params['donor_id']}", params['mobile'])
+        offline_worker.update(activity_sid: activity_sid('Idle'))
+        AcceptedCallNotificationJob.perform_later(params['donor_id'], params['mobile'])
+      end
       render json: {}
     end
 

--- a/app/jobs/accepted_call_notification_job.rb
+++ b/app/jobs/accepted_call_notification_job.rb
@@ -1,0 +1,18 @@
+class AcceptedCallNotificationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(user_id, mobile)
+    user     = User.find_by(id: user_id)
+    reviewer = User.user_exist?(mobile)
+    offer_id = user.try(:recent_active_offer_id)
+    offer    = Offer.find_by(id: offer_id)
+    text     = "Call from #{user.full_name} has been accepted \
+      by #{reviewer.full_name}."
+
+    PushService.new.send_notification(
+      text:        text,
+      entity_type: "offer",
+      entity:      offer,
+      channel:     Channel.reviewer)
+  end
+end

--- a/app/jobs/accepted_call_notification_job.rb
+++ b/app/jobs/accepted_call_notification_job.rb
@@ -3,16 +3,16 @@ class AcceptedCallNotificationJob < ActiveJob::Base
 
   def perform(user_id, mobile)
     user     = User.find_by(id: user_id)
-    reviewer = User.user_exist?(mobile)
+    receiver = User.user_exist?(mobile)
     offer_id = user.try(:recent_active_offer_id)
     offer    = Offer.find_by(id: offer_id)
     text     = "Call from #{user.full_name} has been accepted \
-      by #{reviewer.full_name}."
+      by #{receiver.full_name}."
 
     PushService.new.send_notification(
       text:        text,
       entity_type: "offer",
       entity:      offer,
-      channel:     Channel.reviewer)
+      channel:     offer.call_notify_channels - ["user_#{receiver.id}"])
   end
 end

--- a/app/jobs/send_donor_calling_notification_job.rb
+++ b/app/jobs/send_donor_calling_notification_job.rb
@@ -8,10 +8,10 @@ class SendDonorCallingNotificationJob < ActiveJob::Base
     text     = "#{user.full_name} calling now: "
 
     PushService.new.send_notification(
-      text: text,
+      text:        text,
       entity_type: "offer",
-      entity: offer,
-      channel: Channel.reviewer,
-      call: true)
+      entity:      offer,
+      channel:     offer.call_notify_channels,
+      call:        true)
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -222,6 +222,17 @@ class Offer < ActiveRecord::Base
       is_admin_app: true)
   end
 
+  def reviewer_channel
+    reviewed_by_id && "user_#{reviewed_by_id}"
+  end
+
+  def call_notify_channels
+    channel_names = Channel.user_ids(subscribed_users(true))
+    channel_names = Channel.supervisor if (channel_names - [reviewer_channel]).blank?
+    channel_names << reviewer_channel
+    channel_names.uniq.compact
+  end
+
   private
 
   def cancel_message(time)

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -228,7 +228,9 @@ class Offer < ActiveRecord::Base
 
   def call_notify_channels
     channel_names = Channel.user_ids(subscribed_users(true))
-    channel_names = Channel.supervisor if (channel_names - [reviewer_channel]).blank?
+    if (channel_names - [reviewer_channel]).blank?
+      channel_names = Channel.user_ids(User.supervisors.pluck(:id))
+    end
     channel_names << reviewer_channel
     channel_names.uniq.compact
   end

--- a/app/services/push_service.rb
+++ b/app/services/push_service.rb
@@ -57,9 +57,9 @@ class PushService
   def notification_data(text, entity)
     {
       message:    text,
-      offer_id:   entity.offer_id,
-      item_id:    entity.item_id,
-      is_private: entity.is_private
+      offer_id:   entity.try(:offer).try(:id),
+      item_id:    entity.try(:item_id),
+      is_private: entity.try(:is_private)
     }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,12 +79,14 @@ Rails.application.routes.draw do
 
       post "twilio/voice" => "twilio#voice"
       post "ask_voicemail" => "twilio#ask_voicemail"
-      get "accept_voicemail" => "twilio#accept_voicemail"
-      get "send_voicemail" => "twilio#send_voicemail"
-      get "twilio/accept_call" => "twilio#accept_call"
+      get  "accept_voicemail" => "twilio#accept_voicemail"
+      get  "send_voicemail" => "twilio#send_voicemail"
+      get  "twilio/accept_call" => "twilio#accept_call"
       post "twilio/assignment" => "twilio#assignment"
       post "hold_gc_donor" => "twilio#hold_gc_donor"
-      get "twilio/hold_music" => "twilio#hold_music"
+      get  "twilio/hold_music" => "twilio#hold_music"
+      post "twilio/call_summary" => "twilio#call_summary"
+      post "twilio/call_fallback" => "twilio#call_fallback"
     end
   end
 end

--- a/lib/goodcity/redis.rb
+++ b/lib/goodcity/redis.rb
@@ -1,18 +1,14 @@
-module Goodcity
-  class RedisStore
-    attr_accessor :params
+require 'redis'
 
+module Goodcity
+  class Redis < ::Redis
     def initialize(options = {})
-      @params = {
+      opts = {
         namespace: ENV['REDIS_NAMESPACE'] || 'goodcity',
         password:  ENV['REDIS_PASSWORD'],
         url:       ENV['REDIS_URL'] || 'redis://localhost:6379'
       }
-      @params.merge!(options)
-    end
-
-    def init
-      Redis.new(@params)
+      super(opts.merge(options))
     end
   end
 end


### PR DESCRIPTION
This PR has changes for
- Send call notification to Donor's recent active offer's private thread subscriber else supervisors
- Send call accept notification to Donor's recent active offer's private thread subscriber else supervisors other than who have accepted call.
- handle failure with twilio if any invalid response and notify via airbreak and play try-again message to caller
- handle call complete callback and set assigned worker's state back to offline.

Thanks.