### PR TITLE
fix for organisation search was not working when either name_en or name_zh_tw is empty

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,7 +7,8 @@ class Organisation < ActiveRecord::Base
   has_many :users, through: :organisations_users
 
   def self.search(search_text)
-    where("name_en || name_zh_tw ILIKE ?", "%#{search_text}%")
+    where("name_en ILIKE :search_text OR name_zh_tw ILIKE :search_text",
+      search_text: "%#{search_text}%")
   end
 
   def name_as_per_locale

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -23,15 +23,31 @@ RSpec.describe Organisation, type: :model do
 
   describe 'Class Methods' do
     describe '.search' do
-      let(:organisation) { create :organisation, name_en: "ZUNI ICOSAHEDRON", name_zh_tw: "進念二十面體" }
+      context 'when name_en and name_zh_tw both are pesent' do
+        let(:organisation) { create :organisation, name_en: "ZUNI ICOSAHEDRON", name_zh_tw: "進念二十面體" }
 
-      it 'performs case insensitive search for organisation with matching name_en' do
-        expect(Organisation.search("zun")).to include(organisation)
-        expect(Organisation.search("ZUNI")).to include(organisation)
+        it 'performs case insensitive search for organisation with matching name_en' do
+          expect(Organisation.search("zun")).to include(organisation)
+          expect(Organisation.search("ZUNI")).to include(organisation)
+        end
+
+        it 'performs case insensitive search for organisation with matching name_zh_tw' do
+          expect(Organisation.search("進念")).to include(organisation)
+        end
       end
 
-      it 'performs case insensitive search for organisation with matching name_zh_tw' do
-        expect(Organisation.search("進念")).to include(organisation)
+      context 'when name_zh_tw is nil' do
+        it 'performs case insensitive search for organisation with matching name_en' do
+          organisation = create :organisation, name_en: "ZUNI ICOSAHEDRON"
+          expect(Organisation.search("zun")).to include(organisation)
+        end
+      end
+
+      context 'when name_en is nil' do
+        it 'performs case insensitive search for organisation with matching name_en' do
+          organisation = create :organisation, name_zh_tw: "進念二十面體"
+          expect(Organisation.search("進念二十")).to include(organisation)
+        end
       end
     end
   end


### PR DESCRIPTION
Hi Team,

This PR fixes issue: Organisation is not searchable when either name_en or name_zh_tw is nil.

https://jira.crossroads.org.hk/browse/GCW-2124

Please review.

Thanks.