### PR TITLE
GCW-2060 systemctl sidekiq

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,7 +5,6 @@ install_plugin Capistrano::SCM::Git
 require 'capistrano/rvm'
 require 'capistrano/bundler'
 require 'capistrano/rails/migrations'
-require 'capistrano/sidekiq'
 require 'capistrano/rake'
 require 'rollbar/capistrano3'
 require "whenever/capistrano"

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,6 @@ group :development, :test do
   gem 'capistrano-rails'
   gem 'capistrano-bundler'
   gem 'capistrano-rvm'
-  gem 'capistrano-sidekiq'
   gem 'capistrano-rake', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,9 +121,6 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capistrano-sidekiq (1.0.2)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4)
     chronic (0.10.2)
     cloudinary (1.1.2)
       aws_cf_signer
@@ -433,7 +430,6 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rake
   capistrano-rvm
-  capistrano-sidekiq
   cloudinary
   dotenv-rails (= 0.11.1)
   easyzpl!

--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -27,11 +27,11 @@ module Api
       api :POST, "/v1/organisations_user", "Create a package"
       param_group :organisations_user
       def create
-        organisation_user = OrganisationsUserBuilder.new(@organisations_user).build
-        if organisation_user.valid?
+        builder = OrganisationsUserBuilder.new(@organisations_user).build
+        if builder['result'] == true
           render json: organisation_user, serializer: serializer, status: 201
         else
-          render_error(organisation_user.errors.full_messages.join('. '))
+          render_error(builder['errors'])
         end
       end
 

--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -27,7 +27,8 @@ module Api
       api :POST, "/v1/organisations_user", "Create a package"
       param_group :organisations_user
       def create
-        save_and_render_object_with_errors(@organisations_user)
+        org_user = OrganisationsUser.organisation_user?(@organisations_user)
+        save_and_render_object_with_errors(org_user)
       end
 
       private

--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -27,8 +27,7 @@ module Api
       api :POST, "/v1/organisations_user", "Create a package"
       param_group :organisations_user
       def create
-        organisation_user = OrganisationsUser.create_or_update_existing_user_object(@organisations_user)
-        save_and_render_object_with_errors(organisation_user)
+        save_and_render_object_with_errors(@organisations_user.create_or_update_existing_organisation_user)
       end
 
       private

--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -27,7 +27,12 @@ module Api
       api :POST, "/v1/organisations_user", "Create a package"
       param_group :organisations_user
       def create
-        save_and_render_object_with_errors(@organisations_user.create_or_update_existing_organisation_user)
+        organisation_user = OrganisationsUserBuilder.new(@organisations_user).build
+        if organisation_user.valid?
+          render json: organisation_user, serializer: serializer, status: 201
+        else
+          render_error(organisation_user.errors.full_messages.join('. '))
+        end
       end
 
       private

--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -27,8 +27,8 @@ module Api
       api :POST, "/v1/organisations_user", "Create a package"
       param_group :organisations_user
       def create
-        org_user = OrganisationsUser.organisation_user?(@organisations_user)
-        save_and_render_object_with_errors(org_user)
+        organisation_user = OrganisationsUser.create_or_update_existing_user_object(@organisations_user)
+        save_and_render_object_with_errors(organisation_user)
       end
 
       private

--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -8,7 +8,7 @@ class OrganisationsUser < ActiveRecord::Base
 
   def create_or_update_existing_organisation_user
     existing_user = User.find_by_mobile(user.mobile)
-    if existing_user && !already_exist_in_same_organisation?(existing_user)
+    if existing_user && already_exist_in_same_organisation?(existing_user)
       existing_user.first_name = user.first_name
       existing_user.last_name = user.last_name
       existing_user.email = user.email
@@ -19,7 +19,7 @@ class OrganisationsUser < ActiveRecord::Base
   end
 
   def already_exist_in_same_organisation?(existing_user)
-    existing_user.organisations.include?(organisation)
+    !existing_user.organisations.include?(organisation)
   end
 
   private

--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -8,23 +8,28 @@ class OrganisationsUser < ActiveRecord::Base
 
   def create_or_update_existing_organisation_user
     existing_user = User.find_by_mobile(user.mobile)
