### PR TITLE
Gcw 2198 order filtering for designation

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -38,9 +38,7 @@ class Order < ActiveRecord::Base
 
   INACTIVE_STATUS = ['Closed', 'Sent', 'Cancelled'].freeze
 
-  LOCKED_STATES = ['cancelled', 'closed'].freeze
-
-  INACTIVE_STATES = (LOCKED_STATES + ['draft']).freeze
+  INACTIVE_STATES = ['cancelled', 'closed', 'draft'].freeze
 
   scope :non_draft_orders, -> { where('state NOT IN (?)', 'draft') }
 
@@ -58,11 +56,11 @@ class Order < ActiveRecord::Base
     query = <<-SQL
       (
         submitted_at IS NOT NULL
-        AND (status NOT IN (:inactive_status) OR orders.state NOT IN (:locked_state))
+        AND (status NOT IN (:inactive_status) OR orders.state NOT IN (:inactive_states))
       )
       OR (state = 'draft' AND detail_type != 'GoodCity')
     SQL
-    where(query, inactive_status: INACTIVE_STATUS, locked_state: LOCKED_STATES)
+    where(query, inactive_status: INACTIVE_STATUS, inactive_states: INACTIVE_STATES)
   }
 
   scope :my_orders, -> { where("created_by_id = (?)", User.current_user.try(:id)) }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -36,9 +36,11 @@ class Order < ActiveRecord::Base
   accepts_nested_attributes_for :beneficiary
   accepts_nested_attributes_for :address
 
-  INACTIVE_STATUS = ['Closed', 'Sent', 'Cancelled']
+  INACTIVE_STATUS = ['Closed', 'Sent', 'Cancelled'].freeze
 
-  INACTIVE_STATES = ['cancelled', 'closed', 'draft'].freeze
+  LOCKED_STATES = ['cancelled', 'closed'].freeze
+
+  INACTIVE_STATES = (LOCKED_STATES + ['draft']).freeze
 
   scope :non_draft_orders, -> { where('state NOT IN (?)', 'draft') }
 
@@ -51,6 +53,17 @@ class Order < ActiveRecord::Base
   scope :descending, -> { order('id desc') }
 
   scope :active_orders, -> { where('status NOT IN (?) or orders.state NOT IN (?)', INACTIVE_STATUS, INACTIVE_STATES) }
+
+  scope :designatable_orders, -> { 
+    query = <<-SQL
+      (
+        submitted_at IS NOT NULL
+        AND (status NOT IN (:inactive_status) OR orders.state NOT IN (:locked_state))
+      )
+      OR (state = 'draft' AND detail_type != 'GoodCity')
+    SQL
+    where(query, inactive_status: INACTIVE_STATUS, locked_state: LOCKED_STATES)
+  }
 
   scope :my_orders, -> { where("created_by_id = (?)", User.current_user.try(:id)) }
 
@@ -263,7 +276,7 @@ class Order < ActiveRecord::Base
 
   def self.fetch_orders(to_designate_item)
     if to_designate_item
-      join_order_associations.active_orders
+      join_order_associations.designatable_orders
     else
       join_order_associations.non_draft_orders
     end

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
   let(:charity_user) { create :user, :charity, :with_can_manage_orders_permission}
   let!(:order) { create :order, :with_state_submitted, created_by: charity_user }
   let(:draft_order) { create :order, :with_orders_packages, :with_state_draft, status: nil }
-  let(:draft_order_with_status) { create :order, :with_orders_packages, :with_state_draft }
   let(:user) { create(:user_with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
   let!(:order_created_by_supervisor) { create :order, :with_state_submitted, created_by: user }
@@ -134,33 +133,54 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
         expect(parsed_body['meta']['search']).to eql('john smith')
       end
 
-      it 'returns goodcity order if search text is non draft goodcity order with toDesignateItem params' do
-        get :index, searchText: order.code, toDesignateItem: true
-        expect(response.status).to eq(200)
-        expect(parsed_body['designations'].count).to eq(1)
-        expect(parsed_body['meta']['total_pages']).to eql(1)
-      end
-
-      it 'do not returns goodcity order if search text is draft goodcity order with toDesignateItem params' do
-        get :index, searchText: draft_order.code, toDesignateItem: true
-        expect(response.status).to eq(200)
-        expect(parsed_body['designations'].count).to eq(0)
-        expect(parsed_body['meta']['total_pages']).to eql(0)
-      end
-
-      it 'returns goodicty order if search text is non-draft goodcity order with toDesignateItem params even if status is active_status list' do
-        get :index, searchText: draft_order_with_status.code, toDesignateItem: true
-        expect(response.status).to eq(200)
-        expect(parsed_body['designations'].count).to eq(1)
-        expect(parsed_body['meta']['total_pages']).to eql(1)
-      end
-
       it "should be able to fetch designations without their associations" do
         get :index, shallow: 'true'
         expect(response.status).to eq(200)
         expect(parsed_body.keys.length).to eq(2)
         expect(parsed_body).to have_key('designations')
         expect(parsed_body).to have_key('meta')
+      end
+
+      describe "When designating an item ( ?toDesignateItem=true )" do
+        it 'returns a non draft goodcity order with a submitted_at timestamp' do
+          record = create :order, :with_state_submitted, submitted_at: DateTime.now
+          get :index, searchText: record.code, toDesignateItem: true, submitted_at: DateTime.now
+          expect(response.status).to eq(200)
+          expect(parsed_body['designations'].count).to eq(1)
+          expect(parsed_body['meta']['total_pages']).to eql(1)
+        end
+
+        it 'doesnt return a non draft goodcity order with no submitted_at timestamp' do
+          record = create :order, :with_state_submitted, submitted_at: nil
+          get :index, searchText: record.code, toDesignateItem: true, submitted_at: DateTime.now
+          expect(response.status).to eq(200)
+          expect(parsed_body['designations'].count).to eq(0)
+          expect(parsed_body['meta']['total_pages']).to eql(0)
+        end
+  
+        it 'returns a draft stockit order' do
+          record = create :order, :with_state_draft, detail_type: 'StockitLocalOrder'
+          get :index, searchText: record.code, toDesignateItem: true
+          expect(response.status).to eq(200)
+          expect(parsed_body['designations'].count).to eq(1)
+          expect(parsed_body['meta']['total_pages']).to eql(1)
+        end
+
+        it 'doesnt return a draft goodcity order' do
+          record = create :order, :with_state_draft, detail_type: 'GoodCity'
+          get :index, searchText: record.code, toDesignateItem: true
+          expect(response.status).to eq(200)
+          expect(parsed_body['designations'].count).to eq(0)
+          expect(parsed_body['meta']['total_pages']).to eql(0)
+        end
+  
+        it 'returns a draft goodicty order if status marks it as active' do
+          draft_order_with_status = create :order, state: 'draft', status: 'Processing', submitted_at: DateTime.now
+          get :index, searchText: draft_order_with_status.code, toDesignateItem: true
+          expect(response.status).to eq(200)
+          expect(parsed_body['designations'].count).to eq(1)
+          expect(parsed_body['meta']['total_pages']).to eql(1)
+        end
       end
 
     end


### PR DESCRIPTION
When searching for orders to which we can designate items, we **only** show the orders that matches any of the following rules : 
- The order is a **Draft StockIT** order 
This allows Recycling and LocalBoutique to appear in the results

- The order is in an **active state** (Submitted/Processing/Scheduled/Dispatching) **and** has a submitted_at timestamp

--> https://jira.crossroads.org.hk/browse/GCW-2198