### PR TITLE
Delivery abilities

### DIFF
--- a/app/controllers/api/v1/deliveries_controller.rb
+++ b/app/controllers/api/v1/deliveries_controller.rb
@@ -128,7 +128,11 @@ module Api::V1
     end
 
     def delete_existing_delivery
-      Delivery.where(offer_id: params[:delivery][:offer_id]).map(&:destroy)
+      offer_id = params[:delivery][:offer_id]
+      Delivery.where(offer_id: offer_id).each do |delivery|
+        authorize!(:destroy, delivery)
+        delivery.destroy
+      end
     end
 
     def delete_old_associations

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,13 +20,20 @@ class Ability
       can(:manage, :all) if admin
 
       # Address
+      # TODO
       can [:create, :show], Address
 
       # Contact
+      # TODO
       can [:create, :destroy], Contact
 
       # Delivery
-      can [:create, :show, :update, :destroy, :confirm_delivery], Delivery
+      can [:create], Delivery
+      if reviewer || supervisor
+        can [:index, :show, :update, :destroy, :confirm_delivery], Delivery
+      else
+        can [:show, :update, :destroy, :confirm_delivery], Delivery, offer_id: user_offer_ids
+      end
 
       # Item
       if reviewer || supervisor
@@ -99,6 +106,7 @@ class Ability
       can :create, Schedule
 
       # GogovanOrder
+      # TODO
       can [:calculate_price, :confirm_order, :destroy], GogovanOrder
 
       # User

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,13 +17,13 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   enable_extension "plpgsql"
 
   create_table "addresses", force: :cascade do |t|
-    t.string   "flat",             limit: 255
-    t.string   "building",         limit: 255
-    t.string   "street",           limit: 255
+    t.string   "flat"
+    t.string   "building"
+    t.string   "street"
     t.integer  "district_id"
     t.integer  "addressable_id"
-    t.string   "addressable_type", limit: 255
-    t.string   "address_type",     limit: 255
+    t.string   "addressable_type"
+    t.string   "address_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20151007060024) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.datetime "otp_code_expiry"
-    t.string   "otp_secret_key",  limit: 255
+    t.string   "otp_secret_key"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -39,28 +39,28 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   end
 
   create_table "contacts", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.string   "mobile",     limit: 255
+    t.string   "name"
+    t.string   "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
   end
 
   create_table "crossroads_transports", force: :cascade do |t|
-    t.string   "name_en",        limit: 255
-    t.string   "name_zh_tw",     limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "cost"
     t.float    "truck_size"
-    t.boolean  "is_van_allowed",             default: true
+    t.boolean  "is_van_allowed", default: true
   end
 
   create_table "deliveries", force: :cascade do |t|
     t.integer  "offer_id"
     t.integer  "contact_id"
     t.integer  "schedule_id"
-    t.string   "delivery_type",    limit: 255
+    t.string   "delivery_type"
     t.datetime "start"
     t.datetime "finish"
     t.datetime "created_at"
@@ -70,8 +70,8 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   end
 
   create_table "districts", force: :cascade do |t|
-    t.string   "name_en",      limit: 255
-    t.string   "name_zh_tw",   limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.integer  "territory_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -80,15 +80,15 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   end
 
   create_table "donor_conditions", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "gogovan_orders", force: :cascade do |t|
     t.integer  "booking_id"
-    t.string   "status",         limit: 255
+    t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -103,8 +103,8 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   add_index "gogovan_orders", ["ggv_uuid"], name: "index_gogovan_orders_on_ggv_uuid", unique: true, using: :btree
 
   create_table "gogovan_transports", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -112,14 +112,14 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   create_table "holidays", force: :cascade do |t|
     t.datetime "holiday"
     t.integer  "year"
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "images", force: :cascade do |t|
-    t.string   "cloudinary_id", limit: 255
-    t.boolean  "favourite",                 default: false
+    t.string   "cloudinary_id"
+    t.boolean  "favourite",     default: false
     t.integer  "item_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -128,14 +128,14 @@ ActiveRecord::Schema.define(version: 20151007060024) do
 
   create_table "items", force: :cascade do |t|
     t.text     "donor_description"
