### PR TITLE
Put socketio push updates on to it's own queue.

### DIFF
--- a/app/jobs/socketio_send_job.rb
+++ b/app/jobs/socketio_send_job.rb
@@ -1,5 +1,5 @@
 class SocketioSendJob < ActiveJob::Base
-  queue_as :default
+  queue_as :push_updates
 
   def perform(channels, event, data, resync = false)
     url = Rails.application.secrets.socketio_service['url'] + (resync ? '&resync=true' : '')

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,7 @@
 #  A queue with a weight of 2 will be checked twice as often as a queue with a weight of 1
 :queues:
   - default
+  - push_updates
   - mailers
   - low
   - gogovan_orders


### PR DESCRIPTION
This enables us to separate out jobs during stock take.