### PR TITLE
Fixed: Browse login/Signup issue fixed by passing  app_name to creation_with_auth method.

### DIFF
--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -114,7 +114,7 @@ module Api
       error 422, "Validation Error"
       error 500, "Internal Server Error"
       def signup
-        @user = User.creation_with_auth(auth_params)
+        @user = User.creation_with_auth(auth_params, app_name)
         if @user.valid? && @user.persisted?
           render json: { otp_auth_key: otp_auth_key_for(@user) }, status: :ok
         else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,13 +48,13 @@ class User < ActiveRecord::Base
 
   # If user exists, ignore data and just send_verification_pin
   # Otherwise, create new user and send pin
-  def self.creation_with_auth(user_params)
+  def self.creation_with_auth(user_params, app_name)
     mobile = user_params['mobile']
     user = find_by_mobile(mobile) if mobile.present?
     user ||= new(user_params)
     begin
       user.save if user.changed?
-      user.send_verification_pin if user.valid?
+      user.send_verification_pin(app_name) if user.valid?
     rescue Twilio::REST::RequestError => e
       msg = e.message.try(:split, '.').try(:first)
       user.errors.add(:base, msg)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,7 +85,7 @@ describe User, :type => :model do
       it "should create new user" do
         allow(new_user).to receive(:send_verification_pin)
         expect(User).to receive(:new).with(user_attributes).and_return(new_user)
-        User.creation_with_auth(user_attributes)
+        User.creation_with_auth(user_attributes, DONOR_APP)
       end
     end
 
@@ -94,14 +94,14 @@ describe User, :type => :model do
         user = create(:user, mobile: mobile)
         expect(User).to receive(:find_by_mobile).with(mobile).and_return(user)
         expect(user).to receive(:send_verification_pin)
-        User.creation_with_auth(user_attributes)
+        User.creation_with_auth(user_attributes, DONOR_APP)
       end
     end
 
     context "when mobile blank" do
       let(:mobile) { nil }
       it "should raise validation error" do
-        user = User.creation_with_auth(user_attributes)
+        user = User.creation_with_auth(user_attributes, DONOR_APP)
         expect(user.errors[:mobile]).to include("can't be blank")
         expect(user.errors[:mobile]).to include("is invalid")
       end


### PR DESCRIPTION
Hi Team,

This is PR is for login issue on browse. `Signup` action on controller used `creation_with_auth` which is expecting `app_name` because of which app was breaking. So, have added code for the same and also handled test cases accordingly.
Please review the PR.

Thanks.