-    if existing_user && already_exist_in_same_organisation?(existing_user)
-       self
-    elsif existing_user
-       existing_user.first_name = user.first_name
-       existing_user.last_name = user.last_name
-       existing_user.email = user.email
-       self.user_id = existing_user.id
-       existing_user.save
-       existing_user
-     else
-       self
-     end
-
+    return self if already_existing_user_with_same_organisation?(existing_user)
+    if existing_user
+      update_existing_user(existing_user)
+    end
+    self
   end
 
   def already_exist_in_same_organisation?(existing_user)
     existing_user.organisations.include?(organisation)
+  end
+
+  def already_existing_user_with_same_organisation?(existing_user)
+    existing_user && already_exist_in_same_organisation?(existing_user)
+  end
+
+  def update_existing_user(existing_user)
+    existing_user.first_name = user.first_name
+    existing_user.last_name = user.last_name
+    existing_user.email = user.email
+    existing_user.save
+    self.user_id = existing_user.id
+    self
   end
 
   private

--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -8,28 +8,18 @@ class OrganisationsUser < ActiveRecord::Base
 
   def create_or_update_existing_organisation_user
     existing_user = User.find_by_mobile(user.mobile)
-    return self if already_existing_user_with_same_organisation?(existing_user)
-    if existing_user
-      update_existing_user(existing_user)
+    if existing_user && !already_exist_in_same_organisation?(existing_user)
+      existing_user.first_name = user.first_name
+      existing_user.last_name = user.last_name
+      existing_user.email = user.email
+      existing_user.save
+      self.user_id = existing_user.id
     end
     self
   end
 
   def already_exist_in_same_organisation?(existing_user)
     existing_user.organisations.include?(organisation)
-  end
-
-  def already_existing_user_with_same_organisation?(existing_user)
-    existing_user && already_exist_in_same_organisation?(existing_user)
-  end
-
-  def update_existing_user(existing_user)
-    existing_user.first_name = user.first_name
-    existing_user.last_name = user.last_name
-    existing_user.email = user.email
-    existing_user.save
-    self.user_id = existing_user.id
-    self
   end
 
   private

--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -6,16 +6,24 @@ class OrganisationsUser < ActiveRecord::Base
 
   after_create :send_welcome_msg, :create_user_role
 
-  def self.organisation_user?(org_user)
-    user = User.find_by_mobile(org_user.user.mobile)
-    unless user.nil?
-      return org_user if user.organisations_users.exists? && user.organisations_users.pluck(:organisation_id).include?(org_user.organisation_id)
-      user.update_attributes(first_name: org_user.user.first_name, last_name: org_user.user.last_name, email: org_user.user.email)
-      org_user.user_id = user.id
-      org_user
+  def self.create_or_update_existing_user_object(organisation_user)
+    existing_user = User.find_by_mobile(organisation_user.user.mobile)
+    unless existing_user.nil?
+      return organisation_user if is_user_exists_in_organisation(existing_user, organisation_user)
+      begin
+        existing_user.update_attributes(first_name: organisation_user.user.first_name, last_name: organisation_user.user.last_name, email: organisation_user.user.email)
+      rescue Exception => e
+        return e
+      end
+      organisation_user.user_id = existing_user.id
+      organisation_user
     else
-      org_user
+      organisation_user
     end
+  end
+
+  def self.is_user_exists_in_organisation(existing_user, organisation_user)
+    existing_user.organisations_users.exists? && existing_user.organisations_users.pluck(:organisation_id).include?(organisation_user.organisation_id)
   end
 
   private

--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -1,35 +1,9 @@
 class OrganisationsUser < ActiveRecord::Base
   belongs_to :organisation
   belongs_to :user
+  # position
 
-  accepts_nested_attributes_for :user, allow_destroy: true, limit: 1
+  validates :organisation_id, :user_id, presence: true
 
-  after_create :send_welcome_msg, :create_user_role
-
-  def create_or_update_existing_organisation_user
-    existing_user = User.find_by_mobile(user.mobile)
-    if existing_user && already_exist_in_same_organisation?(existing_user)
-      existing_user.first_name = user.first_name
-      existing_user.last_name = user.last_name
-      existing_user.email = user.email
-      existing_user.save
-      self.user_id = existing_user.id
-    end
-    self
-  end
-
-  def already_exist_in_same_organisation?(existing_user)
-    !existing_user.organisations.include?(organisation)
-  end
-
-  private
-
-  def send_welcome_msg
-    TwilioService.new(user).send_welcome_msg
-  end
-
-  def create_user_role
-    UserRole.create_user_role(user.id, Role.charity.id)
-  end
 end
 

