### PR TITLE
Fix bug where a holiday would show as available if it is today

### DIFF
--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -8,7 +8,7 @@ class Holiday < ActiveRecord::Base
   before_save :set_year, if: :holiday_changed?
 
   scope :within_days, ->(days) {
-    between_times(Time.zone.now, Time.zone.now + days) }
+    between_times(Time.zone.now.beginning_of_day, Time.zone.now.end_of_day + days) }
 
   def self.is_holiday(date)
     Holiday.where(" date(holiday AT TIME ZONE 'HKT') = ?", date.to_date).count > 0

--- a/lib/classes/date_set.rb
+++ b/lib/classes/date_set.rb
@@ -15,7 +15,7 @@ class DateSet
       get_dates_list
       break if @dates.count >= @days
       @last = @start + @offset
-      @holidays = Holiday.within_days(@offset + @days.days)
+      @holidays = Holiday.within_days(@offset + @days.days).pluck(:holiday)
     end
     @dates[0..@days - 1]
   end

--- a/spec/controllers/api/v1/holidays_controller_spec.rb
+++ b/spec/controllers/api/v1/holidays_controller_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe Api::V1::HolidaysController, type: :controller do
       expect(body.length).to eq(6)
       expect(body).to_not include(JSON.parse(holiday_1.holiday.to_json))
     end
+
+
+    describe 'Timestamp edge cases' do
+      it "Should not include current day if it is a holiday", :show_in_doc do
+        create(:holiday, holiday: Time.now.beginning_of_day)
+        get :available_dates, schedule_days: 6
+        pp response.body
+        body = JSON.parse(response.body)
+        expect(body.length).to eq(6)
+        expect(body).to_not include(Time.now.to_date.to_s)
+      end
+    end
+
   end
 
   describe 'DELETE holiday/1' do


### PR DESCRIPTION
Quick notes: 
During debug I saw some of the tests are potentially faulty, so is the DateSet class. After fixing the bug it entered into a new part of the code and broke there (hence the addition of `.pluck(:holiday)`
I think a proper migration from `timestamp` to `date` is very much needed here

Some details on the issue ->

the `within_days` method searches for timestamps which are `> Time.now` , however holidays are stored with hour `00:00`.
Meaning that at `10am` is already out of that range 