### PR TITLE
Added gin trigram indexes for free-text search. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,6 @@ jobs:
           name: Wait for DB and Redis containers to start
           command: dockerize -wait tcp://localhost:5432 -wait tcp://localhost:6379 -timeout 1m
       - run: bundle exec rake db:create:all db:migrate
-      #- run:
-      #  name: Migrate 'timestamp without timezone' to 'timestamp with timezone'
-      #  command: bundle exec rake db:migrate:redo VERSION=20181122111014 RAILS_ENV=test
       - run:
           name: Rspec tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: Wait for DB and Redis containers to start
           command: dockerize -wait tcp://localhost:5432 -wait tcp://localhost:6379 -timeout 1m
-      - run: bundle exec rake db:create:all db:schema:load
+      - run: bundle exec rake db:create:all db:migrate
       #- run:
       #  name: Migrate 'timestamp without timezone' to 'timestamp with timezone'
       #  command: bundle exec rake db:migrate:redo VERSION=20181122111014 RAILS_ENV=test

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -125,18 +125,18 @@ module Api
 
       api :GET, "/v1/packages/search_stockit_items", "Search packages (items for stock app) using inventory-number"
       def search_stockit_items
-        records = {}; pages = 0
+        records = @packages # security
+        records = records.undispatched if params["orderId"].present?
         if params['searchText'].present?
-          records = params["orderId"].present? ? @packages.undispatched : @packages
           records = records.search(
             params['searchText'],
             params['itemId'].presence,
             with_inventory_no: params['withInventoryNumber'] == 'true'
           )
-          # apply selected filters
-          records = apply_filters(records).page(params["page"]).per(params["per_page"])
-          pages = records.total_pages
         end