-    t.string   "state",               limit: 255
-    t.integer  "offer_id",                                        null: false
+    t.string   "state"
+    t.integer  "offer_id",                            null: false
     t.integer  "package_type_id"
     t.integer  "rejection_reason_id"
-    t.string   "reject_reason",       limit: 255
+    t.string   "reject_reason"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "saleable",                        default: false
+    t.boolean  "saleable",            default: false
     t.integer  "donor_condition_id"
     t.datetime "deleted_at"
     t.text     "rejection_comments"
@@ -153,12 +153,12 @@ ActiveRecord::Schema.define(version: 20151007060024) do
   end
 
   create_table "offers", force: :cascade do |t|
-    t.string   "language",                limit: 255
-    t.string   "state",                   limit: 255
-    t.string   "origin",                  limit: 255
+    t.string   "language"
+    t.string   "state"
+    t.string   "origin"
     t.boolean  "stairs"
     t.boolean  "parking"
-    t.string   "estimated_size",          limit: 255
+    t.string   "estimated_size"
     t.text     "notes"
     t.integer  "created_by_id"
     t.datetime "created_at"
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 20151007060024) do
     t.integer  "height"
     t.text     "notes"
     t.integer  "item_id"
-    t.string   "state",           limit: 255
+    t.string   "state"
     t.datetime "received_at"
     t.datetime "rejected_at"
     t.integer  "package_type_id"
@@ -223,27 +223,27 @@ ActiveRecord::Schema.define(version: 20151007060024) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.integer  "image_id"
-    t.integer  "offer_id",                    default: 0, null: false
+    t.integer  "offer_id",        default: 0, null: false
   end
 
   create_table "permissions", force: :cascade do |t|
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "rejection_reasons", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
+    t.string   "name_en"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_zh_tw"
   end
 
   create_table "schedules", force: :cascade do |t|
-    t.string   "resource",     limit: 255
+    t.string   "resource"
     t.integer  "slot"
-    t.string   "slot_name",    limit: 255
-    t.string   "zone",         limit: 255
+    t.string   "slot_name"
+    t.string   "zone"
     t.datetime "scheduled_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -261,29 +261,29 @@ ActiveRecord::Schema.define(version: 20151007060024) do
     t.integer "offer_id"
     t.integer "user_id"
     t.integer "message_id"
-    t.string  "state",      limit: 255
+    t.string  "state"
   end
 
   add_index "subscriptions", ["offer_id", "user_id", "message_id"], name: "offer_user_message", unique: true, using: :btree
 
   create_table "territories", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "timeslots", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name",        limit: 255
-    t.string   "last_name",         limit: 255
-    t.string   "mobile",            limit: 255
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "permission_id"

--- a/spec/controllers/api/v1/deliveries_controller_spec.rb
+++ b/spec/controllers/api/v1/deliveries_controller_spec.rb
@@ -262,4 +262,26 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
     end
   end
 
+  describe "delete_existing_delivery" do
+    let(:delivery) { create :drop_off_delivery }
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:params).and_return({ delivery: { offer_id: delivery.offer_id } })
+      allow(Delivery).to receive(:where).and_return([delivery])
+    end
+    describe "owned by me" do
+      let(:user) { delivery.offer.created_by }
+      it do
+        expect(delivery).to receive(:destroy)
+        controller.send(:delete_existing_delivery)
+      end
+    end
+    describe "not owned by me" do
+      let(:user) { create :user }
+      it do
+        expect{controller.send(:delete_existing_delivery)}.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+
 end

