### PR TITLE
GCW-1224 Admin-app Donor tab doesn't show past offers

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -182,7 +182,7 @@ class Offer < ActiveRecord::Base
       valid_states - not_active_states
     end
     def nondraft_states
-      active_states - ["draft"]
+      valid_states - ["draft"]
     end
   end
 


### PR DESCRIPTION
Hi,

This PR has some changes in scope to show all the offers of donor in Admin app except "draft". Please review and advice.

Thanks