### PR TITLE
Updated redis-rails gem to 5.0.2 version as Redis-store <=v1.3.0 has …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'http_accept_language'
 gem 'oj', '2.10.2' # 2.10.3 causes a 'too deeply nested' error
 gem 'oj_mimic_json'
 gem 'redis'
-gem 'redis-rails'
+gem 'redis-rails', '~> 5.0.2'
 gem 'rollbar'
 gem 'apipie-rails' , git: "https://github.com/Apipie/apipie-rails.git", branch: 'master'
 gem "go_go_van_api", git: "git@github.com:crossroads/go_go_van_api.git", branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,22 +275,22 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redis (3.3.2)
-    redis-actionpack (4.0.1)
-      actionpack (~> 4)
-      redis-rack (~> 1.5.0)
-      redis-store (~> 1.1.0)
-    redis-activesupport (4.1.5)
-      activesupport (>= 3, < 5)
-      redis-store (~> 1.1.0)
-    redis-rack (1.5.0)
-      rack (~> 1.5)
-      redis-store (~> 1.1.0)
-    redis-rails (4.0.0)
-      redis-actionpack (~> 4)
-      redis-activesupport (~> 4)
-      redis-store (~> 1.1.0)
-    redis-store (1.1.7)
-      redis (>= 2.2)
+    redis-actionpack (5.0.2)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.0.4)
+      activesupport (>= 3, < 6)
+      redis-store (>= 1.3, < 2)
+    redis-rack (2.0.3)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.4.1)
+      redis (>= 2.2, < 5)
     request_store (1.3.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -443,7 +443,7 @@ DEPENDENCIES
   rails-i18n
   rake-progressbar
   redis
-  redis-rails
+  redis-rails (~> 5.0.2)
   request_store
   rollbar
   rspec-rails
@@ -468,4 +468,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.15.1
+   1.15.2


### PR DESCRIPTION
Updated redis-rails gem to 5.0.2 version as Redis-store <=v1.3.0 has Vulnerability