--- a/app/models/organisations_user.rb
+++ b/app/models/organisations_user.rb
@@ -6,6 +6,18 @@ class OrganisationsUser < ActiveRecord::Base
 
   after_create :send_welcome_msg, :create_user_role
 
+  def self.organisation_user?(org_user)
+    user = User.find_by_mobile(org_user.user.mobile)
+    unless user.nil?
+      return org_user if user.organisations_users.exists? && user.organisations_users.pluck(:organisation_id).include?(org_user.organisation_id)
+      user.update_attributes(first_name: org_user.user.first_name, last_name: org_user.user.last_name, email: org_user.user.email)
+      org_user.user_id = user.id
+      org_user
+    else
+      org_user
+    end
+  end
+
   private
 
   def send_welcome_msg

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,7 +9,6 @@ set :deploy_to, '/opt/rails/goodcity_server'
 set :linked_files, %w{ config/database.yml .env }
 set :linked_dirs, %w{log tmp/pids tmp/cache}
 set :bundle_binstubs, nil
-set :sidekiq_processes, 2
 set :rvm_ruby_version, '2.5.1'
 set :rollbar_token, ENV['ROLLBAR_ACCESS_TOKEN']
 set :rollbar_env, Proc.new { fetch :stage }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,3 +64,11 @@ en:
     move_stockit: "You can only move it using Stockit."
   orders_package:
     already_dispatched: "This has been already dispatched."
+  organisations_user_builder:
+    organisation:
+      blank: "Organisation can't be blank"
+      not_found: "Organisation not found"
+    user:
+      mobile:
+        blank: "Mobile can't be blank"
+    

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -59,4 +59,11 @@ zh-tw:
     move_stockit: "You can only move it using Stockit."
   orders_package:
     already_dispatched: "This has been already dispatched."
+  organisations_user_builder:
+    organisation:
+      blank: "Organisation can't be blank"
+      not_found: "Organisation not found"
+    user:
+      mobile:
+        blank: "Mobile can't be blank"
 

--- a/config/sidekiq.service
+++ b/config/sidekiq.service
@@ -1,0 +1,27 @@
+# This file corresponds to a single Sidekiq process.  Add multiple copies
+# to run multiple processes (sidekiq-1, sidekiq-2, etc).
+# Save this file to /usr/lib/systemd/system/sidekiq.service
+
+[Unit]
+Description=sidekiq
+After=syslog.target network.target redis.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/rails/goodcity_server/current
+Environment=NODE_VERSION=lts/boron MALLOC_ARENA_MAX=2
+ExecStart=/home/deployer/.nvm/nvm-exec /home/deployer/.rvm/bin/rvm 2.5.1 do bundle exec sidekiq -e staging -C config/sidekiq.yml
+User=deployer
+Group=deployer
+UMask=0002
+
+RestartSec=10
+Restart=on-failure
+
+# output goes to /var/log/messages
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sidekiq
+
+[Install]
+WantedBy=multi-user.target

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,6 @@
 ---
-:concurrency: 5
+:concurrency: 10
 :pidfile: tmp/pids/sidekiq.pid
-staging:
-  :concurrency: 3
-production:
-  :concurrency: 20
 
 #  A queue with a weight of 2 will be checked twice as often as a queue with a weight of 1
 :queues:

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -1,0 +1,41 @@
+namespace :sidekiq do
+  desc 'Start sidekiq'
+  task :start do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :sudo, :systemctl, :start, :sidekiq
+    end
+  end
+
+  desc 'Stop sidekiq'
+  task :stop do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :sudo, :systemctl, :stop, :sidekiq
+    end
+  end
+
+  desc 'Restart sidekiq'
+  task :restart do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :sudo, :systemctl, :restart, :sidekiq
+    end
+  end
+
+  desc 'Status of sidekiq'
+  task :status do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :sudo, :systemctl, :status, :sidekiq
+    end
+  end
+
+  task :add_default_hooks do
+    after 'deploy:updated', 'sidekiq:stop'
+    after 'deploy:reverted', 'sidekiq:stop'
+    after 'deploy:published', 'sidekiq:start'
+  end
+end
+
+namespace :deploy do
+  before :starting, :insert_sidekiq_hooks do
+    invoke 'sidekiq:add_default_hooks'
+  end
+end

