### PR TITLE
Processing checklist

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -170,7 +170,8 @@ module Api
           :address_id,:submitted_by_id, :staff_note,
           purpose_ids: [], cart_package_ids: [],
           beneficiary_attributes: beneficiary_attributes,
-          address_attributes: address_attributes
+          address_attributes: address_attributes,
+          orders_process_checklists_attributes: orders_process_checklists_attributes
         )
       end
 
@@ -180,6 +181,10 @@ module Api
 
       def beneficiary_attributes
         [:identity_type_id, :identity_number, :title, :first_name, :last_name, :phone_number]
+      end
+
+      def orders_process_checklists_attributes
+        [:id, :order_id, :process_checklist_id, :_destroy]
       end
 
       def serializer

--- a/app/controllers/api/v1/process_checklists_controller.rb
+++ b/app/controllers/api/v1/process_checklists_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    class ProcessChecklistsController < Api::V1::ApiController
+      load_and_authorize_resource :process_checklist, parent: false
+
+      resource_description do
+        short 'List Processing checklist items'
+        formats ['json']
+        error 401, "Unauthorized"
+        error 404, "Not Found"
+        error 422, "Validation Error"
+        error 500, "Internal Server Error"
+      end
+
+      api :GET, '/v1/process_checklists', "List all processing checklists options."
+      def index
+        render json: @process_checklists, each_serializer: serializer
+      end
+
+      private
+
+      def serializer
+        Api::V1::ProcessChecklistSerializer
+      end
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -194,6 +194,7 @@ class Ability
     can [:index, :show, :update, :destroy], Order, created_by_id: @user_id
     if can_manage_orders? || @api_user
       can [:create, :index, :show, :update, :transition, :destroy, :summary], Order
+      can :index, ProcessChecklist
     end
   end
 

--- a/app/models/orders_process_checklist.rb
+++ b/app/models/orders_process_checklist.rb
@@ -1,0 +1,4 @@
+class OrdersProcessChecklist < ActiveRecord::Base
+  belongs_to :order, inverse_of: :orders_process_checklists
+  belongs_to :process_checklist
+end

--- a/app/models/process_checklist.rb
+++ b/app/models/process_checklist.rb
@@ -1,0 +1,9 @@
+class ProcessChecklist < ActiveRecord::Base
+  translates :text
+  belongs_to :booking_type
+  has_many :orders
+
+  def self.for_booking_type(bt)
+    where({ booking_type: bt })
+  end
+end

--- a/app/serializers/api/v1/order_process_checklist_serializer.rb
+++ b/app/serializers/api/v1/order_process_checklist_serializer.rb
@@ -1,0 +1,6 @@
+module Api::V1
+  class OrderProcessChecklistSerializer < ApplicationSerializer
+    embed :ids, include: true
+    attributes :id, :order_id, :process_checklist_id
+  end
+end

--- a/app/serializers/api/v1/order_serializer.rb
+++ b/app/serializers/api/v1/order_serializer.rb
@@ -13,6 +13,7 @@ module Api::V1
     has_many :orders_purposes, serializer: OrdersPurposeSerializer
     has_many :goodcity_requests, serializer: GoodcityRequestSerializer
     has_many :messages, serializer: CharityMessageSerializer, root: :messages
+    has_many :orders_process_checklists, serializer: OrderProcessChecklistSerializer
     has_one  :closed_by, serializer: UserSerializer
     has_one  :processed_by, serializer: UserSerializer
     has_one  :cancelled_by, serializer: UserSerializer

--- a/app/serializers/api/v1/process_checklist_serializer.rb
+++ b/app/serializers/api/v1/process_checklist_serializer.rb
@@ -2,5 +2,9 @@ module Api::V1
   class ProcessChecklistSerializer < ApplicationSerializer
     embed :ids, include: true
     attributes :id, :text, :booking_type_id
+
+    def text__sql
+      "text_#{current_language}"
+    end
   end
 end

