### PR TITLE
Gcw 2125 make gc orders searchable on item designation

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -45,7 +45,7 @@ class Order < ActiveRecord::Base
 
   scope :descending, -> { order('id desc') }
 
-  scope :active_orders, -> { where("status NOT IN (?) or state NOT IN (?)", INACTIVE_STATUS, INACTIVE_STATES) }
+  scope :active_orders, -> { where('status NOT IN (?) or orders.state NOT IN (?)', INACTIVE_STATUS, INACTIVE_STATES) }
 
   scope :my_orders, -> { where("created_by_id = (?)", User.current_user.try(:id)) }
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -33,6 +33,8 @@ class Order < ActiveRecord::Base
 
   INACTIVE_STATUS = ['Closed', 'Sent', 'Cancelled']
 
+  INACTIVE_STATES = ['cancelled', 'closed']
+
   scope :non_draft_orders, -> { where('state NOT IN (?)', 'draft') }
 
   scope :with_eager_load, -> {
@@ -43,7 +45,7 @@ class Order < ActiveRecord::Base
 
   scope :descending, -> { order('id desc') }
 
-  scope :active_orders, -> { where('status NOT IN (?)', INACTIVE_STATUS) }
+  scope :active_orders, -> { where("status NOT IN (?) or state NOT IN (?)", INACTIVE_STATUS, INACTIVE_STATES) }
 
   scope :my_orders, -> { where("created_by_id = (?)", User.current_user.try(:id)) }
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -33,7 +33,7 @@ class Order < ActiveRecord::Base
 
   INACTIVE_STATUS = ['Closed', 'Sent', 'Cancelled']
 
-  INACTIVE_STATES = ['cancelled', 'closed', 'draft']
+  INACTIVE_STATES = ['cancelled', 'closed', 'draft'].freeze
 
   scope :non_draft_orders, -> { where('state NOT IN (?)', 'draft') }
 
@@ -244,7 +244,7 @@ class Order < ActiveRecord::Base
 
   def self.search(search_text, to_designate_item)
     fetch_orders(to_designate_item)
-      .where("code ILIKE :query OR 
+      .where("code ILIKE :query OR
       description ILIKE :query OR
       organisations.name_en ILIKE :query OR
       organisations.name_zh_tw ILIKE :query OR
@@ -267,7 +267,7 @@ class Order < ActiveRecord::Base
   def self.join_order_associations
     joins("LEFT OUTER JOIN stockit_local_orders ON orders.detail_id = stockit_local_orders.id and orders.detail_type = 'LocalOrder'
     LEFT OUTER JOIN users ON orders.submitted_by_id = users.id or orders.created_by_id = users.id
-    LEFT OUTER JOIN stockit_contacts ON orders.stockit_contact_id = stockit_contacts.id 
+    LEFT OUTER JOIN stockit_contacts ON orders.stockit_contact_id = stockit_contacts.id
     LEFT OUTER JOIN stockit_organisations ON orders.stockit_organisation_id = stockit_organisations.id
     LEFT OUTER JOIN organisations ON orders.organisation_id = organisations.id")
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -33,7 +33,7 @@ class Order < ActiveRecord::Base
 
   INACTIVE_STATUS = ['Closed', 'Sent', 'Cancelled']
 
-  INACTIVE_STATES = ['cancelled', 'closed']
+  INACTIVE_STATES = ['cancelled', 'closed', 'draft']
 
   scope :non_draft_orders, -> { where('state NOT IN (?)', 'draft') }
 


### PR DESCRIPTION
Hi Team,

This PR is to make gc orders searchable while designating item from stock app.

https://jira.crossroads.org.hk/browse/GCW-2125

Please review and let me know in case of any changes.

Thanks.