### PR TITLE
Created a locale switcher to ensure I18n.locale state doesn't pollute…

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe ApplicationController, type: :controller do
         expect(I18n.locale).to eql(:en)
       end
 
+      after do
+        I18n.locale = 'en'
+      end
+
     end
 
     context "current_user" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -57,13 +57,15 @@ RSpec.describe Organisation, type: :model do
       let(:organisation) { create :organisation }
 
       it 'returns name_en if locale is en' do
-        I18n.locale = :"zh-tw"
-        expect(organisation.name_as_per_locale).to eq(organisation.name_zh_tw)
+        in_locale 'en' do
+          expect(organisation.name_as_per_locale).to eq(organisation.name_en)
+        end
       end
 
       it 'returns name_zh_tw if locale is zh-tw' do
-        I18n.locale = :en
-        expect(organisation.name_as_per_locale).to eq(organisation.name_en)
+        in_locale 'zh-tw' do
+          expect(organisation.name_as_per_locale).to eq(organisation.name_zh_tw)
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
   config.include Warden::Test::ControllerHelpers, type: :controller
   config.include ControllerMacros, type: :controller
   config.include ActiveJob::TestHelper
+  config.include LocaleSwitcher
 
   Warden.test_mode!
 

--- a/spec/serializers/api/v1/district_serializer_spec.rb
+++ b/spec/serializers/api/v1/district_serializer_spec.rb
@@ -16,9 +16,10 @@ describe Api::V1::DistrictSerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    expect(json['district']['name']).to eql(district.name_zh_tw)
-    #~ expect(json['territories'].first['name']).to eql(district.territory.name_zh_tw)
+    in_locale 'zh-tw' do
+      expect(json['district']['name']).to eql(district.name_zh_tw)
+      #~ expect(json['territories'].first['name']).to eql(district.territory.name_zh_tw)
+    end
   end
 
 end

--- a/spec/serializers/api/v1/donor_condition_serializer_spec.rb
+++ b/spec/serializers/api/v1/donor_condition_serializer_spec.rb
@@ -14,8 +14,9 @@ describe Api::V1::DonorConditionSerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    expect(json['donor_condition']['name']).to eql(donor_condition.name_zh_tw)
+    in_locale 'zh-tw' do
+      expect(json['donor_condition']['name']).to eql(donor_condition.name_zh_tw)
+    end
   end
 
 end

--- a/spec/serializers/api/v1/organisation_without_order_serializer_spec.rb
+++ b/spec/serializers/api/v1/organisation_without_order_serializer_spec.rb
@@ -18,8 +18,9 @@ describe Api::V1::OrganisationWithoutOrderSerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    expect(json['organisation_without_order']['name_zh_tw']).to eql(organisation_without_order.name_zh_tw)
-    expect(json['organisation_without_order']['description_zh_tw']).to eql(organisation_without_order.description_zh_tw)
+    in_locale 'zh-tw' do
+      expect(json['organisation_without_order']['name_zh_tw']).to eql(organisation_without_order.name_zh_tw)
+      expect(json['organisation_without_order']['description_zh_tw']).to eql(organisation_without_order.description_zh_tw)
+    end
   end
 end

--- a/spec/serializers/api/v1/package_category_serializer_spec.rb
+++ b/spec/serializers/api/v1/package_category_serializer_spec.rb
@@ -15,8 +15,9 @@ describe Api::V1::PackageCategorySerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    expect(json['package_category']['name']).to eql(package_category.name_zh_tw)
+    in_locale 'zh-tw' do
+      expect(json['package_category']['name']).to eql(package_category.name_zh_tw)
+    end
   end
 
 end

--- a/spec/serializers/api/v1/package_type_serializer_spec.rb
+++ b/spec/serializers/api/v1/package_type_serializer_spec.rb
@@ -13,18 +13,21 @@ describe Api::V1::PackageTypeSerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    expect(json['package_type']['name']).to eql(package_type.name_zh_tw)
+    in_locale 'zh-tw' do
+      expect(json['package_type']['name']).to eql(package_type.name_zh_tw)
+    end
   end
 
   it "returns name_zh_tw for chinese" do
-    I18n.locale = 'zh-tw'
-    expect(described_class.new("test").name__sql).to eq("coalesce(NULLIF(name_zh_tw, ''), name_en)")
+    in_locale 'zh-tw' do
+      expect(described_class.new("test").name__sql).to eq("coalesce(NULLIF(name_zh_tw, ''), name_en)")
+    end
   end
 
   it "returns name_en for english" do
-    I18n.locale = 'en'
-    expect(described_class.new("test").name__sql).to eq("coalesce(NULLIF(name_en, ''), name_en)")
+    in_locale 'en' do
+      expect(described_class.new("test").name__sql).to eq("coalesce(NULLIF(name_en, ''), name_en)")
+    end
   end
 
 end

--- a/spec/serializers/api/v1/rejection_reason_serializer_spec.rb
+++ b/spec/serializers/api/v1/rejection_reason_serializer_spec.rb
@@ -14,9 +14,10 @@ describe Api::V1::RejectionReasonSerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    json = JSON.parse( serializer.to_json )
-    expect(json['rejection_reason']['name']).to eql(rejection_reason.name_zh_tw)
+    in_locale 'zh-tw' do
+      json = JSON.parse( serializer.to_json )
+      expect(json['rejection_reason']['name']).to eql(rejection_reason.name_zh_tw)
+    end
   end
 
 end

--- a/spec/serializers/api/v1/territory_serializer_spec.rb
+++ b/spec/serializers/api/v1/territory_serializer_spec.rb
@@ -14,8 +14,9 @@ describe Api::V1::TerritorySerializer do
   end
 
   it "translates JSON" do
-    I18n.locale = 'zh-tw'
-    expect(json['territory']['name']).to eql(territory.name_zh_tw)
+    in_locale 'zh-tw' do
+      expect(json['territory']['name']).to eql(territory.name_zh_tw)
+    end
   end
 
 end

--- a/spec/support/in_locale.rb
+++ b/spec/support/in_locale.rb
@@ -1,0 +1,10 @@
+module LocaleSwitcher
+
+  def in_locale(locale)
+    current_locale = I18n.locale
+    I18n.locale = locale
+    yield
+    I18n.locale = current_locale
+  end
+  
+end

--- a/spec/support/shared_examples/name_with_language.rb
+++ b/spec/support/shared_examples/name_with_language.rb
@@ -2,13 +2,15 @@ shared_examples 'name_with_language' do
 
   describe "#current_language" do
     it "returns name_zh_tw for chinese" do
-      I18n.locale = 'zh-tw'
-      expect(described_class.new("test").name__sql).to eq("name_zh_tw")
+      in_locale 'zh-tw' do
+        expect(described_class.new("test").name__sql).to eq("name_zh_tw")
+      end
     end
 
     it "returns name_en for english" do
-      I18n.locale = 'en'
-      expect(described_class.new("test").name__sql).to eq("name_en")
+      in_locale 'en' do
+        expect(described_class.new("test").name__sql).to eq("name_en")
+      end
     end
   end
 end


### PR DESCRIPTION
… the global spec space. There were a few cases, where running specs in random order caused locale to be switched to 'zh-tw' and kept.

TLDR;

In our rspec tests, we sometimes write `I18n.locale = 'zh-tw'` to switch into chinese and test some translations. This is fine except that when the spec is finished and the next one starts, the locale isn't reset back to 'en'. Most of our specs assume we want 'en' unless otherwise specified.

This PR ensures that we reset the locale to 'en' after every spec that switches it to another language. It does this by wrapping the locale change and expectation inside a block and resetting it afterwards.