--- a/app/serializers/api/v1/process_checklist_serializer.rb
+++ b/app/serializers/api/v1/process_checklist_serializer.rb
@@ -1,0 +1,6 @@
+module Api::V1
+  class ProcessChecklistSerializer < ApplicationSerializer
+    embed :ids, include: true
+    attributes :id, :text, :booking_type_id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
       get "timeslots", to: "timeslots#index"
       get "gogovan_transports", to: "gogovan_transports#index"
       get "booking_types", to: "booking_types#index"
+      get "process_checklists", to: "process_checklists#index"
       get "purposes", to: "purposes#index"
       get "crossroads_transports", to: "crossroads_transports#index"
 

--- a/db/migrate/20190222023048_create_process_checklist.rb
+++ b/db/migrate/20190222023048_create_process_checklist.rb
@@ -1,0 +1,14 @@
+class CreateProcessChecklist < ActiveRecord::Migration
+  def change
+    create_table :process_checklists do |t|
+      t.string :text_en
+      t.string :text_zh_tw
+      t.references :booking_type, index: true, foreign_key: true
+    end
+
+    create_table :orders_process_checklists do |t|
+      t.references :order, index: true, foreign_key: true
+      t.references :process_checklist, index: true, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -394,7 +394,6 @@ ActiveRecord::Schema.define(version: 20190222023048) do
     t.integer  "district_id"
     t.integer  "authorised_by_id"
     t.integer  "booking_type_id"
-    t.integer  "authorised_by_id"
     t.string   "staff_note",              default: ""
   end
 
@@ -559,7 +558,6 @@ ActiveRecord::Schema.define(version: 20190222023048) do
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
-    t.boolean  "last_allow_web_published"
   end
 
   add_index "packages", ["allow_web_publish"], name: "index_packages_on_allow_web_publish", using: :btree
@@ -788,7 +786,7 @@ ActiveRecord::Schema.define(version: 20190222023048) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))", using: :btree
+  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))", using: :btree
   add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
   add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
@@ -808,6 +806,6 @@ ActiveRecord::Schema.define(version: 20190222023048) do
   add_foreign_key "organisations", "organisation_types"
   add_foreign_key "organisations_users", "organisations"
   add_foreign_key "organisations_users", "users"
-  add_foreign_key "subscriptions", "orders"
   add_foreign_key "process_checklists", "booking_types"
+  add_foreign_key "subscriptions", "orders"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190218025723) do
+ActiveRecord::Schema.define(version: 20190222023048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -390,8 +390,9 @@ ActiveRecord::Schema.define(version: 20190218025723) do
     t.integer  "people_helped",           default: 0
     t.integer  "beneficiary_id"
     t.integer  "address_id"
-    t.integer  "district_id"
     t.text     "cancellation_reason"
+    t.integer  "district_id"
+    t.integer  "authorised_by_id"
     t.integer  "booking_type_id"
     t.integer  "authorised_by_id"
     t.string   "staff_note",              default: ""
@@ -430,6 +431,14 @@ ActiveRecord::Schema.define(version: 20190218025723) do
   add_index "orders_packages", ["order_id"], name: "index_orders_packages_on_order_id", using: :btree
   add_index "orders_packages", ["package_id"], name: "index_orders_packages_on_package_id", using: :btree
   add_index "orders_packages", ["updated_by_id"], name: "index_orders_packages_on_updated_by_id", using: :btree
+
+  create_table "orders_process_checklists", force: :cascade do |t|
+    t.integer "order_id"
+    t.integer "process_checklist_id"
+  end
+
+  add_index "orders_process_checklists", ["order_id"], name: "index_orders_process_checklists_on_order_id", using: :btree
+  add_index "orders_process_checklists", ["process_checklist_id"], name: "index_orders_process_checklists_on_process_checklist_id", using: :btree
 
   create_table "orders_purposes", force: :cascade do |t|
     t.integer "order_id"
@@ -604,6 +613,14 @@ ActiveRecord::Schema.define(version: 20190218025723) do
     t.datetime "updated_at"
   end
 
+  create_table "process_checklists", force: :cascade do |t|
+    t.string  "text_en"
+    t.string  "text_zh_tw"
+    t.integer "booking_type_id"
+  end
+
+  add_index "process_checklists", ["booking_type_id"], name: "index_process_checklists_on_booking_type_id", using: :btree
+
   create_table "purposes", force: :cascade do |t|
     t.string   "name_en"
     t.string   "name_zh_tw"
@@ -771,7 +788,7 @@ ActiveRecord::Schema.define(version: 20190218025723) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))", using: :btree
+  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))", using: :btree
   add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
   add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
