### PR TITLE
GCW-2155 filtered responses

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -158,8 +158,7 @@ module Api
       end
 
       def select_serializer
-        is_shallow_render = params[:shallow] == 'true'
-        is_shallow_render ? shallow_serializer : serializer
+        params[:shallow] == 'true' ? shallow_serializer : serializer
       end
 
       def stockit_activity

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -158,7 +158,7 @@ module Api
       end
 
       def select_serializer
-        is_shallow_render = params[:shallow] == true || params[:shallow] == 'true'
+        is_shallow_render = params[:shallow] == 'true'
         is_shallow_render ? shallow_serializer : serializer
       end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -98,8 +98,10 @@ module Api
       private
 
       def order_response(records)
+        is_shallow_render = params[:shallow] == true
+        selected_serializer = is_shallow_render ? shallow_serializer : serializer
         ActiveModel::ArraySerializer.new(records,
-          each_serializer: serializer,
+          each_serializer: selected_serializer,
           root: "designations",
           include_packages: true,
           include_order: false,
@@ -151,6 +153,10 @@ module Api
 
       def serializer
         Api::V1::OrderSerializer
+      end
+
+      def shallow_serializer
+        Api::V1::OrderShallowSerializer
       end
 
       def stockit_activity

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -86,7 +86,7 @@ module Api
       end
 
       def my_orders
-        render json: @orders.my_orders.goodcity_orders, each_serializer: serializer,
+        render json: @orders.my_orders.goodcity_orders, each_serializer: select_serializer,
           root: "orders", include_packages: false, browse_order: true
       end
 
@@ -98,10 +98,8 @@ module Api
       private
 
       def order_response(records)
-        is_shallow_render = params[:shallow] == true
-        selected_serializer = is_shallow_render ? shallow_serializer : serializer
         ActiveModel::ArraySerializer.new(records,
-          each_serializer: selected_serializer,
+          each_serializer: select_serializer,
           root: "designations",
           include_packages: true,
           include_order: false,
@@ -157,6 +155,11 @@ module Api
 
       def shallow_serializer
         Api::V1::OrderShallowSerializer
+      end
+
+      def select_serializer
+        is_shallow_render = params[:shallow] == true || params[:shallow] == 'true'
+        is_shallow_render ? shallow_serializer : serializer
       end
 
       def stockit_activity

--- a/app/serializers/api/v1/order_serializer.rb
+++ b/app/serializers/api/v1/order_serializer.rb
@@ -1,13 +1,6 @@
 module Api::V1
-  class OrderSerializer < ApplicationSerializer
-    embed :ids, include: true
-    attributes :status, :created_at, :code, :detail_type, :id, :detail_id,
-      :contact_id, :local_order_id, :organisation_id, :description, :activity,
-      :country_name, :state, :purpose_description, :created_by_id, :item_ids,
-      :gc_organisation_id, :processed_at, :processed_by_id, :cancelled_at, :cancelled_by_id,
-      :process_completed_at, :process_completed_by_id, :closed_at, :closed_by_id, :dispatch_started_at,
-      :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped, :beneficiary_id
-
+  class OrderSerializer < OrderShallowSerializer
+    attributes :item_ids
     has_one :created_by, serializer: UserProfileSerializer, root: :user
     has_one :stockit_contact, serializer: StockitContactSerializer
     has_one :stockit_organisation, serializer: StockitOrganisationSerializer, root: :organisation
@@ -27,64 +20,15 @@ module Api::V1
     has_one  :submitted_by, serializer: UserSerializer
     has_one  :beneficiary, serializer: BeneficiarySerializer
 
-    def include_packages?
-      @options[:include_packages]
+    def item_ids
     end
-
-    def item_ids; end
 
     def item_ids__sql
       'package_ids'
     end
 
-    def local_order_id
-      (object.detail_type == "LocalOrder" || object.detail_type == "StockitLocalOrder") ? object.detail_id : nil
-    end
-
-    def local_order_id__sql
-      "case when (detail_type = 'LocalOrder' OR detail_type = 'StockitLocalOrder') then detail_id end"
-    end
-
-    def contact_id
-      object.stockit_contact_id
-    end
-
-    def contact_id__sql
-      "stockit_contact_id"
-    end
-
-    def gc_organisation_id
-      object.organisation_id
-    end
-
-    def gc_organisation_id__sql
-      "organisation_id"
-    end
-
-    def organisation_id
-      object.stockit_organisation_id
-    end
-
-    def organisation_id__sql
-    "stockit_organisation_id"
-    end
-
-    def activity
-      object.stockit_activity.try(:name)
-    end
-
-    def activity__sql
-      "(select a.name from stockit_activities a
-        where a.id = orders.stockit_activity_id LIMIT 1)"
-    end
-
-    def country_name
-      object.country.try(:name)
-    end
-
-    def country_name__sql
-      "(select a.name_#{current_language} from countries a
-        where a.id = orders.country_id LIMIT 1)"
+    def include_packages?
+      @options[:include_packages]
     end
 
     def include_non_browse_details?

