### PR TITLE
Gcw 2335 notification fixes

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -325,7 +325,7 @@ class Ability
   end
 
   def user_abilities
-    can [:current_user_profile, :current_user_rooms], User
+    can [:current_user_profile], User
     can [:show, :update], User, id: @user_id
     can [:index, :show, :update, :recent_users], User if can_read_or_modify_user?
   end

--- a/app/models/concerns/push_updates.rb
+++ b/app/models/concerns/push_updates.rb
@@ -1,10 +1,11 @@
 #
 # This is the generic Push Update store that sends websocket updates
 #   whenever the following classes are saved:
-#   Address, GogovanOrder, Image, Item, Location, User, Version
-# We will refactor out the following updates which 
-# Offer, Order, Package
-
+#   Offer, Item, Address, GogovanOrder, Image, Location, User, Version
+#
+# Message, Subscription, Delivery have their own push_updates_for_* modules
+# TODO: need to move Order and Package to their own module logic
+#
 module PushUpdates
   extend ActiveSupport::Concern
   include PushUpdatesBase

--- a/app/services/channel.rb
+++ b/app/services/channel.rb
@@ -28,11 +28,15 @@ class Channel
     # Returns the channels a user should tune into given a particular app context
     # E.g. ['user_1_admin']
     #   ['user_1_browse', 'browse']
+    # Also handles case when user is nil and they are on browse app
     def channels_for(user, app_name)
-      channels = [private_channels_for(user, app_name)]
-      channels << REVIEWER_CHANNEL if user.reviewer? and app_name == ADMIN_APP
-      channels << SUPERVISOR_CHANNEL if user.supervisor? and app_name == ADMIN_APP
-      channels << ORDER_FULFILMENT_CHANNEL if user.order_fulfilment? and app_name == STOCK_APP
+      channels = []
+      if user.present?
+        channels += [private_channels_for(user, app_name)]
+        channels << REVIEWER_CHANNEL if user.reviewer? and app_name == ADMIN_APP
+        channels << SUPERVISOR_CHANNEL if user.supervisor? and app_name == ADMIN_APP
+        channels << ORDER_FULFILMENT_CHANNEL if user.order_fulfilment? and app_name == STOCK_APP
+      end
       channels << BROWSE_CHANNEL if app_name == BROWSE_APP
       channels.flatten.compact.uniq
     end

--- a/spec/controllers/api/v1/authentication_controller_spec.rb
+++ b/spec/controllers/api/v1/authentication_controller_spec.rb
@@ -242,8 +242,15 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
         set_browse_app_header
         get :current_user_rooms
       end
-      let(:expected_channels) { ["browse"] }
-      it { expect(parsed_body).to eql(expected_channels) }
+      it { expect(parsed_body).to eql(["browse"]) }
+    end
+
+    context 'stock app with anonymous user' do
+      before do
+        set_stock_app_header
+        get :current_user_rooms
+      end
+      it { expect(parsed_body).to eql([]) }
     end
   end
 

--- a/spec/models/abilities/user_abilities_spec.rb
+++ b/spec/models/abilities/user_abilities_spec.rb
@@ -4,7 +4,7 @@ require 'cancan/matchers'
 describe "User abilities" do
 
   subject(:ability) { Ability.new(user) }
-  let(:all_actions) { [:index, :show, :create, :update, :destroy, :manage, :current_user_profile, :current_user_rooms] }
+  let(:all_actions) { [:index, :show, :create, :update, :destroy, :manage, :current_user_profile] }
 
   context "when Administrator" do
     let(:user)   { create(:user, :administrator) }
@@ -15,7 +15,7 @@ describe "User abilities" do
   context "when Supervisor" do
     let(:user)   { create(:user, :with_can_read_or_modify_user_permission, role_name: 'Supervisor') }
     let(:person) { create :user }
