### PR TITLE
Package state refactor

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -32,14 +32,22 @@ class Package < ActiveRecord::Base
     state :expecting, :missing, :received
 
     event :mark_received do
-      transition [:expecting, :missing, :received] => :received
+      transition [:expecting, :missing] => :received
+    end
+
+    event :mark_received_with_inventory do
+      transition [:expecting, :missing] => :received
     end
 
     event :mark_missing do
-      transition [:expecting, :missing, :received] => :missing
+      transition [:expecting, :received] => :missing
     end
 
     before_transition on: :mark_received do |package|
+      package.inventory_number = nil
+    end
+
+    before_transition on: :mark_received_with_inventory do |package|
       package.received_at = Time.now
       package.add_to_stockit
     end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -70,8 +70,6 @@ class Package < ActiveRecord::Base
       response = Stockit::Item.delete(inventory_number)
       if response && (errors = response["errors"]).present?
         errors.each{|key, value| self.errors.add(key, value) }
-      else
-        self.inventory_number = nil
       end
     end
   end


### PR DESCRIPTION
The thinking here is that we can encapsulate the required model state within a workflow action. In Ember, we can call the correct `state_event` and the API ensures the model is in a consistent state. We also move the `inventory_number=nil` mutation to the `receive` action to fix an edge case where item is marked missing but already has a barcode label on it and is then subsequently added back into inventory. It will keep the same label.
