### PR TITLE
Converted object and object_changes in versions table to JSONB column

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -27,14 +27,27 @@ class Location < ActiveRecord::Base
     where("building || area ILIKE ?", "%#{key}%")
   end
 
+  # For a given user_id, return their 15 most recently used locations
   def self.recently_used(user_id)
-    select("DISTINCT ON (locations.id) locations.id, building, area, versions.created_at AS recently_used_at").
-    joins("INNER JOIN versions ON ((object_changes -> 'location_id' ->> 1) = CAST(locations.id AS TEXT))").
-    joins("INNER JOIN packages_locations ON (packages_locations.id = versions.item_id AND versions.item_type = 'PackagesLocation')").
-    where("versions.event IN (?) AND
-      (object_changes ->> 'location_id') IS NOT NULL AND
-      CAST(whodunnit AS integer) = ? AND
-      (object_changes ->> 'created_at') >= (?)", ['create', 'update'], user_id, 15.days.ago).
-    order("locations.id, recently_used_at DESC").where("building NOT IN (?)", ['Dispatched', 'Multiple'])
+    # the following SQL is carefully crafted to use versions.partial_index_recent_locations
+    # SELECT object_changes -> 'location_id' -> 1
+    # FROM versions
+    # WHERE
+    #   versions.event IN ('create', 'update') AND
+    #   (object_changes ? 'location_id') AND
+    #   whodunnit = '2'
+    # GROUP BY (object_changes -> 'location_id' -> 1)
+    # ORDER BY MAX(created_at) DESC
+    # LIMIT 15
+    location_ids = Version.
+      item_location_changed(user_id).
+      limit(15).
+      map(&:location_id)
+    locations = Location.
+      where(id: location_ids).
+      where("building NOT IN (?)", ['Dispatched', 'Multiple']).
+      inject({}) {|h,v| h[v.id] = v; h}
+    # we want most recently used first so preserve location_ids order
+    location_ids.map{|id| locations[id]}
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -76,6 +76,15 @@ class Version < PaperTrail::Version
     joins("inner join users ON users.id = CAST(versions.whodunnit AS integer)")
   }
 
+  scope :item_location_changed, ->(user_id) {
+    select("object_changes -> 'location_id' -> 1 AS location_id").
+    where(event: ['create', 'update']).
+    where("object_changes ? 'location_id'").
+    where(whodunnit: user_id).
+    group("object_changes -> 'location_id' -> 1").
+    order('MAX(created_at) DESC')
+  }
+
   def to_s
     "id:#{id} #{item_type}##{item_id} #{event}"
   end

--- a/db/migrate/20190201084112_add_indexes_to_versions.rb
+++ b/db/migrate/20190201084112_add_indexes_to_versions.rb
@@ -1,0 +1,22 @@
+class AddIndexesToVersions < ActiveRecord::Migration
+  def change
+    remove_index :versions, column: [:related_id, :related_type], name: 'index_versions_on_related_id_and_related_type'
+    add_index :versions, [:related_type, :related_id]
+    add_index :versions, :event
+    add_index :versions, :created_at
+    add_index :versions, :item_type
+    add_index :versions, :related_type
+    
+    reversible do |dir|
+      dir.up   { change_column :versions, :object, 'jsonb USING CAST(object AS jsonb)' }
+      dir.down { change_column :versions, :object, 'json USING CAST(object AS json)' }
+    end
+
+    reversible do |dir|
+      dir.up   { change_column :versions, :object_changes, 'jsonb USING CAST(object_changes AS jsonb)' }
+      dir.down { change_column :versions, :object_changes, 'json USING CAST(object_changes AS json)' }
+    end
+    
+    add_index :versions, [:created_at, :whodunnit], name: 'partial_index_recent_locations', where: "versions.event IN ('create', 'update') AND (object_changes ? 'location_id')"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190131083340) do
+ActiveRecord::Schema.define(version: 20190201084112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -754,15 +754,20 @@ ActiveRecord::Schema.define(version: 20190131083340) do
     t.integer  "item_id",        null: false
     t.string   "event",          null: false
     t.string   "whodunnit"
-    t.json     "object"
-    t.json     "object_changes"
+    t.jsonb    "object"
+    t.jsonb    "object_changes"
     t.integer  "related_id"
     t.string   "related_type"
     t.datetime "created_at"
   end
 
+  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))", using: :btree
+  add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
+  add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
-  add_index "versions", ["related_id", "related_type"], name: "index_versions_on_related_id_and_related_type", using: :btree
+  add_index "versions", ["item_type"], name: "index_versions_on_item_type", using: :btree
+  add_index "versions", ["related_type", "related_id"], name: "index_versions_on_related_type_and_related_id", using: :btree
+  add_index "versions", ["related_type"], name: "index_versions_on_related_type", using: :btree
   add_index "versions", ["whodunnit"], name: "index_versions_on_whodunnit", using: :btree
 
   add_foreign_key "beneficiaries", "identity_types"

--- a/spec/controllers/api/v1/versions_controller_spec.rb
+++ b/spec/controllers/api/v1/versions_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::VersionsController, type: :controller do
   let(:supervisor_offer) { create :offer, :with_items, items_count: 1, created_by: supervisor }
   let(:offer) { create :offer }
   let!(:version_1) { create :version, event: 'admin_called', item: supervisor_offer, related: supervisor_offer }
-  let!(:version_2) { create :version, :with_item, item: supervisor_offer.items.first, related: offer }
+  let!(:version_2) { create :version, item: supervisor_offer.items.first, related: offer }
 
   subject { JSON.parse(response.body) }
 

--- a/spec/factories/versions.rb
+++ b/spec/factories/versions.rb
@@ -2,10 +2,7 @@ FactoryBot.define do
   factory :version do
     event       { %w(create update).sample }
     whodunnit   {|v| v.association(:user).id }
-
-    trait :with_item do
-      association :item
-    end
+    association :item # required
 
     trait :related_offer do
       related { |v| v.association(:offer)}

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+context Version, type: :model do
+
+  let(:user1) { create :user }
+  let(:user2) { create :user }
+  
+  context "item_location_changed" do
+    it "finds ordered grouped location changes for a particular user" do
+      create :version, whodunnit: user1.id, event: 'update', object_changes: {'location_id': [1,2]}
+      create :version, whodunnit: user1.id, event: 'update', object_changes: {'location_id': [2,3]}
+      create :version, whodunnit: user1.id, event: 'update', object_changes: {'location_id': [2,3]}
+      create :version, whodunnit: user2.id, event: 'update', object_changes: {'location_id': [3,4]}
+      expect(Version.item_location_changed(user1.id).map(&:location_id)).to eql([3,2])
+    end
+  end
+
+end

--- a/spec/serializers/api/v1/version_serializer_spec.rb
+++ b/spec/serializers/api/v1/version_serializer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Api::V1::VersionSerializer do
   let(:object_changes) { {"state"=>["draft", "submitted"]} }
-  let(:version)   { build(:version, :with_item, :related_offer, object_changes: object_changes) }
+  let(:version)   { build(:version, :related_offer, object_changes: object_changes) }
   let(:serializer) { Api::V1::VersionSerializer.new(version).as_json }
   let(:json)       { JSON.parse( serializer.to_json ) }
 


### PR DESCRIPTION
This is the next in a series of API speed improvements.

- JSONB columns (faster and natively indexed)
- Adjusted Location.recently_used method to use new partial index.

Please note, on a versions table with 1.2million rows, this migration can take upwards of 20 seconds.