--- a/lib/classes/organisations_user_builder.rb
+++ b/lib/classes/organisations_user_builder.rb
@@ -1,0 +1,33 @@
+class OrganisationsUserBuilder
+
+  def initialize(organisations_user)
+    @organisations_user = organisations_user
+    @organisation_id = organisations_user.organisation_id
+    @user = organisations_user.user
+  end
+
+  def build
+    mobile = @user.mobile
+    raise ValueError("No mobile provided") unless mobile.present?
+    user = User.where(mobile: mobile).first_or_create(@user.attributes)
+    if user && !user_belongs_to_organisation(user)
+      @organisations_user.user = user
+      if @organisations_user.save
+        TwilioService.new(user).send_welcome_msg
+        user.roles << charity_role unless user.roles.include?(charity_role)
+      end
+    end
+    @organisations_user
+  end
+
+  private
+
+  def user_belongs_to_organisation(user)
+    user.organisation_ids.include?(@organisation_id)
+  end
+
+  def charity_role
+    @charity_role ||= Role.charity
+  end
+
+end

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(subject["errors"]).to eq("User email is invalid")
     end
 
-    it "add organisation user with existing mobile from User Model" do
+    it "adds organisation user with existing mobile from User Model" do
       organisations_user = create :organisations_user
       organisations_user_params[:user_attributes][:mobile] = "+85295367257"
       expect {
@@ -86,6 +86,15 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
         post :create, format: :json, organisations_user: new_organisations_user_params
       }.to change(OrganisationsUser, :count).by(0)
       expect(response.status).to eq(422)
+    end
+
+    it "adds new user organisation user if user do not exist in User Model" do
+      organisations_user = create :organisations_user
+      expect {
+        post :create, format: :json, organisations_user: organisations_user_params
+      }.to change(OrganisationsUser, :count).by(1)
+      expect(response.status).to eq(201)
+      expect(OrganisationsUser.count).to eq(2)
     end
   end
 end

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -25,16 +25,6 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(response.status).to eq(201)
     end
 
-    # it "sends error if new organisations_user is with existing mobile number", :show_in_doc do
-    #   organisations_user = create :organisations_user
-    #   organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
-    #   expect {
-    #     post :create, format: :json, organisations_user: organisations_user_params
-    #   }.to change(OrganisationsUser, :count).by(0)
-    #   expect(response.status).to eq(422)
-    #   expect(subject["errors"]).to eq("Mobile has already been taken")
-    # end
-
     it "sends error if new organisations_user is with invalid mobile number", :show_in_doc do
       organisations_user_params[:user_attributes][:mobile] = "23535"
       expect {
@@ -95,6 +85,19 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       }.to change(OrganisationsUser, :count).by(1)
       expect(response.status).to eq(201)
       expect(OrganisationsUser.count).to eq(2)
+    end
+
+    it "update existing user first_name, last_name and email" do
+      organisations_user = create :organisations_user
+      new_organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
+      expect {
+        post :create, format: :json, organisations_user: organisations_user_params
+      }.to change(OrganisationsUser, :count).by(1)
+      expect(response.status).to eq(201)
+      expect(OrganisationsUser.count).to eq(2)
+      debugger
+      expect(OrganisationsUser.last.user.first_name).to eq(new_organisations_user_params[:user_attributes][:first_name])
+      expect(OrganisationsUser.last.user.last_name).to eq(new_organisations_user_params[:user_attributes][:last_name])
     end
   end
 end

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -71,10 +71,21 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
 
     it "add organisation user with existing mobile from User Model" do
       organisations_user = create :organisations_user
-      organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
+      organisations_user_params[:user_attributes][:mobile] = "+85295367257"
       expect {
         post :create, format: :json, organisations_user: organisations_user_params
       }.to change(OrganisationsUser, :count).by(1)
+      expect(response.status).to eq(201)
+    end
+
+    it "do not add organisation user if mobile number already exists in organisation", :show_in_doc do
+      organisations_user = create :organisations_user
+      new_organisations_user_params[:organisation_id] = organisations_user.organisation_id
+      new_organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
+      expect {
+        post :create, format: :json, organisations_user: new_organisations_user_params
+      }.to change(OrganisationsUser, :count).by(0)
+      expect(response.status).to eq(422)
     end
   end
 end

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
   let(:organisations_user_params) do
     FactoryBot.attributes_for(:organisations_user, organisation_id: "#{organisation.id}", user_attributes: user_attributes)
   end
+  let(:new_organisations_user_params) do
+    FactoryBot.attributes_for(:organisations_user, organisation_id: "#{organisation.id}", user_attributes: user_attributes)
+  end
 
   let(:subject) { JSON.parse(response.body) }
 