+        # apply selected filters
+        records = apply_filters(records).page(params["page"]).per(params["per_page"])
+        pages = records.total_pages
         packages = ActiveModel::ArraySerializer.new(records,
           each_serializer: stock_serializer,
           root: "items",

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -67,44 +67,6 @@ class Package < ActiveRecord::Base
 
   attr_accessor :skip_set_relation_update, :request_from_admin
 
-  def self.search(search_text, item_id, options = {})
-    records =
-      if item_id.presence
-        where("item_id = ?", item_id)
-      else
-        state = options[:state]
-        queries = [search_query]
-        queries.push "inventory_number IS NOT NULL" if options[:with_inventory_no]
-        queries.push "state = :state" unless state.blank?
-
-        with_associations.where(
-          queries.map { |q| "(#{q})" }.join(" AND "),
-          search_text: "%#{search_text}%",
-          state: state
-        )
-      end
-    records
-  end
-
-  def self.search_query
-    fields_to_match = [
-      'inventory_number',
-      'designation_name',
-      'notes',
-      'case_number',
-      'locations.building',
-      'locations.area'
-    ]
-    fields_to_match
-      .map { |f| "#{f} ILIKE :search_text" }
-      .join(" OR ")
-  end
-
-  def self.with_associations
-    joins("LEFT OUTER JOIN packages_locations ON packages_locations.package_id = packages.id
-      LEFT OUTER JOIN locations ON locations.id = packages_locations.location_id")
-  end
-
   # Workaround to set initial state for the state_machine
   # StateMachine has Issue with rails 4.2, it does not set initial state by default
   # refer - https://github.com/pluginaweek/state_machine/issues/334

--- a/db/migrate/20190129073952_add_indexes_to_package.rb
+++ b/db/migrate/20190129073952_add_indexes_to_package.rb
@@ -7,9 +7,13 @@ class AddIndexesToPackage < ActiveRecord::Migration
     execute "CREATE INDEX index_packages_on_notes ON packages USING gin (notes gin_trgm_ops)"
     execute "CREATE INDEX index_packages_on_case_number ON packages USING gin (case_number gin_trgm_ops)"
     execute "CREATE INDEX index_packages_on_state ON packages USING gin (state gin_trgm_ops)"
+    add_index :packages, :quantity, name: 'partial_index_quantity_greater_than_zero', where: "quantity > 0"
+    add_index :packages, :allow_web_publish
   end
 
   def down
+    remove_index :packages, :allow_web_publish
+    remove_index :packages, name: "partial_index_quantity_greater_than_zero"
     execute "DROP INDEX index_packages_on_designation_name"
     execute "DROP INDEX index_packages_on_notes"
     execute "DROP INDEX index_packages_on_case_number"

--- a/db/migrate/20190129073952_add_indexes_to_package.rb
+++ b/db/migrate/20190129073952_add_indexes_to_package.rb
@@ -1,0 +1,19 @@
+class AddIndexesToPackage < ActiveRecord::Migration
+
+  def up
+    execute "CREATE EXTENSION IF NOT EXISTS btree_gin;"
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+    execute "CREATE INDEX index_packages_on_designation_name ON packages USING gin (designation_name gin_trgm_ops)"
+    execute "CREATE INDEX index_packages_on_notes ON packages USING gin (notes gin_trgm_ops)"
+    execute "CREATE INDEX index_packages_on_case_number ON packages USING gin (case_number gin_trgm_ops)"
+    execute "CREATE INDEX index_packages_on_state ON packages USING gin (state gin_trgm_ops)"
+  end
+
+  def down
+    execute "DROP INDEX index_packages_on_designation_name"
+    execute "DROP INDEX index_packages_on_notes"
+    execute "DROP INDEX index_packages_on_case_number"
+    execute "DROP INDEX index_packages_on_state"
+  end
+
+end

--- a/db/migrate/20190129081612_add_indexes_on_location.rb
+++ b/db/migrate/20190129081612_add_indexes_on_location.rb
@@ -1,0 +1,15 @@
+class AddIndexesOnLocation < ActiveRecord::Migration
+  def up
+    add_index :locations, :stockit_id
+    execute "CREATE EXTENSION IF NOT EXISTS btree_gin;"
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+    execute "CREATE INDEX index_locations_on_building ON locations USING gin (building gin_trgm_ops)"
+    execute "CREATE INDEX index_locations_on_area ON locations USING gin (area gin_trgm_ops)"
+  end
+
+  def down
+    execute "DROP INDEX index_locations_on_area"
+    execute "DROP INDEX index_locations_on_building"
+    remove_index :locations, :stockit_id
+  end
+end

--- a/db/migrate/20190131083340_add_indexes_to_packages_locations.rb
+++ b/db/migrate/20190131083340_add_indexes_to_packages_locations.rb
@@ -1,0 +1,8 @@
+class AddIndexesToPackagesLocations < ActiveRecord::Migration
+  def change
+    add_index :packages_locations, :reference_to_orders_package
+    add_index :packages_locations, [:package_id, :location_id]#, unique: true
+    remove_index :packages_locations, column: [:location_id, :package_id], name: 'index_packages_locations_on_location_id_and_package_id'
+    add_index :packages_locations, [:location_id, :package_id]#, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -549,6 +549,7 @@ ActiveRecord::Schema.define(version: 20190131083340) do
     t.integer  "received_quantity"
   end
 
+  add_index "packages", ["allow_web_publish"], name: "index_packages_on_allow_web_publish", using: :btree
   add_index "packages", ["box_id"], name: "index_packages_on_box_id", using: :btree
   add_index "packages", ["case_number"], name: "index_packages_on_case_number", using: :gin
   add_index "packages", ["designation_name"], name: "index_packages_on_designation_name", using: :gin
@@ -561,6 +562,7 @@ ActiveRecord::Schema.define(version: 20190131083340) do
   add_index "packages", ["order_id"], name: "index_packages_on_order_id", using: :btree
   add_index "packages", ["package_type_id"], name: "index_packages_on_package_type_id", using: :btree
   add_index "packages", ["pallet_id"], name: "index_packages_on_pallet_id", using: :btree
+  add_index "packages", ["quantity"], name: "partial_index_quantity_greater_than_zero", where: "(quantity > 0)", using: :btree
   add_index "packages", ["set_item_id"], name: "index_packages_on_set_item_id", using: :btree
   add_index "packages", ["state"], name: "index_packages_on_state", using: :gin
   add_index "packages", ["stockit_designated_by_id"], name: "index_packages_on_stockit_designated_by_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190124105020) do
+ActiveRecord::Schema.define(version: 20190131083340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,7 +208,6 @@ ActiveRecord::Schema.define(version: 20190124105020) do
     t.integer  "created_by_id"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.text     "item_specifics"
   end
 
   add_index "goodcity_requests", ["created_by_id"], name: "index_goodcity_requests_on_created_by_id", using: :btree
@@ -275,6 +274,10 @@ ActiveRecord::Schema.define(version: 20190124105020) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "locations", ["area"], name: "index_locations_on_area", using: :gin
+  add_index "locations", ["building"], name: "index_locations_on_building", using: :gin
+  add_index "locations", ["stockit_id"], name: "index_locations_on_stockit_id", using: :btree
 
   create_table "messages", force: :cascade do |t|
     t.text     "body"
@@ -387,8 +390,8 @@ ActiveRecord::Schema.define(version: 20190124105020) do
     t.integer  "address_id"
     t.integer  "district_id"
     t.text     "cancellation_reason"
-    t.integer  "booking_type_id"
     t.integer  "authorised_by_id"
+    t.integer  "booking_type_id"
   end
 
   add_index "orders", ["address_id"], name: "index_orders_on_address_id", using: :btree
@@ -544,19 +547,22 @@ ActiveRecord::Schema.define(version: 20190124105020) do
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
-    t.boolean  "last_allow_web_published"
   end
 
   add_index "packages", ["box_id"], name: "index_packages_on_box_id", using: :btree
+  add_index "packages", ["case_number"], name: "index_packages_on_case_number", using: :gin
+  add_index "packages", ["designation_name"], name: "index_packages_on_designation_name", using: :gin
   add_index "packages", ["donor_condition_id"], name: "index_packages_on_donor_condition_id", using: :btree
   add_index "packages", ["inventory_number"], name: "inventory_numbers_search_idx", using: :gin
   add_index "packages", ["item_id"], name: "index_packages_on_item_id", using: :btree
   add_index "packages", ["location_id"], name: "index_packages_on_location_id", using: :btree
+  add_index "packages", ["notes"], name: "index_packages_on_notes", using: :gin
   add_index "packages", ["offer_id"], name: "index_packages_on_offer_id", using: :btree
   add_index "packages", ["order_id"], name: "index_packages_on_order_id", using: :btree
   add_index "packages", ["package_type_id"], name: "index_packages_on_package_type_id", using: :btree
   add_index "packages", ["pallet_id"], name: "index_packages_on_pallet_id", using: :btree
   add_index "packages", ["set_item_id"], name: "index_packages_on_set_item_id", using: :btree
+  add_index "packages", ["state"], name: "index_packages_on_state", using: :gin
   add_index "packages", ["stockit_designated_by_id"], name: "index_packages_on_stockit_designated_by_id", using: :btree
   add_index "packages", ["stockit_id"], name: "index_packages_on_stockit_id", using: :btree
   add_index "packages", ["stockit_moved_by_id"], name: "index_packages_on_stockit_moved_by_id", using: :btree
@@ -573,7 +579,9 @@ ActiveRecord::Schema.define(version: 20190124105020) do
 
   add_index "packages_locations", ["location_id", "package_id"], name: "index_packages_locations_on_location_id_and_package_id", using: :btree
   add_index "packages_locations", ["location_id"], name: "index_packages_locations_on_location_id", using: :btree
+  add_index "packages_locations", ["package_id", "location_id"], name: "index_packages_locations_on_package_id_and_location_id", using: :btree
   add_index "packages_locations", ["package_id"], name: "index_packages_locations_on_package_id", using: :btree
+  add_index "packages_locations", ["reference_to_orders_package"], name: "index_packages_locations_on_reference_to_orders_package", using: :btree
 
   create_table "pallets", force: :cascade do |t|
     t.string   "pallet_number"

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -500,9 +500,8 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("456")
       expect(subject['items'].length).to eql(3)
-      # 'id ASC' ordering is guaranteed by pagination
-      expect(subject['items'][0]['inventory_number']).to eql("456222")
-      expect(subject['items'][1]['inventory_number']).to eql("456111")
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("456222")
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("456111")
     end
 
     it 'should find items by inventory number (includes quantity items)' do
@@ -514,10 +513,9 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("456")
       expect(subject['items'].length).to eql(3)
-      # 'id ASC' ordering is guaranteed by pagination
-      expect(subject['items'][0]['inventory_number']).to eql("456333")
-      expect(subject['items'][1]['inventory_number']).to eql("456222")
-      expect(subject['items'][2]['inventory_number']).to eql("456111")
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("456333")
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("456222")
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("456111")
     end
 
     it 'should find items by notes' do
@@ -529,8 +527,8 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("UTter")
       expect(subject['items'].length).to eql(2)
-      expect(subject['items'][0]['notes']).to eql("butter")
-      expect(subject['items'][1]['notes']).to eql("butterfly")
+      expect(subject['items'].map{|i| i['notes']}).to include("butter")
+      expect(subject['items'].map{|i| i['notes']}).to include("butterfly")
     end
 
     it 'should find items by case number' do
@@ -542,8 +540,8 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("cas-12")
       expect(subject['items'].length).to eql(2)
-      expect(subject['items'][0]['case_number']).to eql("CAS-123")
-      expect(subject['items'][1]['case_number']).to eql("CAS-124")
+      expect(subject['items'].map{|i| i['case_number']}).to include("CAS-123")
+      expect(subject['items'].map{|i| i['case_number']}).to include("CAS-124")
     end
 
     it 'should find items by designation_name' do
@@ -555,20 +553,8 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("peP")
       expect(subject['items'].length).to eql(2)
-      expect(subject['items'][0]['designation_name']).to eql("pepper")
-      expect(subject['items'][1]['designation_name']).to eql("peppermint")
-    end
-
-    it 'should find items by location' do
-      pkg1 = create :package, received_quantity: 1
-      create :package, received_quantity: 1
-      create :packages_location, location: create(:location, building: 'blue house'), package: pkg1
-      get :search_stockit_items, searchText: 'blue Hou', showQuantityItems: 'true'
-      expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
-      expect(subject['meta']['search']).to eql('blue Hou')
-      expect(subject['items'].length).to eql(1)
-      expect(subject['items'][0]['id']).to eql(pkg1.id)
+      expect(subject['items'].map{|i| i['designation_name']}).to include("pepper")
+      expect(subject['items'].map{|i| i['designation_name']}).to include("peppermint")
     end
 
     it 'should use filters to only find items that have an inventory number and are marked as received' do
@@ -581,7 +567,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql('couch')
       expect(subject['items'].length).to eql(1)
-      expect(subject['items'][0]['inventory_number']).to eql('11111')
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("11111")
     end
 
     it 'should filter out item with published, has_images, and in_stock status' do
@@ -599,7 +585,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql('111')
       expect(subject['items'].length).to eql(1)
-      expect(subject['items'][0]['inventory_number']).to eql('111005')
+      expect(subject['items'].map{|i| i['inventory_number']}).to include("111005")
     end
     
   end

--- a/spec/models/concerns/package_filtering_spec.rb
+++ b/spec/models/concerns/package_filtering_spec.rb
@@ -116,4 +116,60 @@ describe Package do
     #     .to eq(1)
     # end
   end
+
+  context "search" do
+    let(:item_id) { nil }
+    let(:options) { {} }
+    
+    subject { Package.search(search_text, item_id, options) }
+
+    context 'should find items by inventory number' do
+      let!(:pkg1) { create :package, received_quantity: 1, inventory_number: "456222" }
+      let!(:pkg2) { create :package, received_quantity: 1, inventory_number: "111111" }
+      let!(:pkg3) { create :package, received_quantity: 2, inventory_number: "456333" }
+      let(:search_text) { '456' }
+      it do
+        expect(subject.size).to eql(2)
+        expect(subject.to_a).to include(pkg1)
+        expect(subject.to_a).to include(pkg3)
+      end
+    end
+
+    context 'should find items by notes' do
+      let!(:pkg1) { create :package, received_quantity: 1, notes: "butter" }
+      let!(:pkg2) { create :package, received_quantity: 2, notes: "butterfly" }
+      let!(:pkg3) { create :package, received_quantity: 1, notes: "margarine" }
+      let(:search_text) { 'UTter' }
+      it do
+        expect(subject.size).to eql(2)
+        expect(subject.to_a).to include(pkg1)
+        expect(subject.to_a).to include(pkg2)
+      end
+    end
+
+    context 'should find items by notes' do
+      let!(:pkg1) { create :package, received_quantity: 1, case_number: "CAS-123" }
+      let!(:pkg2) { create :package, received_quantity: 2, case_number: "CAS-124" }
+      let!(:pkg3) { create :package, received_quantity: 1, case_number: "CAS-666" }
+      let(:search_text) { 'cas-12' }
+      it do
+        expect(subject.size).to eql(2)
+        expect(subject.to_a).to include(pkg1)
+        expect(subject.to_a).to include(pkg2)
+      end
+    end
+
+    context 'should find items by designation_name' do
+      let!(:pkg1) { create :package, received_quantity: 1, designation_name: "pepper" }
+      let!(:pkg2) { create :package, received_quantity: 2, designation_name: "peppermint" }
+      let!(:pkg3) { create :package, received_quantity: 1, designation_name: "garlic" }
+      let(:search_text) { 'peP' }
+      it do
+        expect(subject.size).to eql(2)
+        expect(subject.to_a).to include(pkg1)
+        expect(subject.to_a).to include(pkg2)
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Queries perform x1000 faster.

Notes:
- this speeds up free text search and the paginiation (COUNT) queries
- we've removed location free text search in order to ensure the query planner always chooses to use indexes
- switching rspec test suite to use `rake db:migrate` instead of `rake db:schema:load` - the migrations contain postgresql specific SQL that isn't captured inside schema.db