### PR TITLE
Gcw 2189 sms refactoring bug fixes

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,4 +2,7 @@ class Subscription < ActiveRecord::Base
   belongs_to :user
   belongs_to :message
   belongs_to :offer
+
+  scope :unread, -> { where(state: 'unread') }
+
 end

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -2,7 +2,7 @@ class SubscriptionsReminder
 
   def generate
     user_candidates_for_reminder.each do |user|
-      user.update_attribute(:sms_reminder_sent_at, Time.zone.now)
+      user.update(sms_reminder_sent_at: Time.now)
       send_sms_reminder(user)
     end
   end
@@ -19,7 +19,7 @@ class SubscriptionsReminder
     user_ids = Offer.distinct.pluck(:created_by_id)
     User.joins(subscriptions: [:message]).
       where('users.id IN (?)', user_ids).
-      where("COALESCE(users.sms_reminder_sent_at, users.created_at) < (?)", delta.to_s(:db)).
+      where("COALESCE(users.sms_reminder_sent_at, users.created_at) < (?)", delta.iso8601).
       where('subscriptions.state': 'unread').
       where("messages.created_at > COALESCE(users.sms_reminder_sent_at, users.created_at)").
       where('messages.sender_id != users.id').

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -1,26 +1,46 @@
 class SubscriptionsReminder
 
   def generate
-    sms_url = "#{Rails.application.secrets.base_urls['app']}/offers"
-    donor_unread_subscriptions(donor_users).group_by(&:user_id).each do |user_id, subscriptions|
-      begin
-        Subscription.where(id: subscriptions.map(&:id)).update_all(sms_reminder_sent_at: Time.zone.now)
-        TwilioService.new(User.find(user_id)).send_unread_message_reminder(sms_url)
-        Rails.logger.info("\n Message sent to user: #{user_id}")
-      rescue Exception => e
-        Rails.logger.error("\nError: #{e.message}")
-      end
+    users_to_remind.each do |user_id, subscriptions|
+      user = User.find(user_id)
+      user.update(sms_reminder_sent_at: Time.zone.now)
+      send_sms_reminder(user)
     end
   end
 
   private
 
-  def donor_users
-    Offer.distinct.pluck(:created_by_id)
+  # Get list of subscriptions distinct by user where user is donor and hasn't received reminder since
+
+  def users_to_remind
+    donor_ids = Offer.distinct.pluck(:created_by_id).compact
+
+    User.joins(subscriptions: [:messages]).where(
+     'id IN (?) AND
+     subscriptions.state = (?) AND
+     MIN(messages.created_at) > users.sms_reminder_sent_at AND
+     MIN(messages.created_at) > (?)',
+     donor_ids, 'unread', delta
+    ).distinct('id')
+
+    # Subscription.
+    #   joins(:message, :user).
+    #   where('users.id IN (?) AND 
+    #     subscriptions.state = (?) AND
+    #     MIN(messages.created_at) > users.sms_reminder_sent_at AND
+    #     MIN(messages.created_at) > (?)',
+    #     donor_ids, 'unread', delta)
   end
 
-  def donor_unread_subscriptions(users)
-    Subscription.where(state: 'unread', user_id: users).
-      where("sms_reminder_sent_at IS NULL OR sms_reminder_sent_at < ?", SUBSCRIPTION_REMINDER_TIME_DELTA.ago)
+  def send_sms_reminder(user)
+    sms_url = "#{Rails.application.secrets.base_urls['app']}/offers"
+    TwilioService.new(user).send_unread_message_reminder(sms_url)
+    Rails.logger.info("SMS reminder sent to user #{user.id}")
   end
+
+  # E.g. 4.hours.ago
+  def delta
+    SUBSCRIPTION_REMINDER_TIME_DELTA.ago
+  end
+
 end

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -2,7 +2,7 @@ class SubscriptionsReminder
 
   def generate
     user_candidates_for_reminder.each do |user|
