### PR TITLE
GCW 2368 remove sms notification for order fulfilment

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -224,9 +224,6 @@ class Order < ActiveRecord::Base
         order.designate_orders_packages
         order.send_new_order_notificationen
         order.send_new_order_confirmed_sms_to_charity
-        # GCW-2368 Remove SMS notification for new orders
-        # Commenting out in case we want to use this in future
-        # order.send_order_placed_sms_to_order_fulfilment_users
       end
     end
   end
@@ -245,12 +242,6 @@ class Order < ActiveRecord::Base
   def send_new_order_confirmed_sms_to_charity
     TwilioService.new(created_by).order_confirmed_sms_to_charity(self)
   end
-
-  # def send_order_placed_sms_to_order_fulfilment_users
-  #   User.order_fulfilment.each do |user|
-  #     TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self)
-  #   end
-  # end
 
   def nullify_columns(*columns)
     columns.map { |column| send("#{column}=", nil) }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -224,7 +224,9 @@ class Order < ActiveRecord::Base
         order.designate_orders_packages
         order.send_new_order_notificationen
         order.send_new_order_confirmed_sms_to_charity
-        order.send_order_placed_sms_to_order_fulfilment_users
+        # GCW-2368 Remove SMS notification for new orders
+        # Commenting out in case we want to use this in future
+        # order.send_order_placed_sms_to_order_fulfilment_users
       end
     end
   end
@@ -244,11 +246,11 @@ class Order < ActiveRecord::Base
     TwilioService.new(created_by).order_confirmed_sms_to_charity(self)
   end
 
-  def send_order_placed_sms_to_order_fulfilment_users
-    User.order_fulfilment.each do |user|
-      TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self)
-    end
-  end
+  # def send_order_placed_sms_to_order_fulfilment_users
+  #   User.order_fulfilment.each do |user|
+  #     TwilioService.new(user).order_submitted_sms_to_order_fulfilment_users(self)
+  #   end
+  # end
 
   def nullify_columns(*columns)
     columns.map { |column| send("#{column}=", nil) }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -642,18 +642,18 @@ RSpec.describe Order, type: :model do
     end
   end
 
-  describe '#send_order_placed_sms_to_order_fulfilment_users' do
-    let(:charity) { create(:user, :charity) }
-    let(:order_1) { create(:order, submitted_by: charity) }
-    let(:order_fulfiment_user_1) { create(:user, :order_fulfilment) }
-    let(:twilio)     { TwilioService.new(order_fulfiment_user_1) }
+  # describe '#send_order_placed_sms_to_order_fulfilment_users' do
+  #   let(:charity) { create(:user, :charity) }
+  #   let(:order_1) { create(:order, submitted_by: charity) }
+  #   let(:order_fulfiment_user_1) { create(:user, :order_fulfilment) }
+  #   let(:twilio)     { TwilioService.new(order_fulfiment_user_1) }
 
-    it "send new order submitted alert sms to order_fulfilment users" do
-      expect(TwilioService).to receive(:new).with(order_fulfiment_user_1).and_return(twilio)
-      expect(twilio).to receive(:order_submitted_sms_to_order_fulfilment_users).with(order_1)
-      order_1.send_order_placed_sms_to_order_fulfilment_users
-    end
-  end
+  #   it "send new order submitted alert sms to order_fulfilment users" do
+  #     expect(TwilioService).to receive(:new).with(order_fulfiment_user_1).and_return(twilio)
+  #     expect(twilio).to receive(:order_submitted_sms_to_order_fulfilment_users).with(order_1)
+  #     order_1.send_order_placed_sms_to_order_fulfilment_users
+  #   end
+  # end
 
   describe 'Order filtering rules' do
     before do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -642,19 +642,6 @@ RSpec.describe Order, type: :model do
     end
   end
 
-  # describe '#send_order_placed_sms_to_order_fulfilment_users' do
-  #   let(:charity) { create(:user, :charity) }
-  #   let(:order_1) { create(:order, submitted_by: charity) }
-  #   let(:order_fulfiment_user_1) { create(:user, :order_fulfilment) }
-  #   let(:twilio)     { TwilioService.new(order_fulfiment_user_1) }
-
-  #   it "send new order submitted alert sms to order_fulfilment users" do
-  #     expect(TwilioService).to receive(:new).with(order_fulfiment_user_1).and_return(twilio)
-  #     expect(twilio).to receive(:order_submitted_sms_to_order_fulfilment_users).with(order_1)
-  #     order_1.send_order_placed_sms_to_order_fulfilment_users
-  #   end
-  # end
-
   describe 'Order filtering rules' do
     before do
       create :order, state: "submitted", description: "A table", submitted_at: Time.now - 25.hours


### PR DESCRIPTION
Hi Team,

This PR removes order sms notification for Order fulfilment users.
Jira ticket:- https://jira.crossroads.org.hk/browse/GCW-2368

Please review.