### PR TITLE
remove organisation name from charity sms

### DIFF
--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -9,7 +9,7 @@ class OrganisationsUser < ActiveRecord::Base
   private
 
   def send_welcome_msg
-    TwilioService.new(user, organisation).send_welcome_msg
+    TwilioService.new(user).send_welcome_msg
   end
 
   def create_user_role

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,11 +1,10 @@
 require 'twilio-ruby'
 class TwilioService
 
-  attr_accessor :user, :organisation
+  attr_accessor :user
 
-  def initialize(user, organisation = nil)
+  def initialize(user)
     @user = user
-    @organisation = organisation
   end
 
   def sms_verification_pin
@@ -49,7 +48,6 @@ class TwilioService
 
   def welcome_sms_text
     I18n.t('twilio.charity_user_welcome_sms',
-      full_name: User.current_user.full_name,
-      organisation_name: @organisation.name_as_per_locale)
+      full_name: User.current_user.full_name)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
       Single-use pin is %{pin}. GoodCity.HK welcomes you! Enjoy donating
       your quality goods. (If you didn't request this message, please ignore)
     charity_user_welcome_sms: |
-      %{full_name} from %{organisation_name} has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.
+      %{full_name} has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.
     input_offer_id_message: "Please input an offer ID and we will forward you to the donor's number."
     thank_you_calling_message: "Thank you for calling GoodCity.HK, operated by Crossroads Foundation. Please wait a moment while we try to connect you to one of our staff."
   activerecord:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -20,7 +20,7 @@ zh-tw:
       一次性驗證碼為 %{pin}。好人好市歡迎您！我們期待您的善心捐獻。
       （如你並沒有要求驗證碼，請忽略此信息）
     charity_user_welcome_sms: |
-      %{full_name} from %{organisation_name} has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.
+      %{full_name} has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.
     input_offer_id_message: "請輸入捐獻號碼，提取捐贈人士的號碼。"
     thank_you_calling_message: "感謝致電十字路會主辦物資捐獻系統，好人好市。請稍候片刻，職員將儘快接聽你的電話。"
   activerecord:


### PR DESCRIPTION
Hi Team, 

This PR is to change sms text which is sent if any user is added to organisation from stock app. (i.e manage charity users feature).

https://jira.crossroads.org.hk/browse/GCW-2013

Previous text : Nokia from crossroads has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.

New text : Nokia  has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.

![screenshot_2018-07-04-16-52-30-039_com android mms](https://user-images.githubusercontent.com/8424592/42274681-321182fc-7fab-11e8-9644-a9dabb35b0df.png)

Please review and let me know if any changes required.

Thanks.