--- a/spec/controllers/api/v1/deliveries_controller_spec.rb
+++ b/spec/controllers/api/v1/deliveries_controller_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::DeliveriesController, type: :controller do
 
-  let(:user) { create :user_with_token }
+  let(:user) { delivery.offer.created_by }
   subject { JSON.parse(response.body) }
+  before { generate_and_set_token(user) }
 
   describe "GET delivery with gogovan-transport" do
     let(:delivery) { create :gogovan_delivery }
     let(:serialized_delivery) { Api::V1::DeliverySerializer.new(delivery) }
     let(:serialized_delivery_json) { JSON.parse( serialized_delivery.to_json ) }
 
-    before { generate_and_set_token(user) }
     it "return serialized delivery", :show_in_doc do
       get :show, id: delivery.id
       expect(response.status).to eq(200)
@@ -23,7 +23,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
     let(:serialized_delivery) { Api::V1::DeliverySerializer.new(delivery) }
     let(:serialized_delivery_json) { JSON.parse( serialized_delivery.to_json ) }
 
-    before { generate_and_set_token(user) }
     it "return serialized delivery", :show_in_doc do
       get :show, id: delivery.id
       expect(response.status).to eq(200)
@@ -36,7 +35,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
     let(:serialized_delivery) { Api::V1::DeliverySerializer.new(delivery) }
     let(:serialized_delivery_json) { JSON.parse( serialized_delivery.to_json ) }
 
-    before { generate_and_set_token(user) }
     it "return serialized delivery", :show_in_doc do
       get :show, id: delivery.id
       expect(response.status).to eq(200)
@@ -45,10 +43,11 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
   end
 
   describe "POST delivery/1" do
-    before { generate_and_set_token(user) }
     let!(:offer) { create :offer, :reviewed }
+    let(:user) { offer.created_by }
 
     it "returns 201", :show_in_doc do
+      expect(controller).to receive(:delete_existing_delivery)
       post :create, delivery: attributes_for(:delivery).merge(offer_id: offer.id)
       expect(response.status).to eq(201)
     end
@@ -57,7 +56,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
   describe "PUT delivery/1 : update gogovan delivery" do
     let(:delivery) { create :gogovan_delivery, gogovan_order: nil }
     let(:gogovan_order) { create(:gogovan_order) }
-    before { generate_and_set_token(user) }
 
     it "owner can update", :show_in_doc do
       params = { gogovan_order_id: gogovan_order.id }
@@ -70,7 +68,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
   describe "PUT delivery/1 : update crossroads delivery" do
     let(:delivery) { create :crossroads_delivery, contact: nil, schedule: nil }
     let(:crossroads_delivery) { build(:crossroads_delivery) }
-    before { generate_and_set_token(user) }
 
     it "owner can update", :show_in_doc do
       put :update, id: delivery.id, delivery: crossroads_delivery.attributes.except(:id)
@@ -82,7 +79,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
   describe "PUT delivery/1 : update drop-off delivery" do
     let(:delivery) { create :drop_off_delivery, schedule: nil }
     let(:drop_off_delivery) { build(:drop_off_delivery) }
-    before { generate_and_set_token(user) }
 
     it "owner can update", :show_in_doc do
       put :update, id: delivery.id, delivery: drop_off_delivery.attributes.except(:id)
@@ -92,7 +88,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
   end
 
   describe "DELETE delivery/1" do
-    before { generate_and_set_token(user) }
     let(:delivery) { create :drop_off_delivery }
 
     it "returns 200", :show_in_doc do
@@ -104,7 +99,6 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
   end
 
   describe "confirm_delivery" do
-    before { generate_and_set_token(user) }
     let!(:gogovan_order) { create :gogovan_order }
 
     let(:offer) { create :offer, :reviewed, :with_transport }

