### PR TITLE
ADD: Item search filters for state and inventory_number presence

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -128,7 +128,13 @@ module Api
         if params['searchText'].present?
           records = params["orderId"].present? ?
             @packages.undispatched : @packages
-          records = records.search(params['searchText'], params["itemId"], params['showQuantityItems']).page(params["page"]).per(params["per_page"])
+          records = records.search(
+            params['searchText'], 
+            params['itemId'], 
+            :show_quantity_items => params['showQuantityItems'] == 'true', 
+            :state => params['state'],
+            :with_inventory_no => params['withInventoryNumber'] == 'true'
+          ).page(params["page"]).per(params["per_page"])
           pages = records.total_pages
         end
         packages = ActiveModel::ArraySerializer.new(records,

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -129,9 +129,9 @@ module Api
           records = params["orderId"].present? ?
             @packages.undispatched : @packages
           records = records.search(
-            params['searchText'], 
-            params['itemId'], 
-            :show_quantity_items => params['showQuantityItems'] == 'true', 
+            params['searchText'],
+            params['itemId'],
+            :show_quantity_items => params['showQuantityItems'] == 'true',
             :state => params['state'],
             :with_inventory_no => params['withInventoryNumber'] == 'true'
           ).page(params["page"]).per(params["per_page"])

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -74,7 +74,7 @@ class Package < ActiveRecord::Base
         state = options[:state]
         queries = [search_query]
         queries.push "inventory_number IS NOT NULL" if options[:with_inventory_no]
-        queries.push "state = :state" if  !state.nil? && !state.empty?
+        queries.push "state = :state" unless state.blank?
 
         with_associations.where(
           queries.map { |q| "(#{q})" }.join(" AND "),

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -72,12 +72,12 @@ class Package < ActiveRecord::Base
         where("item_id = ?", item_id)
       else
         state = options[:state]
-        queries = [ search_query ]
+        queries = [search_query]
         queries.push "inventory_number IS NOT NULL" if options[:with_inventory_no]
-        queries.push "state = :state" if not state.nil? and not state.empty?
+        queries.push "state = :state" if  !state.nil? && !state.empty?
 
         with_associations.where(
-          queries.map {|q| "(#{q})"}.join(" AND "),
+          queries.map { |q| "(#{q})" }.join(" AND "),
           search_text: "%#{search_text}%",
           state: state
         )

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -66,28 +66,37 @@ class Package < ActiveRecord::Base
 
   attr_accessor :skip_set_relation_update, :request_from_admin
 
-  def self.search(search_text, item_id, show_quantity_item = false)
+  def self.search(search_text, item_id, options = {}) 
     records =
       if item_id.presence
         where("item_id = ?", item_id)
       else
-        allowed_search_columns = [
-          'inventory_number',
-          'designation_name',
-          'notes',
-          'state',
-          'locations.building',
-          'locations.area'
-        ]
+        state = options[:state]
+        queries = [ search_query ]
+        queries.push "inventory_number IS NOT NULL" if options[:with_inventory_no]
+        queries.push "state = :state" if not state.nil? and not state.empty?
+
         with_associations.where(
-          allowed_search_columns
-            .map { |f| "#{f} ILIKE :query" }
-            .join(" OR "),
-          query: "%#{search_text}%"
+          queries.map {|q| "(#{q})"}.join(" AND "),
+          search_text: "%#{search_text}%",
+          state: state
         )
       end
-    records = records.where(received_quantity: 1) unless show_quantity_item == "true"
+    records = records.where(received_quantity: 1) unless options[:show_quantity_items]
     records
+  end
+
+  def self.search_query
+    fields_to_match = [
+      'inventory_number',
+      'designation_name',
+      'notes',
+      'locations.building',
+      'locations.area'
+    ]
+    fields_to_match
+      .map { |f| "#{f} ILIKE :search_text" }
+      .join(" OR ")
   end
 
   def self.with_associations


### PR DESCRIPTION
Matt noticed that we could search items on Stock which had not yet been received, or items which had no inventory numbers.
This PR is adding query options to filter those out in the search. (Will be added to the stock app soon)