### PR TITLE
GCW-2009 serializer changes

### DIFF
--- a/app/serializers/api/v1/order_transport_serializer.rb
+++ b/app/serializers/api/v1/order_transport_serializer.rb
@@ -2,10 +2,19 @@ module Api::V1
   class OrderTransportSerializer < ApplicationSerializer
     embed :ids, include: true
     attributes :id, :order_id, :scheduled_at, :timeslot, :gogovan_transport_id,
-      :transport_type, :need_english, :need_cart, :need_carry, :designation_id
+      :transport_type, :need_english, :need_cart, :need_carry, :designation_id,
+      :need_over_6ft, :remove_net, :need_over_six_ft
 
     has_one :contact, serializer: ContactSerializer
     has_one :gogovan_order, serializer: GogovanOrderSerializer
+
+    def need_over_six_ft
+      object.need_over_6ft
+    end
+
+    def need_over_six_ft__sql
+      "need_over_6ft"
+    end
 
     def designation_id
       object.order_id


### PR DESCRIPTION
Hi Team,

This PR includes serializer changes for feature of transport_detail page pre-filled if it was already filled up user.
Transport detail stays the same even after refreshing the page.

Jira ticket:- https://jira.crossroads.org.hk/browse/GCW-2009