### PR TITLE
beneficiary destroy action added

### DIFF
--- a/app/controllers/api/v1/beneficiaries_controller.rb
+++ b/app/controllers/api/v1/beneficiaries_controller.rb
@@ -56,6 +56,12 @@ module Api
         end
       end
 
+      api :DELETE, '/v1/beneficiary/1', "Delete a beneficiary"
+      def destroy
+        @beneficiary.destroy
+        render json: {}
+      end
+
       def serializer
         Api::V1::BeneficiarySerializer
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -91,7 +91,7 @@ class Ability
     can :create, Beneficiary
     can [:create, :index, :show, :update], Beneficiary, created_by_id: @user_id
     if can_manage_orders? || @api_user
-      can [:create, :index, :show, :update], Beneficiary
+      can [:create, :index, :show, :update, :destroy], Beneficiary
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ Rails.application.routes.draw do
           put :transition
         end
       end
-      resources :beneficiaries, only: [:create, :show, :index, :update]
+      resources :beneficiaries, only: [:create, :show, :index, :update, :destroy]
       resources :order_transports, only: [:create, :show, :index, :update]
       resources :stockit_activities, only: [:create]
       resources :countries, only: [:create]

--- a/spec/controllers/api/v1/beneficiaries_controller_spec.rb
+++ b/spec/controllers/api/v1/beneficiaries_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V1::BeneficiariesController, type: :controller do
       end
 
       it 'returns all beneficiaries' do
-        5.times { FactoryBot.create :beneficiary }        
+        5.times { FactoryBot.create :beneficiary }
         get :index
         expect(parsed_body['beneficiaries'].count).to eq(Beneficiary.count)
       end
@@ -141,6 +141,15 @@ RSpec.describe Api::V1::BeneficiariesController, type: :controller do
       end
     end
 
+  end
+
+  describe "DELETE beneficiaries/1" do
+    before { generate_and_set_token(supervisor) }
+
+    it "returns 200", :show_in_doc do
+      delete :destroy, id: beneficiary.id
+      expect(response.status).to eq(200)
+    end
   end
 
 end


### PR DESCRIPTION
Hi Team, 
This PR is for ticket GCW-2344-Browse - Ensure orders on behalf of a beneficiary have beneficiary data. https://jira.crossroads.org.hk/browse/GCW-2344
I have added delete action to delete orphan 'beneficiary' data along with spec.
Please review the PR and let me know if any change is required.
