### PR TITLE
Moved User#channels to Channels#user_channels

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,14 +143,6 @@ class User < ActiveRecord::Base
     TwilioService.new(self).sms_verification_pin(app_name)
   end
 
-  def channels
-    channels = Channel.private(self)
-    channels += Channel.reviewer if reviewer?
-    channels += Channel.supervisor if supervisor?
-    channels += Channel.order_fulfilment if order_fulfilment?
-    channels
-  end
-
   def self.current_user
     RequestStore.store[:current_user]
   end

--- a/app/services/channel.rb
+++ b/app/services/channel.rb
@@ -34,6 +34,7 @@ class Channel
     end
 
     # users - can be array or single instance of user id or user object
+    # TODO change name
     def private(users)
       [users].flatten.map{ |user| "user_#{user.is_a?(User) ? user.id : user}" }
     end
@@ -42,12 +43,19 @@ class Channel
       [channel_name].flatten.any? {|n| n.include?('user_')}
     end
 
+    def user_channels(user)
+      channels = Channel.private(user)
+      channels += reviewer if user.reviewer?
+      channels += supervisor if user.supervisor?
+      channels += order_fulfilment if user.order_fulfilment?
+      channels  
+    end
+
     # Gets the channels for a user and ensures the correct app_name context
     # E.g. user_1_admin, user_1_browse
-    def channels_for_user_with_app_context(current_user, app_name)
-      channels = current_user.channels
-      channels = Channel.add_app_name_suffix(channels, app_name)
-      channels
+    def channels_for_user_with_app_context(user, app_name)
+      channels = user_channels(user)
+      add_app_name_suffix(channels, app_name)
     end
 
     # add the appropriate app_name suffix on the user channels when registering the device

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,32 +194,6 @@ describe User, :type => :model do
     end
   end
 
-  describe "#channels" do
-    describe "should return array of channels" do
-
-      it "for donor" do
-        user = create(:user)
-        expect(user.channels).to eq(["user_#{user.id}"])
-      end
-
-      it "for reviewer" do
-        user = create(:user, :reviewer)
-        expect(user.channels).to match_array(["user_#{user.id}", "reviewer"])
-      end
-
-      it "for supervisor" do
-        user = create(:user, :supervisor)
-        expect(user.channels).to match_array(["user_#{user.id}", "supervisor"])
-      end
-
-      it "for order_fulfilment" do
-        user = create(:user, :order_fulfilment)
-        expect(user.channels).to match_array(["user_#{user.id}", "order_fulfilment"])
-      end
-
-    end
-  end
-
   describe '#user_role_names' do
     it 'returns role names for user' do
       user = create :user, :reviewer

--- a/spec/services/channel_spec.rb
+++ b/spec/services/channel_spec.rb
@@ -120,4 +120,23 @@ describe Channel do
     end
   end
 
+  context "#user_channels" do
+    it "for donor" do
+      user = create(:user)
+      expect(Channel.user_channels(user)).to eq(["user_#{user.id}"])
+    end
+    it "for reviewer" do
+      user = create(:user, :reviewer)
+      expect(Channel.user_channels(user)).to match_array(["user_#{user.id}", "reviewer"])
+    end
+    it "for supervisor" do
+      user = create(:user, :supervisor)
+      expect(Channel.user_channels(user)).to match_array(["user_#{user.id}", "supervisor"])
+    end
+    it "for order_fulfilment" do
+      user = create(:user, :order_fulfilment)
+      expect(Channel.user_channels(user)).to match_array(["user_#{user.id}", "order_fulfilment"])
+    end
+  end
+
 end


### PR DESCRIPTION
This improves separation of concerns as Channel names should live inside Channel and not in the User class.