### PR TITLE
Subscription: sms_reminder_sent_at update changed from Time.now to Time.zone.now

### DIFF
--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -4,7 +4,7 @@ class SubscriptionsReminder
     sms_url = "#{Rails.application.secrets.base_urls['app']}/offers"
     donor_unread_subscriptions(donor_users).group_by(&:user_id).each do |user_id, subscriptions|
       begin
-        Subscription.where(id: subscriptions.map(&:id)).update_all(sms_reminder_sent_at: Time.now)
+        Subscription.where(id: subscriptions.map(&:id)).update_all(sms_reminder_sent_at: Time.zone.now)
         TwilioService.new(User.find(user_id)).send_unread_message_reminder(sms_url)
         Rails.logger.info("\n Message sent to user: #{user_id}")
       rescue Exception => e


### PR DESCRIPTION
Hi Team,
This is PR for `sms_reminder_sent_at` update from `Time.now` to `Time.zone.now`.

Please review this PR and let me know if any change is required.