-    let(:can)    { [:index, :show, :update, :current_user_profile, :current_user_rooms] }
+    let(:can)    { [:index, :show, :update, :current_user_profile] }
     let(:cannot) { [:create, :destroy, :manage] }
     it{ can.each do |do_action|
       is_expected.to be_able_to(do_action, person)
@@ -28,7 +28,7 @@ describe "User abilities" do
   context "when Reviewer" do
     let(:user)   { create(:user, :with_can_read_or_modify_user_permission, role_name: 'Reviewer') }
     let(:person) { create :user }
-    let(:can)    { [:index, :show, :update, :current_user_profile, :current_user_rooms] }
+    let(:can)    { [:index, :show, :update, :current_user_profile] }
     let(:cannot) { [:create, :destroy, :manage] }
     it{ can.each do |do_action|
       is_expected.to be_able_to(do_action, person)
@@ -41,7 +41,7 @@ describe "User abilities" do
   context "when Owner" do
     let(:user)   { create :user }
     let(:person) { user }
-    let(:can)    { [:show, :update, :current_user_profile, :current_user_rooms] }
+    let(:can)    { [:show, :update, :current_user_profile] }
     let(:cannot) { [:index, :create, :destroy, :manage] }
     it{ can.each do |do_action|
       is_expected.to be_able_to(do_action, person)
@@ -54,7 +54,7 @@ describe "User abilities" do
   context "when not Owner" do
     let(:user)   { create :user }
     let(:person) { create :user }
-    let(:can)    { [:current_user_profile, :current_user_rooms] }
+    let(:can)    { [:current_user_profile] }
     let(:cannot) { [:show, :update, :index, :create, :destroy, :manage] }
     it{ can.each do |do_action|
       is_expected.to be_able_to(do_action, person)

--- a/spec/models/concerns/message_subscription_spec.rb
+++ b/spec/models/concerns/message_subscription_spec.rb
@@ -45,6 +45,18 @@ context MessageSubscription do
       end
     end
 
+    context "should subscribe all reviewers if donor sends messages but offer has no reviewer" do
+      let!(:reviewer) { create :user, :reviewer }
+      let(:offer) { create :offer }
+      let(:message) { create :message, sender: offer.created_by, offer: offer }
+      it do
+        expect(message.offer.reviewed_by_id).to eql(nil)
+        # expect(message).to receive(:add_subscription).with('read', message.offer.created_by_id)
+        expect(message).to receive(:add_subscription).with('unread', reviewer.id)
+        message.subscribe_users_to_message
+      end
+    end
+
     context "should not subscribe system users" do
       let(:sender) { create :user, :system }
       before(:each) { allow(message).to receive(:sender_id).and_return(sender.id) }
@@ -74,7 +86,7 @@ context MessageSubscription do
         end
       end
 
-      context "should subscribe all supervisors if none are already participating" do
+      context "should subscribe all supervisors" do
         let!(:supervisor) { create :user, :supervisor }
         it do
           expect(message).to receive(:add_subscription).with('read', reviewer.id) # sender

--- a/spec/services/channel_spec.rb
+++ b/spec/services/channel_spec.rb
@@ -33,6 +33,30 @@ describe Channel do
       let(:expected_channels) { ["user_#{user.id}_browse", "browse"] }
       it { expect(subject).to eql(expected_channels) }
     end
+
+    context 'unauthenticated user' do
+    
+      context 'on browse app' do
+        let(:app_name) { BROWSE_APP }
+        let(:user) { nil }
+        it { expect(subject).to eql(["browse"]) }
+      end
+      context 'on admin app' do
+        let(:app_name) { ADMIN_APP }
+        let(:user) { nil }
+        it { expect(subject).to eql([]) }
+      end
+      context 'on donr app' do
+        let(:app_name) { DONOR_APP }
+        let(:user) { nil }
+        it { expect(subject).to eql([]) }
+      end
+      context 'on stock app' do
+        let(:app_name) { STOCK_APP }
+        let(:user) { nil }
+        it { expect(subject).to eql([]) }
+      end
+    end
   
   end
 


### PR DESCRIPTION
Moves Browse channel logic fully into `app/services/channel.rb` and removes any responsibility from the `authentication_controller` to understand channel logic.

This also enables `register_device` to call the same channel logic and fixes a bug where empty channels were being fed to the Notification Service.

Also fixed case where a donor messages on an offer that has no reviewers. No reviewers were being alerted by now all reviewers will receive alerts.