--- a/spec/models/abilities/delivery_abilities_spec.rb
+++ b/spec/models/abilities/delivery_abilities_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe "Delivery abilities" do
+
+  subject(:ability) { Ability.new(user) }
+  let(:all_actions) { [:index, :show, :create, :update, :destroy, :manage, :confirm_delivery] }
+
+  context "when Administrator" do
+    let(:user)     { create(:user, :administrator) }
+    let(:delivery) { create :delivery }
+    it{ all_actions.each { |do_action| is_expected.to be_able_to(do_action, delivery) } }
+  end
+
+  context "when Supervisor" do
+    let(:user)     { create(:user, :supervisor) }
+    let(:delivery) { create :delivery }
+    let(:can)      { [:index, :show, :create, :update, :destroy, :confirm_delivery] }
+    let(:cannot)   { [:manage] }
+    it { can.each { |do_action| is_expected.to be_able_to(do_action, delivery) } }
+    it { cannot.each { |do_action| is_expected.to_not be_able_to(do_action, delivery) } }
+  end
+
+  context "when Reviewer" do
+    let(:user)     { create(:user, :reviewer) }
+    let(:delivery) { create :delivery }
+    let(:can)      { [:index, :show, :create, :update, :destroy, :confirm_delivery] }
+    let(:cannot)   { [:manage] }
+    it { can.each { |do_action| is_expected.to be_able_to(do_action, delivery) } }
+    it { cannot.each { |do_action| is_expected.to_not be_able_to(do_action, delivery) } }
+  end
+
+  context "when Owner" do
+    let(:user)     { delivery.offer.created_by }
+    let(:delivery) { create :delivery }
+    let(:can)      { [:show, :create, :update, :destroy, :confirm_delivery] }
+    let(:cannot)   { [:index, :manage] }
+    it { can.each { |do_action| is_expected.to be_able_to(do_action, delivery) } }
+    it { cannot.each { |do_action| is_expected.to_not be_able_to(do_action, delivery) } }
+  end
+
+  context "when not Owner" do
+    let(:user)     { create(:user) }
+    let(:delivery) { create :delivery }
+    let(:can)      { [:create] }
+    let(:cannot)   { [:show, :index, :update, :destroy, :confirm_delivery, :manage] }
+    it { can.each { |do_action| is_expected.to be_able_to(do_action, delivery) } }
+    it { cannot.each { |do_action| is_expected.to_not be_able_to(do_action, delivery) } }
+  end
+
+  context "when Anonymous" do
+    let(:user)     { nil }
+    let(:delivery) { create :delivery }
+    let(:can)      { [] }
+    let(:cannot)   { [:index, :show, :create, :update, :destroy, :manage, :confirm_delivery] }
+    it { can.each { |do_action| is_expected.to be_able_to(do_action, delivery) } }
+    it { cannot.each { |do_action| is_expected.to_not be_able_to(do_action, delivery) } }
+  end
+
+end


### PR DESCRIPTION
The following CanCanCan definition for `Delivery` was too open. It allows any logged in user to perform these actions on *any* delivery object, not just their own.

    can [:create, :show, :update, :destroy, :confirm_delivery], Delivery

This has been tightened to only allow Donors to perform actions on deliveries that belong to their own offers.

    can [:create], Delivery
    if reviewer || supervisor
      can [:index, :show, :update, :destroy, :confirm_delivery], Delivery
    else
      can [:show, :update, :destroy, :confirm_delivery], Delivery, offer_id: user_offer_ids
    end

Specs have been added to confirm the permissions are locked down.

The `DeliveriesController#delete_existing_delivery` method has also been tightened to check permissions before deleting existing deliveries. As a general rule, user param data should be considered highly dangerous and not be allowed to directly influence actions such as delete without proper checking.

    Delivery.where(offer_id: params[:delivery][:offer_id]).map(&:destroy)

becomes

    offer_id = params[:delivery][:offer_id]
    Delivery.where(offer_id: offer_id).each do |delivery|
      authorize!(:destroy, delivery)
      delivery.destroy
    end

cc @swatijadhav 