-      user.update(sms_reminder_sent_at: Time.zone.now)
+      user.update_attribute(:sms_reminder_sent_at, Time.zone.now)
       send_sms_reminder(user)
     end
   end

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -1,33 +1,29 @@
 class SubscriptionsReminder
 
   def generate
-    users_with_unread_messages.each do |user|
-
-      oldest_unread_message = user.subscriptions.unread.map{|s| s.message.created_at}.min
-      if oldest_unread_message > max(user.sms_reminder_sent_at, delta)
-        user.update(sms_reminder_sent_at: Time.zone.now)
-        send_sms_reminder(user)
-      end
-
-      # Better to start with messages created in last 'delta' hours and find users who haven't been reminded in last 4 hours
-
+    user_candidates_for_reminder.each do |user|
+      user.update(sms_reminder_sent_at: Time.zone.now)
+      send_sms_reminder(user)
     end
   end
 
   private
 
-  # Get list of subscriptions distinct by user where user is donor and hasn't received reminder since
-
-  def users_to_remind
-    user_ids = Offer.distinct.pluck(:created_by_id).compact
-    # User.joins(subscriptions: [:message]).where(id: user_ids, 'subscriptions.state': 'unread').group('users.id, sms_reminder_sent_at').having("MIN(messages.created_at) > sms_reminder_sent_at AND MIN(messages.created_at) > '#{delta}'").distinct(:id)    
-    # GREATEST(sms_reminder_sent_at, '#{delta}')").distinct(:id)
-  end
-
-  def users_with_unread_messages
-    user_ids = Offer.distinct.pluck(:created_by_id).compact
-    User.joins(:subscriptions).
-      where(id: user_ids, 'subscriptions.state': 'unread').distinct(:id)
+  # Users who 
+  #   haven't been reminded in last X hours
+  #   have unread messages
+  #   are donors
+  #   aren't the author of the message
+  # If sms_reminder_sent_at is NULL then use created_at so we don't SMS user immediately
+  def user_candidates_for_reminder
+    user_ids = Offer.distinct.pluck(:created_by_id)
+    User.joins(subscriptions: [:message]).
+      where('users.id IN (?)', user_ids).
+      where("COALESCE(users.sms_reminder_sent_at, users.created_at) < (?)", delta.to_s(:db)).
+      where('subscriptions.state': 'unread').
+      where("messages.created_at > COALESCE(users.sms_reminder_sent_at, users.created_at)").
+      where('messages.sender_id != users.id').
+      distinct
   end
 
   def send_sms_reminder(user)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,6 +5,8 @@ every :tuesday, at: '5 pm' do
   rake 'goodcity:import_swd_organisations'
 end
 
-# every '*/15 8-20 * * *' do
-#   rake 'goodcity:send_unread_message_reminders'
+# if environment.to_s == "staging"
+#   every '*/15 8-20 * * *' do
+#     rake 'goodcity:send_unread_message_reminders'
+#   end
 # end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,6 +5,6 @@ every :tuesday, at: '5 pm' do
   rake 'goodcity:import_swd_organisations'
 end
 
-# every 15.minutes do
+# every '*/15 8-20 * * *' do
 #   rake 'goodcity:send_unread_message_reminders'
 # end

--- a/db/migrate/20190126035002_move_sms_reminder_at_to_user.rb
+++ b/db/migrate/20190126035002_move_sms_reminder_at_to_user.rb
@@ -1,6 +1,6 @@
 class MoveSmsReminderAtToUser < ActiveRecord::Migration
   def change
-    remove_column :subscriptions, :sms_reminder_sent_at
-    add_column :users, :sms_reminder_sent_at, 'timestamp without time zone', default: nil
+    remove_column :subscriptions, :sms_reminder_sent_at, :datetime
+    add_column :users, :sms_reminder_sent_at, :datetime, default: nil
   end
 end

