### PR TITLE
GCW-2033 new order sms notification for order fulfilment users

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -219,7 +219,9 @@ class Order < ActiveRecord::Base
   end
 
   def send_order_placed_sms_to_order_fulfilment_users
-    User.order_fulfilment.map { |user| TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self) }
+    User.order_fulfilment.each do |user|
+      TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self)
+    end
   end
 
   def nullify_columns(*columns)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -197,7 +197,8 @@ class Order < ActiveRecord::Base
       if order.detail_type == "GoodCity"
         order.designate_orders_packages
         order.send_new_order_notificationen
-        order.send_new_order_sms
+        order.send_new_order_confirmed_sms_to_charity
+        order.send_order_placed_sms_to_order_fulfilment_users
       end
     end
   end
@@ -213,8 +214,13 @@ class Order < ActiveRecord::Base
     }
   end
 
-  def send_new_order_sms
-    TwilioService.new(submitted_by).send_new_order_sms(self)
+  def send_new_order_confirmed_sms_to_charity
+    TwilioService.new(submitted_by).order_confirmed_sms_to_charity(self)
+  end
+
+  def send_order_placed_sms_to_order_fulfilment_users
+    debugger
+    User.order_fulfilment.map { |user| TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self) }
   end
 
   def nullify_columns(*columns)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -219,7 +219,6 @@ class Order < ActiveRecord::Base
   end
 
   def send_order_placed_sms_to_order_fulfilment_users
-    debugger
     User.order_fulfilment.map { |user| TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self) }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ActiveRecord::Base
   scope :donors,      -> { where(permission_id: nil) }
   scope :reviewers,   -> { where(roles: { name: 'Reviewer'   }).joins(:roles) }
   scope :supervisors, -> { where(roles: { name: 'Supervisor' }).joins(:roles) }
+  scope :order_fulfilment, -> { where(roles: { name: 'Order fulfilment' }).joins(:roles) }
   scope :system,      -> { where(roles: { name: 'System' }).joins(:roles) }
   scope :staff,       -> { where(roles: { name: ['Supervisor', 'Reviewer'] }).joins(:roles) }
   scope :except_stockit_user, -> { where.not(first_name: "Stockit", last_name: "User") }

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -19,9 +19,15 @@ class TwilioService
     TwilioJob.perform_later(options)
   end
 
-  def send_new_order_sms(order)
+  def order_confirmed_sms_to_charity(order)
     return unless allowed_to_send?
-    options = { to: @user.mobile, body: new_order_text(order) }
+    options = { to: @user.mobile, body: new_order_confirmed_text_to_charity(order) }
+    TwilioJob.perform_later(options)
+  end
+
+  def order_submitted_sms_to_order_fulfilment_users(order)
+    return unless allowed_to_send?
+    options = { to: @user.mobile, body: new_order_placed_text_to_users(order) }
     TwilioJob.perform_later(options)
   end
 
@@ -57,8 +63,13 @@ class TwilioService
       full_name: User.current_user.full_name)
   end
 
-  def new_order_text(order)
-    I18n.t('twilio.new_order_submitted_sms',
+  def new_order_placed_text_to_users(order)
+    I18n.t('twilio.order_submitted_sms_to_order_fulfilment_users',
+      code: order.code, submitter_name: order.submitted_by.full_name, organisation_name: order.organisation.try(:name_en))
+  end
+
+  def new_order_confirmed_text_to_charity(order)
+    I18n.t('twilio.new_order_submitted_sms_to_charity',
       code: order.code)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,9 @@ en:
       your quality goods. (If you didn't request this message, please ignore)
     charity_user_welcome_sms: |
       %{full_name} has added you to the GoodCity for Charities platform. Please download the app and log in using this mobile number.
-    new_order_submitted_sms: |
+    order_submitted_sms_to_order_fulfilment_users: |
+      %{submitter_name} from %{organisation_name} has just placed an order %{code} on GoodCity.
+    new_order_submitted_sms_to_charity: |
       Thank you for placing order %{code} on GoodCity. Our team will be in touch with you soon.
     input_offer_id_message: "Please input an offer ID and we will forward you to the donor's number."
     thank_you_calling_message: "Thank you for calling GoodCity.HK, operated by Crossroads Foundation. Please wait a moment while we try to connect you to one of our staff."

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -21,7 +21,9 @@ zh-tw:
       （如你並沒有要求驗證碼，請忽略此信息）
     charity_user_welcome_sms: |
       %{full_name} 已將閣下登記於好人好巿平台。請下載該應用程式及以此電話號碼登入。
-    new_order_submitted_sms: |
+    order_submitted_sms_to_order_fulfilment_users: |
+      %{submitter_name} from %{organisation_name} has just placed an order %{code} on GoodCity.
+    new_order_submitted_sms_to_charity: |
       Thank you for placing order %{code} on GoodCity. Our team will be in touch with you soon.
     input_offer_id_message: "請輸入捐獻號碼，提取捐贈人士的號碼。"
     thank_you_calling_message: "感謝致電十字路會主辦物資捐獻系統，好人好市。請稍候片刻，職員將儘快接聽你的電話。"

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -249,4 +249,28 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe '#send_new_order_confirmed_sms_to_charity' do
+    let(:charity) { create(:user, :charity) }
+    let(:order) { build(:order, submitted_by: charity) }
+    let(:twilio)     { TwilioService.new(charity) }
+
+    it "send order submission sms to charity user who submitted order" do
+      expect(TwilioService).to receive(:new).with(charity).and_return(twilio)
+      expect(twilio).to receive(:order_confirmed_sms_to_charity).with(order)
+      order.send_new_order_confirmed_sms_to_charity
+    end
+  end
+
+  describe '#send_order_placed_sms_to_order_fulfilment_users' do
+    let(:charity) { create(:user, :charity) }
+    let(:order_1) { create(:order, submitted_by: charity) }
+    let(:order_fulfiment_user_1) { create(:user, :order_fulfilment) }
+    let(:twilio)     { TwilioService.new(order_fulfiment_user_1) }
+
+    it "send new order submitted alert sms to order_fulfilment users" do
+      expect(TwilioService).to receive(:new).with(order_fulfiment_user_1).and_return(twilio)
+      expect(twilio).to receive(:order_submitted_sms_to_order_fulfilment_users).with(order_1)
+      order_1.send_order_placed_sms_to_order_fulfilment_users
+    end
+  end
 end


### PR DESCRIPTION
Hi Team,

This PR adds feature of sending sms notification to Users with "order fulfilment" role whenever any new GoodCity order is submitted.

Jira ticket:- https://jira.crossroads.org.hk/browse/GCW-2046

Please review the PR and let me know if any changes are required.
Thanks