### PR TITLE
fixed warning : include_territory is duplicated and overwritten

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -57,7 +57,6 @@ module Api
           include_order: false,
           include_territory: true,
           include_images: true,
-          include_territory: true,
           exclude_stockit_set_item: true
       end
 


### PR DESCRIPTION
Hi Team,

This PR removes warning: include_territory is duplicated and overwritten

Please review.

Thanks.