### PR TITLE
Fix: charity_role added to user with no roles

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -214,7 +214,7 @@ class Ability
     if can_manage_organisations_users? || @api_user
       can [:create, :show, :index, :update], OrganisationsUser
     end
-
+    can [:update], OrganisationsUser, user_id: @user_id
   end
 
   def package_abilities

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
     FactoryBot.attributes_for(:user, :with_email)
   end
 
+  let(:user) { create :user}
   let(:organisations_user) { create :organisations_user , organisation_id: "#{new_organisation.id}", user_id: "#{supervisor.id}"}
+  let(:organisations_user_without_role) { create :organisations_user , organisation_id: "#{new_organisation.id}", user_id: "#{user.id}"}
 
   let(:update_user_attributes) do
     FactoryBot.attributes_for(:user, :with_email, last_name: "Cooper")
@@ -24,7 +26,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
   end
 
   let(:update_organisations_user_params) do
-    FactoryBot.attributes_for(:organisations_user, organisation_id: "#{new_organisation.id}", user_attributes: update_user_attributes, id: "#{organisations_user.id}")
+    FactoryBot.attributes_for(:organisations_user, organisation_id: "#{new_organisation.id}", user_attributes: update_user_attributes, id: "#{organisations_user_without_role.id}")
   end
 
   let(:subject) { JSON.parse(response.body) }
@@ -90,6 +92,14 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       put :update, id: organisations_user_id, organisations_user: update_organisations_user_params
       organisations_user = OrganisationsUser.find_by_id(organisations_user_id)
       expect(organisations_user.position).to eq("Admin")
+    end
+
+    it "it adds charity_role to organisations_user" do
+      update_organisations_user_params
+      organisations_user_id = update_organisations_user_params[:id]
+      put :update, id: organisations_user_id, organisations_user: update_organisations_user_params
+      organisations_user = OrganisationsUser.find_by_id(organisations_user_id)
+      expect(organisations_user.user.roles.pluck(:name)).to include("Charity")
     end
   end
 end


### PR DESCRIPTION
Hi Team,
This is PR for permission issue for user with no roles. Organisation User update action was not allowed for user with no roles. Issue is fixed.

https://jira.crossroads.org.hk/browse/GCW-2132?focusedCommentId=31692&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-31692

Please review the PR and let me know if any change is required.
Thanks 