--- a/app/serializers/api/v1/order_shallow_serializer.rb
+++ b/app/serializers/api/v1/order_shallow_serializer.rb
@@ -6,7 +6,7 @@ module Api::V1
       :country_name, :state, :purpose_description, :created_by_id,
       :gc_organisation_id, :processed_at, :processed_by_id, :cancelled_at, :cancelled_by_id,
       :process_completed_at, :process_completed_by_id, :closed_at, :closed_by_id, :dispatch_started_at,
-      :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped
+      :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped, :beneficiary_id
 
     def local_order_id
       (object.detail_type == "LocalOrder" || object.detail_type == "StockitLocalOrder") ? object.detail_id : nil

--- a/app/serializers/api/v1/order_shallow_serializer.rb
+++ b/app/serializers/api/v1/order_shallow_serializer.rb
@@ -1,0 +1,62 @@
+module Api::V1
+  class OrderShallowSerializer < ApplicationSerializer
+    embed :ids, include: true
+    attributes :status, :created_at, :code, :detail_type, :id, :detail_id,
+      :contact_id, :local_order_id, :organisation_id, :description, :activity,
+      :country_name, :state, :purpose_description, :created_by_id,
+      :gc_organisation_id, :processed_at, :processed_by_id, :cancelled_at, :cancelled_by_id,
+      :process_completed_at, :process_completed_by_id, :closed_at, :closed_by_id, :dispatch_started_at,
+      :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped
+
+    def local_order_id
+      (object.detail_type == "LocalOrder" || object.detail_type == "StockitLocalOrder") ? object.detail_id : nil
+    end
+
+    def local_order_id__sql
+      "case when (detail_type = 'LocalOrder' OR detail_type = 'StockitLocalOrder') then detail_id end"
+    end
+
+    def contact_id
+      object.stockit_contact_id
+    end
+
+    def contact_id__sql
+      "stockit_contact_id"
+    end
+
+    def gc_organisation_id
+      object.organisation_id
+    end
+
+    def gc_organisation_id__sql
+      "organisation_id"
+    end
+
+    def organisation_id
+      object.stockit_organisation_id
+    end
+
+    def organisation_id__sql
+    "stockit_organisation_id"
+    end
+
+    def activity
+      object.stockit_activity.try(:name)
+    end
+
+    def activity__sql
+      "(select a.name from stockit_activities a
+        where a.id = orders.stockit_activity_id LIMIT 1)"
+    end
+
+    def country_name
+      object.country.try(:name)
+    end
+
+    def country_name__sql
+      "(select a.name_#{current_language} from countries a
+        where a.id = orders.country_id LIMIT 1)"
+    end
+  end
+end
+  

--- a/app/serializers/api/v1/order_shallow_serializer.rb
+++ b/app/serializers/api/v1/order_shallow_serializer.rb
@@ -37,7 +37,7 @@ module Api::V1
     end
 
     def organisation_id__sql
-    "stockit_organisation_id"
+      "stockit_organisation_id"
     end
 
     def activity

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
 
 development:
   <<: *default
-  database: from_staging
+  database: goodcity_server_development
 
 test:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
 
 development:
   <<: *default
-  database: goodcity_server_development
+  database: from_staging
 
 test:
   <<: *default

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -156,9 +156,11 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
       end
 
       it "should be able to fetch designations without their associations" do
-        get :index, shallow: true
+        get :index, shallow: 'true'
         expect(response.status).to eq(200)
-        expect(parsed_body.keys).to eq(['meta', 'designations'])
+        expect(parsed_body.keys.length).to eq(2)
+        expect(parsed_body).to have_key('designations')
+        expect(parsed_body).to have_key('meta')
       end
 
     end

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -154,6 +154,13 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
         expect(parsed_body['designations'].count).to eq(1)
         expect(parsed_body['meta']['total_pages']).to eql(1)
       end
+
+      it "should be able to fetch designations without their associations" do
+        get :index, shallow: true
+        expect(response.status).to eq(200)
+        expect(parsed_body.keys).to eq(['meta', 'designations'])
+      end
+
     end
   end
 

--- a/spec/factories/orders_packages.rb
+++ b/spec/factories/orders_packages.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     state         ["requested", "cancelled", "designated", "received", "dispatched"].sample
     quantity      2
 
+    trait :with_package_item do
+      association :package, :with_item
+    end
+
     trait :with_state_requested do
       state "requested"
     end


### PR DESCRIPTION
Add an option to fetch orders without any associations. This is used to generate the list of orders when designating an item (performance issues)