### PR TITLE
Renamed reference_to_orders_package to orders_package_id

### DIFF
--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -45,7 +45,7 @@ class OrdersPackage < ActiveRecord::Base
     package.packages_locations.create(
       location: location,
       quantity: quantity,
-      reference_to_orders_package: id
+      orders_package_id: id
     )
   end
 

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -204,15 +204,15 @@ class Package < ActiveRecord::Base
 
   def move_full_quantity(location_id, orders_package_id)
     orders_package              = orders_packages.find_by(id: orders_package_id)
-    referenced_package_location = packages_locations.find_by(reference_to_orders_package: orders_package_id)
+    referenced_package_location = packages_locations.find_by(orders_package_id: orders_package_id)
 
     if packages_location_record = self.packages_locations.find_by(location_id: location_id)
       new_qty = orders_package.quantity + packages_location_record.quantity
-      packages_location_record.update(quantity: new_qty, reference_to_orders_package: nil)
+      packages_location_record.update(quantity: new_qty, orders_package_id: nil)
       referenced_package_location.destroy
     else
       referenced_package_location.update(location_id: location_id, quantity: orders_package.quantity,
-        reference_to_orders_package: nil)
+        orders_package_id: nil)
     end
   end
 

--- a/db/migrate/20170320085613_change_ref_to_orders_package_id.rb
+++ b/db/migrate/20170320085613_change_ref_to_orders_package_id.rb
@@ -1,0 +1,5 @@
+class ChangeRefToOrdersPackageId < ActiveRecord::Migration
+  def change
+    rename_column :packages_locations, :reference_to_orders_package, :orders_package_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119144255) do
+ActiveRecord::Schema.define(version: 20170320085613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -405,9 +405,9 @@ ActiveRecord::Schema.define(version: 20170119144255) do
     t.integer  "package_id"
     t.integer  "location_id"
     t.integer  "quantity"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "reference_to_orders_package"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.integer  "orders_package_id"
   end
 
   create_table "pallets", force: :cascade do |t|

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Package, type: :model do
     let!(:location) { create :location }
     let!(:order) { create :order, state: "submitted"}
     let!(:orders_package) { create :orders_package, package: package, state: 'designated', order: order, quantity: 10 }
-    let!(:packages_location) { create :packages_location, package: package, reference_to_orders_package: orders_package.id}
+    let!(:packages_location) { create :packages_location, package: package, orders_package_id: orders_package.id}
 
     context 'if no packages_location record exist with provided location_id' do
       it 'updates quantity of packages_location record with referenced orders package quantity' do
@@ -288,14 +288,14 @@ RSpec.describe Package, type: :model do
         expect(packages_location.reload.location).to eq location
       end
 
-      it 'clears reference_to_orders_package' do
+      it 'clears orders_package_id' do
         package.move_full_quantity(location.id, orders_package.id)
-        expect(packages_location.reload.reference_to_orders_package).to be_nil
+        expect(packages_location.reload.orders_package_id).to be_nil
       end
     end
 
     context 'if packages_location record already exist with provided location_id' do
-      let!(:packages_location_1) { create :packages_location, package: package, reference_to_orders_package: orders_package.id, location: location}
+      let!(:packages_location_1) { create :packages_location, package: package, orders_package_id: orders_package.id, location: location}
 
       it 'adds up orders_package quantity and packages_location quantity and updates packages_location quantity with new quantity' do
         new_quantity = packages_location_1.quantity + orders_package.quantity
@@ -309,9 +309,9 @@ RSpec.describe Package, type: :model do
         }.to change(PackagesLocation, :count).by(-1)
       end
 
-      it 'clears reference_to_orders_package' do
+      it 'clears orders_package_id' do
         package.move_full_quantity(location.id, orders_package.id)
-        expect(packages_location_1.reload.reference_to_orders_package).to be_nil
+        expect(packages_location_1.reload.orders_package_id).to be_nil
       end
     end
   end


### PR DESCRIPTION
Strange to have a reference called reference... using the standard rails naming convention so that the belongs_to and hasbtm methods work normally.

Any reason why this is a bad idea?