@@ -22,15 +25,15 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(response.status).to eq(201)
     end
 
-    it "sends error if new organisations_user is with existing mobile number", :show_in_doc do
-      organisations_user = create :organisations_user
-      organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
-      expect {
-        post :create, format: :json, organisations_user: organisations_user_params
-      }.to change(OrganisationsUser, :count).by(0)
-      expect(response.status).to eq(422)
-      expect(subject["errors"]).to eq("Mobile has already been taken")
-    end
+    # it "sends error if new organisations_user is with existing mobile number", :show_in_doc do
+    #   organisations_user = create :organisations_user
+    #   organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
+    #   expect {
+    #     post :create, format: :json, organisations_user: organisations_user_params
+    #   }.to change(OrganisationsUser, :count).by(0)
+    #   expect(response.status).to eq(422)
+    #   expect(subject["errors"]).to eq("Mobile has already been taken")
+    # end
 
     it "sends error if new organisations_user is with invalid mobile number", :show_in_doc do
       organisations_user_params[:user_attributes][:mobile] = "23535"
@@ -64,6 +67,14 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       }.to change(OrganisationsUser, :count).by(0)
       expect(response.status).to eq(422)
       expect(subject["errors"]).to eq("User email is invalid")
+    end
+
+    it "add organisation user with existing mobile from User Model" do
+      organisations_user = create :organisations_user
+      organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
+      expect {
+        post :create, format: :json, organisations_user: organisations_user_params
+      }.to change(OrganisationsUser, :count).by(1)
     end
   end
 end

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -34,22 +34,6 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(subject["errors"]).to eq("Mobile is invalid")
     end
 
-    it "assigns 'charity' role to user and creates user_role", :show_in_doc do
-      expect {
-        post :create, format: :json, organisations_user: organisations_user_params
-      }.to change(UserRole, :count).by(1)
-      expect(OrganisationsUser.last.user.roles.pluck(:name)).to include('Charity')
-    end
-
-    it "sends error if new organisations_user is with blank mobile number", :show_in_doc do
-      organisations_user_params[:user_attributes][:mobile] = ""
-      expect {
-        post :create, format: :json, organisations_user: organisations_user_params
-      }.to change(OrganisationsUser, :count).by(0)
-      expect(response.status).to eq(422)
-      expect(subject["errors"]).to eq("Mobile can't be blank. Mobile is invalid")
-    end
-
     it "sends error if new organisations_user is with invalid email id", :show_in_doc do
       organisations_user_params[:user_attributes][:email] = "abc"
       expect {
@@ -58,7 +42,6 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(response.status).to eq(422)
       expect(subject["errors"]).to eq("User email is invalid")
     end
-
 
     it "creates new organisations_user record  if user with mobile number exists in db and its not assigned to same organisation" do
       organisations_user = create :organisations_user
@@ -78,29 +61,6 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       }.to change(OrganisationsUser, :count).by(0)
       expect(response.status).to eq(422)
       expect(subject["errors"]).to eq("Mobile has already been taken")
-    end
-
-    it "creates new user organisation_user if user do not exist in db with same mobile number and not assigned to organisation" do
-      expect {
-        post :create, format: :json, organisations_user: organisations_user_params
-      }.to change(OrganisationsUser, :count).by(1)
-      expect(response.status).to eq(201)
-      expect(OrganisationsUser.first.user.first_name).to eq(organisations_user_params[:user_attributes][:first_name])
-      expect(OrganisationsUser.first.user.last_name).to eq(organisations_user_params[:user_attributes][:last_name])
-      expect(OrganisationsUser.first.user.last_name).to eq(organisations_user_params[:user_attributes][:last_name])
-      expect(OrganisationsUser.first.user.email).to eq(organisations_user_params[:user_attributes][:email])
-    end
-
-    it "update existing users first_name, last_name and email while adding it to organisation" do
-      organisations_user = create :organisations_user
-      new_organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
-      expect {
-        post :create, format: :json, organisations_user: organisations_user_params
-      }.to change(OrganisationsUser, :count).by(1)
-      expect(response.status).to eq(201)
-      expect(OrganisationsUser.last.user.first_name).to eq(new_organisations_user_params[:user_attributes][:first_name])
-      expect(OrganisationsUser.last.user.last_name).to eq(new_organisations_user_params[:user_attributes][:last_name])
-      expect(OrganisationsUser.last.user.email).to eq(new_organisations_user_params[:user_attributes][:email])
     end
   end
 end

