### PR TITLE
GCW-1354 updated redis gem version to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redis (3.2.2)
+    redis (3.3.2)
     redis-actionpack (4.0.1)
       actionpack (~> 4)
       redis-rack (~> 1.5.0)
@@ -437,3 +437,6 @@ DEPENDENCIES
   twilio-ruby
   warden
   webmock
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
The updated redis gem has TLS/SSL support. The REDIS_URL environment variable on the server where api.goodcity is deployed has to be updates to point to the redis ssl port on Azure.

The format of the url is -
rediss://[azure redis host]:[ssl port]