### PR TITLE
Gcw 1885 improve rollbar configuration

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,4 +5,5 @@ require 'capistrano/bundler'
 require 'capistrano/rails/migrations'
 require 'capistrano/sidekiq'
 require 'capistrano/rake'
+require 'rollbar/capistrano3'
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,6 +8,9 @@ set :linked_dirs, %w{log tmp/pids tmp/cache}
 set :bundle_binstubs, nil
 set :sidekiq_processes, 2
 set :rvm_ruby_version, '2.2.2'
+set :rollbar_token, ENV['ROLLBAR_ACCESS_TOKEN']
+set :rollbar_env, Proc.new { fetch :stage }
+set :rollbar_role, Proc.new { :app }
 
 namespace :deploy do
   desc 'Restart application'

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -65,4 +65,6 @@ Rollbar.configure do |config|
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+
+  config.project_gems = ['go_go_van_api', 'easyzpl']
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -42,7 +42,8 @@ Rollbar.configure do |config|
   # config.use_sucker_punch
 
   # Enable delayed reporting (using Sidekiq)
-  # config.use_sidekiq
+  config.use_sidekiq
+  config.sidekiq_threshold = 3 # Start reporting ActiveJob errors after 3 retries have failed
   # You can supply custom Sidekiq options:
   # config.use_sidekiq 'queue' => 'default'
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,4 +14,5 @@ production:
   - gogovan_orders
   - stockit_updates
   - stockit_sync_orders_package_updates
+  - rollbar
   - [high, 2]


### PR DESCRIPTION
- use sidekiq to send error reports rather than synchronous thread.
- Integrate with ActiveJob to ensure reports are sent from inside
- Ignore our authorization headers (token)
- Capistrano deploy tracking

https://github.com/rollbar/rollbar-gem/blob/master/README.md