@@ -784,10 +801,13 @@ ActiveRecord::Schema.define(version: 20190218025723) do
   add_foreign_key "goodcity_requests", "orders"
   add_foreign_key "goodcity_requests", "package_types"
   add_foreign_key "messages", "orders"
+  add_foreign_key "orders_process_checklists", "orders"
+  add_foreign_key "orders_process_checklists", "process_checklists"
   add_foreign_key "organisations", "countries"
   add_foreign_key "organisations", "districts"
   add_foreign_key "organisations", "organisation_types"
   add_foreign_key "organisations_users", "organisations"
   add_foreign_key "organisations_users", "users"
   add_foreign_key "subscriptions", "orders"
+  add_foreign_key "process_checklists", "booking_types"
 end

--- a/spec/controllers/api/v1/process_checklists_controller_spec.rb
+++ b/spec/controllers/api/v1/process_checklists_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ProcessChecklistsController, type: :controller do
+  let(:manager) { create(:user_with_token, :with_multiple_roles_and_permissions,
+    roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
+  let(:user) { create(:user_with_token) }
+  let!(:process_checklist) { create(:process_checklist) }
+  let!(:process_checklist2) { create(:process_checklist) }
+  let(:parsed_body) { JSON.parse(response.body) }
+
+  describe "GET process_checklists" do
+
+    describe 'as a user with can_manage_orders ability' do
+      before { generate_and_set_token(manager) }
+
+      it "returns 200", :show_in_doc do
+        get :index
+        expect(response.status).to eq(200)
+      end
+
+      it "returns all the items" do
+        get :index
+        expect(parsed_body['process_checklists'].length).to eq(2)
+        expect(parsed_body['process_checklists'][0]['id']).to eq(process_checklist.id)
+        expect(parsed_body['process_checklists'][1]['id']).to eq(process_checklist2.id)
+      end
+    end
+
+    describe 'as an anonymous user' do
+      it "returns 401", :show_in_doc do
+        get :index
+        expect(response.status).to eq(401)
+      end
+    end
+
+    describe 'as a user without the ability' do
+      before { generate_and_set_token(user) }
+
+      it "returns 403", :show_in_doc do
+        get :index
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/factories/orders_process_checklists.rb
+++ b/spec/factories/orders_process_checklists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :orders_process_checklist do
+    association  :order
+    association  :process_checklist
+  end
+end

--- a/spec/factories/process_checklists.rb
+++ b/spec/factories/process_checklists.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :process_checklist do
+    association :booking_type
+    text_en { FFaker::Lorem.characters(5) }
+    text_zh_tw { FFaker::Lorem.characters(5) }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Order, type: :model do
     it { is_expected.to have_and_belong_to_many(:cart_packages).class_name('Package')}
     it { is_expected.to have_many :orders_packages }
     it { is_expected.to have_many :orders_purposes }
+    it { is_expected.to have_many(:process_checklists).through(:orders_process_checklists) }
     it { is_expected.to have_one :order_transport }
   end
 
@@ -675,6 +676,35 @@ RSpec.describe Order, type: :model do
       expect(Order.count).to eq(6)
       expect(Order.where("description ILIKE '%table%'").count).to eq(3)
       expect(Order.where("description ILIKE '%table%'").filter().count).to eq(3)
+    end
+  end
+
+  describe 'Processing checklist' do
+    let!(:booking_type) { create :booking_type }
+    let!(:booking_type2) { create :booking_type }
+    let!(:checklist_it1) { create :process_checklist, booking_type: booking_type }
+    let!(:checklist_it2) { create :process_checklist, booking_type: booking_type }
+    let!(:checklist_it3) { create :process_checklist, booking_type: booking_type }
+    let!(:checklist_unrequired) { create :process_checklist, booking_type: booking_type2 }
+    let!(:order) { create :order, booking_type: booking_type, state: "processing", description: "", process_checklists: [checklist_it1] }
+
+
+    it 'Should be allowed to transition only if all checklist items have been added to the order' do
+      expect(order.process_checklists.count).to eq(1)
+      expect(order.can_transition).to eq(false) # 1/3
+
+      order.process_checklists.push checklist_it2
+      order.save
+      expect(order.process_checklists.count).to eq(2)
+      expect(order.can_transition).to eq(false) # 2/3
+
+      order.process_checklists.push checklist_it3
+      order.save
+      expect(order.process_checklists.count).to eq(3)
+      expect(order.can_transition).to eq(true) # 3/3, can transition
+
+      create :process_checklist, booking_type: booking_type
+      expect(order.can_transition).to eq(false) # 3/4
     end
   end
 end

--- a/spec/models/process_checklist_spec.rb
+++ b/spec/models/process_checklist_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ProcessChecklist, type: :model do
+
+  describe 'Database Columns' do
+    it { is_expected.to have_db_column(:text_en).of_type(:string) }
+    it { is_expected.to have_db_column(:text_zh_tw).of_type(:string) }
+    it { is_expected.to have_db_column(:booking_type_id).of_type(:integer) }
+  end
+
+end

--- a/spec/serializers/api/v1/order_serializer_spec.rb
+++ b/spec/serializers/api/v1/order_serializer_spec.rb
@@ -6,8 +6,9 @@ describe Api::V1::OrderSerializer do
   let(:district) { create :district }
   let(:stockit_local_order) { create :stockit_local_order }
   let(:stockit_activity) { create :stockit_activity }
+  let(:process_checklist) { create :process_checklist }
   let(:order) { create :order, country: country, detail: stockit_local_order,
-    stockit_activity: stockit_activity, processed_by: user, cancelled_by_id: user.id,
+    stockit_activity: stockit_activity, processed_by: user, cancelled_by_id: user.id, process_checklists: [process_checklist],
     process_completed_by_id: user.id, closed_by_id: user, district: district, staff_note: 'this is a note' }
   let(:serializer) { Api::V1::OrderSerializer.new(order).as_json }
   let(:json)       { JSON.parse( serializer.to_json ) }
@@ -43,6 +44,11 @@ describe Api::V1::OrderSerializer do
     expect(json['order']['closed_at']).to eq(order.closed_at)
     expect(json['order']['district_id']).to eq(order.district_id)
     expect(json['order']['staff_note']).to eq(order.staff_note)
+    expect(json['order']['staff_note']).to eq(order.staff_note)
+    expect(json['order']['orders_process_checklist_ids'].count).to eq(1)
+    order_process_checklist = OrdersProcessChecklist.find(json['order']['orders_process_checklist_ids'][0])
+    expect(order_process_checklist.order_id).to eq(order.id)
+    expect(order_process_checklist.process_checklist_id).to eq(order.process_checklists[0].id)
   end
 
   it 'returns organisation id as gc_organisation_id in json response if stockit_organisation is not assigned' do


### PR DESCRIPTION
There are 2 new tables:

* process_checklists  - This is just a lookup table on the different things to check which we'll configure via a settings page

* orders_process_checklists - This is a join table, if a record exist linking an order to a process_checklist row, that means it was checked. Unchecking something is simply a delete

Note: will probably modify this to forbid transition if the checklist isn't complete (need to check with Matt), there's already a `can_transition` method on the Order for that purpose.