--- a/db/migrate/20190126035002_move_sms_reminder_at_to_user.rb
+++ b/db/migrate/20190126035002_move_sms_reminder_at_to_user.rb
@@ -1,0 +1,6 @@
+class MoveSmsReminderAtToUser < ActiveRecord::Migration
+  def change
+    remove_column :subscriptions, :sms_reminder_sent_at
+    add_column :users, :sms_reminder_sent_at, 'timestamp without time zone', default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190110123923) do
+ActiveRecord::Schema.define(version: 20190126035002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -675,11 +675,10 @@ ActiveRecord::Schema.define(version: 20190110123923) do
   add_index "subpackage_types", ["subpackage_type_id"], name: "index_subpackage_types_on_subpackage_type_id", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|
-    t.integer  "offer_id"
-    t.integer  "user_id"
-    t.integer  "message_id"
-    t.string   "state"
-    t.datetime "sms_reminder_sent_at"
+    t.integer "offer_id"
+    t.integer "user_id"
+    t.integer "message_id"
+    t.string  "state"
   end
 
   add_index "subscriptions", ["offer_id", "user_id", "message_id"], name: "offer_user_message", unique: true, using: :btree
@@ -718,9 +717,10 @@ ActiveRecord::Schema.define(version: 20190110123923) do
     t.integer  "image_id"
     t.datetime "last_connected"
     t.datetime "last_disconnected"
-    t.boolean  "disabled",          default: false
+    t.boolean  "disabled",             default: false
     t.string   "email"
     t.string   "title"
+    t.datetime "sms_reminder_sent_at"
   end
 
   add_index "users", ["image_id"], name: "index_users_on_image_id", using: :btree

--- a/lib/tasks/subscription_sms_sent_reminder_at.rake
+++ b/lib/tasks/subscription_sms_sent_reminder_at.rake
@@ -1,19 +1,6 @@
-require "goodcity/rake_logger"
-
 namespace :goodcity do
-  desc 'Update sms_reminder_sent_at to next day'
-
+  desc 'Set all User.sms_reminder_sent_at values to now'
   task update_sms_reminder_sent_at: :environment do
-    log = Goodcity::RakeLogger.new("update_sms_reminder_sent_at")
-    success_count = 0
-
-    nil_sms_reminder_count = Subscription.where(sms_reminder_sent_at: nil).count
-    log.info("\nSubscription with nil value: #{nil_sms_reminder_count}")
-
-    Subscription.find_each(batch_size: 100) do |subscription|
-      success_count +=1 if subscription.update_column(:sms_reminder_sent_at, Time.zone.now + 24.hours)
-    end
-
-    log.info("\nTotal Records Updated: #{success_count}")
+    User.all.update(sms_reminder_sent_at: Time.zone.now)
   end
 end

--- a/lib/tasks/subscription_sms_sent_reminder_at.rake
+++ b/lib/tasks/subscription_sms_sent_reminder_at.rake
@@ -1,6 +1,6 @@
 namespace :goodcity do
   desc 'Set all User.sms_reminder_sent_at values to now'
   task update_sms_reminder_sent_at: :environment do
-    User.all.update(sms_reminder_sent_at: Time.zone.now)
+    User.update_all(sms_reminder_sent_at: Time.now)
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :subscription, aliases: [:offer_subscription] do
-    offer_id {create(:offer).id }
-    user_id  {create(:user).id }
-    message_id {create(:message).id }
+    offer_id    { create(:offer).id }
+    user_id     { create(:user).id }
+    message_id  { create(:message).id }
     state 'unread'
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
       end
     end
 
-
     trait :with_can_add_or_remove_inventory_number do
       after(:create) do |user, evaluator|
         user.roles << (create :role, :with_can_add_or_remove_inventory_number, name: evaluator.role_name)
@@ -191,9 +190,9 @@ FactoryBot.define do
       end
     end
 
-    trait :with_organisation do
+    trait :with_offer do
       after(:create) do |user|
-        user.organisations << create(:organisation)
+        user.offers << create(:offer)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     last_connected    { 2.days.ago }
     last_disconnected { 1.day.ago }
     disabled          { false }
+    sms_reminder_sent_at { nil }
     initialize_with   { User.find_or_initialize_by(mobile: mobile) }
 
     association :image

--- a/spec/services/subscriptions_reminder_spec.rb
+++ b/spec/services/subscriptions_reminder_spec.rb
@@ -1,31 +1,70 @@
 require 'rails_helper'
 
 describe SubscriptionsReminder do
-  let(:offer) { create :offer }
-  let(:user) { offer.created_by }
-  let!(:subscription) { create(:subscription, user: user, state:'unread' ) }
-  let!(:subscription1) { create(:subscription, user: user, offer: offer, state:'unread', sms_reminder_sent_at: ((SUBSCRIPTION_REMINDER_TIME_DELTA+1).ago) ) }
-  let!(:subscription2) { create(:subscription, user: user, offer: offer, state:'unread', sms_reminder_sent_at: ((SUBSCRIPTION_REMINDER_TIME_DELTA-2).ago) ) }
-  let(:subscription_reminder) { SubscriptionsReminder.new }
-  let(:time) { Time.now }
+  let(:user)          { create :user }
+  let(:delta)         { SUBSCRIPTION_REMINDER_TIME_DELTA }
+  let(:delta_plus_2)  { delta + 2.hours }
+  let(:delta_minus_2) { delta - 2.hours }
+  let(:time)          { Time.now }
 
-  before(:each) do
-    allow(Time).to receive(:now).and_return(time)
-  end
+  before(:each){ allow(Time).to receive(:now).and_return(time) }
+
+  subject { SubscriptionsReminder.new }
 
   context "generate" do
-    it "sends sms of unread messages if sms_reminder_sent_at is nil" do
-      subscription_reminder.generate
-      expect(subscription.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
-    end
-
-    it "sends sms of unread messages if sms_reminder_sent_at gap time is more than 4 hours" do
-      subscription_reminder.generate
-      expect(subscription1.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
-    end
-
-    it "do not sends sms of unread messages if sms_reminder_sent_at gap time is less than 4 hours" do
-      expect{ subscription_reminder.generate}.to_not change(Subscription.find(subscription2.id), :sms_reminder_sent_at)
+    context "sends reminder when" do
+      it "new unread message created in last X hours" do
+        subscription = create(:subscription, user: user, state: 'unread')
+        subject.generate
+        expect(subscription.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
+        # TwilioService.new(User.find(user_id)).send_unread_message_reminder(sms_url)
+        expect(TwilioService).to receive(:new)#.with(user).and_return(TwilioService.new(user))
+      end
+      it "2 new unread message created in last 4 hours only sends one reminder" do
+      end
     end
   end
+
+  context "doesn't send reminder when" do
+    it "other reminders have been sent to same user within 4 hours"
+    it "new message created in last 4 hours has already been read"
+    it "reminder has already been sent for same message"
+    it "it was written by the user themselves"
+  end
+
 end
+
+
+# Send a message if
+#   recipient is donor
+#   a NEW message has been created in last 4 hours
+#   AND it is still unread
+#   AND no other reminders have been sent in last 4 hours
+
+# Don't send message if
+#   no new message has been created
+#   OR new message has been created but it's not been at least 4 hours since the last reminder
+#   OR the new message has been read already
+#   OR it was written by the user
+
+# Only ever alert for a message once
+#   set sms_reminder_sent_at time on all messages when the reminder is sent
+
+# If there is more than one new message, only send one SMS reminder.
+
+
+#   context "generate" do
+#     it "sends sms of unread messages if sms_reminder_sent_at is nil" do
+#       subscription_reminder.generate
+#       expect(subscription.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
+#     end
+
+#     it "sends sms of unread messages if sms_reminder_sent_at gap time is more than 4 hours" do
+#       subscription_reminder.generate
+#       expect(subscription1.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
+#     end
+
+#     it "do not sends sms of unread messages if sms_reminder_sent_at gap time is less than 4 hours" do
+#       expect{ subscription_reminder.generate}.to_not change(Subscription.find(subscription2.id), :sms_reminder_sent_at)
+#     end
+#   end

--- a/spec/services/subscriptions_reminder_spec.rb
+++ b/spec/services/subscriptions_reminder_spec.rb
@@ -1,70 +1,83 @@
 require 'rails_helper'
 
 describe SubscriptionsReminder do
-  let(:user)          { create :user }
-  let(:delta)         { SUBSCRIPTION_REMINDER_TIME_DELTA }
-  let(:delta_plus_2)  { delta + 2.hours }
-  let(:delta_minus_2) { delta - 2.hours }
-  let(:time)          { Time.now }
-
-  before(:each){ allow(Time).to receive(:now).and_return(time) }
+  let(:user_with_offer)  { create :user, :with_offer }
+  let(:reviewer)         { create :user, :reviewer }
+  let(:offer)            { user_with_offer.offers.first }
+  let(:delta)            { SUBSCRIPTION_REMINDER_TIME_DELTA }
+  let(:before_delta)     { delta + 2.hours } # a time over '4' hours ago
+  let(:after_delta)      { delta - 2.hours } # a time less than '4' hours ago
 
   subject { SubscriptionsReminder.new }
+  
+  let!(:message) { create(:message, offer: offer, sender: reviewer) }
 
-  context "generate" do
-    context "sends reminder when" do
-      it "new unread message created in last X hours" do
-        subscription = create(:subscription, user: user, state: 'unread')
-        subject.generate
-        expect(subscription.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
-        # TwilioService.new(User.find(user_id)).send_unread_message_reminder(sms_url)
-        expect(TwilioService).to receive(:new)#.with(user).and_return(TwilioService.new(user))
+  context "check spec setup" do
+    it "correctly forms the test conditions" do
+      expect(Subscription.where(user: user_with_offer, offer: offer, message: message, state: 'unread').count).to eql(1)
+      expect(user_with_offer.offers.count).to eql(1)
+      expect(user_with_offer.sms_reminder_sent_at).to eql(nil)
+      expect(Offer.count).to eql(1)
+      expect(Message.count).to eql(1)
+    end
+  end
+
+  context "user_candidates_for_reminder" do
+
+    context "includes user when" do
+      it "there is a new unread message and we last reminded the user over X hours ago " do
+        expect(user_with_offer.subscriptions.unread.first.message.created_at).to be > delta.ago
+        user_with_offer.update_attribute(:sms_reminder_sent_at, before_delta.ago)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([user_with_offer])
       end
-      it "2 new unread message created in last 4 hours only sends one reminder" do
+      it "there is a new unread message, we've never sent a before reminder, and it's now over X hours since they were created" do
+        expect(user_with_offer.subscriptions.unread.first.message.created_at).to be > delta.ago
+        user_with_offer.update_attribute(:created_at, before_delta.ago)
+        user_with_offer.update_attribute(:sms_reminder_sent_at, nil)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([user_with_offer])
+      end
+      it "2 new unread messages created after we last reminded the user - only sends one reminder" do
+        msg2 = create(:message, offer: offer, sender: reviewer)
+        user_with_offer.update_attribute(:sms_reminder_sent_at, before_delta.ago)
+        expect(user_with_offer.subscriptions.unread.size).to eql(2)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([user_with_offer])
+      end
+    end
+
+    context "doesn't include user when" do
+      it "there is a new unread message but we last reminded the user less than X hours ago" do
+        expect(user_with_offer.subscriptions.unread.first.message.created_at).to be > delta.ago
+        user_with_offer.update_attribute(:sms_reminder_sent_at, after_delta.ago)
+        expect(user_with_offer.sms_reminder_sent_at).to be > delta.ago
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
+      end
+      it "there is a new unread message but user signed up less than X hours ago" do
+        expect(user_with_offer.subscriptions.unread.first.message.created_at).to be > delta.ago
+        user_with_offer.update_attribute(:created_at, after_delta.ago)
+        user_with_offer.update_attribute(:sms_reminder_sent_at, nil)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
+      end
+      it "a new message (created since the user was last reminded) has already been read" do
+        user_with_offer.subscriptions.unread.first.update_attribute(:state, 'read')
+        user_with_offer.update_attribute(:sms_reminder_sent_at, before_delta.ago)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
+      end
+      it "the message was sent by the user themselves" do
+        message.update_attribute(:sender_id, user_with_offer.id)
+        user_with_offer.update_attribute(:sms_reminder_sent_at, before_delta.ago)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
+      end
+      it "no new messages created since we last reminded them" do
+        user_with_offer.update_attribute(:sms_reminder_sent_at, before_delta.ago)
+        message.update_attribute(:created_at, (before_delta + 1).ago)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
+      end
+      it "user is not a donor (has no offers)" do
+        Offer.all.each{|offer| offer.update_attribute(:created_by_id, nil) }
+        user_with_offer.update_attribute(:sms_reminder_sent_at, before_delta.ago)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
       end
     end
   end
 
-  context "doesn't send reminder when" do
-    it "other reminders have been sent to same user within 4 hours"
-    it "new message created in last 4 hours has already been read"
-    it "reminder has already been sent for same message"
-    it "it was written by the user themselves"
-  end
-
 end
-
-
-# Send a message if
-#   recipient is donor
-#   unread messages that have arrived since I last got in touch with them
-#   AND it is still unread
-#   AND no other reminders have been sent in last 4 hours
-
-# Don't send message if
-#   no new message has been created
-#   OR new message has been created but it's less than 4 hours since the user last received a reminder
-#   OR the new message has been read already
-#   OR it was sent by the user
-
-# Only ever alert for a message once
-#   set sms_reminder_sent_at time on all messages when the reminder is sent
-
-# If there is more than one new message, only send one SMS reminder.
-
-
-#   context "generate" do
-#     it "sends sms of unread messages if sms_reminder_sent_at is nil" do
-#       subscription_reminder.generate
-#       expect(subscription.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
-#     end
-
-#     it "sends sms of unread messages if sms_reminder_sent_at gap time is more than 4 hours" do
-#       subscription_reminder.generate
-#       expect(subscription1.reload.sms_reminder_sent_at.to_s(:db)).to eq(time.to_s(:db))
-#     end
-
-#     it "do not sends sms of unread messages if sms_reminder_sent_at gap time is less than 4 hours" do
-#       expect{ subscription_reminder.generate}.to_not change(Subscription.find(subscription2.id), :sms_reminder_sent_at)
-#     end
-#   end

--- a/spec/services/subscriptions_reminder_spec.rb
+++ b/spec/services/subscriptions_reminder_spec.rb
@@ -37,15 +37,15 @@ end
 
 # Send a message if
 #   recipient is donor
-#   a NEW message has been created in last 4 hours
+#   unread messages that have arrived since I last got in touch with them
 #   AND it is still unread
 #   AND no other reminders have been sent in last 4 hours
 
 # Don't send message if
 #   no new message has been created
-#   OR new message has been created but it's not been at least 4 hours since the last reminder
+#   OR new message has been created but it's less than 4 hours since the user last received a reminder
 #   OR the new message has been read already
-#   OR it was written by the user
+#   OR it was sent by the user
 
 # Only ever alert for a message once
 #   set sms_reminder_sent_at time on all messages when the reminder is sent


### PR DESCRIPTION
Rewrote the code to conform to the following specifications:

Send 1 reminder if:

- recipient is donor AND
- messages have arrived since we last sent a reminder AND
- at least one message is still unread AND
- no other reminders have been sent to this user in the last 4 hours

Don't send a reminder if:

- no new message has been created since we last sent a reminder OR
- a new message has been created but it's less than 4 hours since the user last received a reminder OR
- the new message has been read already OR
- it was sent by the user

More generally

- Only ever alert for a message once
- If there is more than one new message, only send one SMS reminder.
- For users that have just signed up, don't message them for at least 4 hours