--- a/spec/lib/classes/organisations_user_builder_spec.rb
+++ b/spec/lib/classes/organisations_user_builder_spec.rb
@@ -1,16 +1,28 @@
 require "rails_helper"
 
+  # :organisations_user: {
+  #   :organisation_id,
+  #   :position,
+  #   user_attributes: {
+  #     :first_name,
+  #     :last_name,
+  #     :mobile,
+  #     :email
+  #   }
+
 describe OrganisationsUserBuilder do
-  let(:organisation){ create :organisation}
-  let(:user){ create :user}
-  let(:organisations_user){ create :organisations_user, user: user, organisation: organisation }
-  let(:organisations_user_builder)  {OrganisationsUserBuilder.new(organisations_user)}
-  let!(:role) { create :charity_role}
+  let(:organisation) { create :organisation}
+  let(:user) { create :user }
+  let(:organisations_user) { create :organisations_user, user: user, organisation: organisation }
+  let(:organisations_user_builder) { OrganisationsUserBuilder.new(params) }
+  let(:params) { 'organisation_id' => organisation.id, 'user_attributes' => {'mobile' => mobile} }
+  let(:mobile) { '+85251111111' }
+  let!(:role) { create :charity_role }
 
   context "initialization" do
     it { expect(organisations_user_builder.instance_variable_get("@organisations_user")).to eql(organisations_user) }
-    it { expect(organisations_user_builder.instance_variable_get("@organisation_id")).to eql(organisations_user.organisation.id) }
-    it { expect(organisations_user_builder.instance_variable_get("@user")).to eql(organisations_user.user) }
+    it { expect(organisations_user_builder.instance_variable_get("@user_attributes")).to eql(organisations_user.organisation.id) }
+    it { expect(organisations_user_builder.instance_variable_get("@mobile")).to eql(organisations_user.user) }
   end
 
   context "build" do

--- a/spec/lib/classes/organisations_user_builder_spec.rb
+++ b/spec/lib/classes/organisations_user_builder_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe OrganisationsUserBuilder do
+  let(:organisation){ create :organisation}
+  let(:user){ create :user}
+  let(:organisations_user){ create :organisations_user, user: user, organisation: organisation }
+  let(:organisations_user_builder)  {OrganisationsUserBuilder.new(organisations_user)}
+  let!(:role) { create :charity_role}
+
+  context "initialization" do
+    it { expect(organisations_user_builder.instance_variable_get("@organisations_user")).to eql(organisations_user) }
+    it { expect(organisations_user_builder.instance_variable_get("@organisation_id")).to eql(organisations_user.organisation.id) }
+    it { expect(organisations_user_builder.instance_variable_get("@user")).to eql(organisations_user.user) }
+  end
+
+  context "build" do
+    it "adds new user if mobile does not exist and associates it with organisation" do
+    end
+
+    it "updates user if already exist with mobile number" do
+    end
+
+    it "adds user to organisation if user does not exist in organisation" do
+    end
+
+    it "associates charity_role to user if user added in organisation" do
+    end
+
+    it "sends twilio send_message after organisations_user creation" do
+    end
+  end
+end

--- a/spec/models/organisations_user_spec.rb
+++ b/spec/models/organisations_user_spec.rb
@@ -12,16 +12,9 @@ RSpec.describe OrganisationsUser, type: :model do
     it { is_expected.to belong_to :user }
   end
 
-  describe 'Callbacks' do
-    it { is_expected.to callback(:send_welcome_msg).after(:create) }
-    it { is_expected.to callback(:create_user_role).after(:create) }
-
-    it "creates entry in UserRole table after creation OrganisationsUser" do
-      organisation_user = build :organisations_user
-      charity_role = create :charity_role
-      expect{
-        organisation_user.save
-      }.to change(UserRole, :count).by(1)
-    end
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:organisation_id) }
+    it { is_expected.to validate_presence_of(:user_id) }
   end
+
 end


### PR DESCRIPTION
This PR enables capistrano to interact with the new systemd sidekiq service. The deployment user is now able to execute sidekiq systemctl commands to control the background job runner and this is now integrated into deployment so that sidekiq is reloaded after a deployment.

    sudo systemctl start sidekiq
    sudo systemctl stop sidekiq
    sudo systemctl restart sidekiq
    sudo systemctl status sidekiq