### PR TITLE
Rake task to update sms_reminder_sent_at time to 24 hours from present Time

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,6 +5,6 @@ every :tuesday, at: '5 pm' do
   rake 'goodcity:import_swd_organisations'
 end
 
-every 15.minutes do
-  rake 'goodcity:send_unread_message_reminders'
-end
+# every 15.minutes do
+#   rake 'goodcity:send_unread_message_reminders'
+# end

--- a/lib/tasks/subscription_sms_sent_reminder_at.rake
+++ b/lib/tasks/subscription_sms_sent_reminder_at.rake
@@ -1,0 +1,19 @@
+require "goodcity/rake_logger"
+
+namespace :goodcity do
+  desc 'Update sms_reminder_sent_at to next day'
+
+  task update_sms_reminder_sent_at: :environment do
+    log = Goodcity::RakeLogger.new("update_sms_reminder_sent_at")
+    success_count = 0
+
+    nil_sms_reminder_count = Subscription.where(sms_reminder_sent_at: nil).count
+    log.info("\nSubscription with nil value: #{nil_sms_reminder_count}")
+
+    Subscription.find_each(batch_size: 100) do |subscription|
+      success_count +=1 if subscription.update_column(:sms_reminder_sent_at, Time.zone.now + 24.hours)
+    end
+
+    log.info("\nTotal Records Updated: #{success_count}")
+  end
+end


### PR DESCRIPTION
Hi Team,
This is PR for rake task to update `sms_reminder_sent_at ` to 24 hours from present time. I've also commented out cron job to run `SMS Reminder`. Once the rake is run on live, will uncomment the job.

Please review it and let me know if any change is required.