### PR TITLE
Improve performance of search_stockit_items method

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -129,7 +129,7 @@ module Api
         records = records.undispatched if params["orderId"].present?
         records = records.search(search_text: params['searchText'], item_id: params['itemId'],
           with_inventory_no: params['withInventoryNumber'] == 'true') if params['searchText'].present?
-        params_for_filter = ['state', 'location'].inject({}){|h, k| h[k] = params[k] if params[k].present?; h}
+        params_for_filter = ['state', 'location'].each_with_object({}){|k, h| h[k] = params[k] if params[k].present?}
         records = records.filter(params_for_filter)
         records = records.order('id desc').offset(page - 1).limit(per_page)
         packages = ActiveModel::ArraySerializer.new(records,

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -131,7 +131,7 @@ module Api
           with_inventory_no: params['withInventoryNumber'] == 'true') if params['searchText'].present?
         params_for_filter = ['state', 'location'].inject({}){|h, k| h[k] = params[k] if params[k].present?; h}
         records = records.filter(params_for_filter)
-        records = records.order('id desc').offset(page).limit(per_page)
+        records = records.order('id desc').offset(page - 1).limit(per_page)
         packages = ActiveModel::ArraySerializer.new(records,
           each_serializer: stock_serializer,
           root: "items",

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -498,9 +498,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, searchText: "456"
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql("456")
-      expect(subject['items'].length).to eql(3)
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("456222")
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("456111")
+      expect(subject['items'].map{|i| i['inventory_number']}).to match_array(['456222', '456111', '456333'])
     end
 
     it 'should find items by inventory number (includes quantity items)' do
@@ -510,10 +508,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, searchText: "456", showQuantityItems: 'true'
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql("456")
-      expect(subject['items'].length).to eql(3)
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("456333")
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("456222")
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("456111")
+      expect(subject['items'].map{|i| i['inventory_number']}).to match_array(['456222', '456111', '456333'])
     end
 
     it 'should find items by notes' do
@@ -523,9 +518,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, searchText: "UTter", showQuantityItems: 'true'
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql("UTter")
-      expect(subject['items'].length).to eql(2)
-      expect(subject['items'].map{|i| i['notes']}).to include("butter")
-      expect(subject['items'].map{|i| i['notes']}).to include("butterfly")
+      expect(subject['items'].map{|i| i['notes']}).to match_array(['butter', 'butterfly'])
     end
 
     it 'should find items by case number' do
@@ -535,9 +528,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, searchText: "cas-12", showQuantityItems: 'true'
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql("cas-12")
-      expect(subject['items'].length).to eql(2)
-      expect(subject['items'].map{|i| i['case_number']}).to include("CAS-123")
-      expect(subject['items'].map{|i| i['case_number']}).to include("CAS-124")
+      expect(subject['items'].map{|i| i['case_number']}).to match_array(['CAS-123', 'CAS-124'])
     end
 
     it 'should find items by designation_name' do
@@ -547,9 +538,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, searchText: "peP", showQuantityItems: 'true'
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql("peP")
-      expect(subject['items'].length).to eql(2)
-      expect(subject['items'].map{|i| i['designation_name']}).to include("pepper")
-      expect(subject['items'].map{|i| i['designation_name']}).to include("peppermint")
+      expect(subject['items'].map{|i| i['designation_name']}).to match_array(['pepper', 'peppermint'])
     end
 
     it 'should use filters to only find items that have an inventory number and are marked as received' do
@@ -560,8 +549,8 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, searchText: 'couch', showQuantityItems: 'true', state: 'received', withInventoryNumber: 'true'
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql('couch')
-      expect(subject['items'].length).to eql(1)
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("11111")
+      expect(subject['items'].map{|i| i['inventory_number']}).to match_array(['11111'])
+      
     end
 
     it 'should filter out item with published, has_images, and in_stock status' do
@@ -577,8 +566,8 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       get :search_stockit_items, params
       expect(response.status).to eq(200)
       expect(subject['meta']['search']).to eql('111')
-      expect(subject['items'].length).to eql(1)
-      expect(subject['items'].map{|i| i['inventory_number']}).to include("111005")
+      expect(subject['items'].map{|i| i['inventory_number']}).to match_array(['111005'])
+      
     end
     
   end

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -497,7 +497,6 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       create :package, received_quantity: 2, inventory_number: "456333"
       get :search_stockit_items, searchText: "456"
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("456")
       expect(subject['items'].length).to eql(3)
       expect(subject['items'].map{|i| i['inventory_number']}).to include("456222")
@@ -510,7 +509,6 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       create :package, received_quantity: 2, inventory_number: "456111"
       get :search_stockit_items, searchText: "456", showQuantityItems: 'true'
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("456")
       expect(subject['items'].length).to eql(3)
       expect(subject['items'].map{|i| i['inventory_number']}).to include("456333")
@@ -524,7 +522,6 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       create :package, received_quantity: 1, notes: "margarine"
       get :search_stockit_items, searchText: "UTter", showQuantityItems: 'true'
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("UTter")
       expect(subject['items'].length).to eql(2)
       expect(subject['items'].map{|i| i['notes']}).to include("butter")
@@ -537,7 +534,6 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       create :package, received_quantity: 1, case_number: "CAS-666"
       get :search_stockit_items, searchText: "cas-12", showQuantityItems: 'true'
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("cas-12")
       expect(subject['items'].length).to eql(2)
       expect(subject['items'].map{|i| i['case_number']}).to include("CAS-123")
@@ -550,7 +546,6 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       create :package, received_quantity: 1, designation_name: "garlic"
       get :search_stockit_items, searchText: "peP", showQuantityItems: 'true'
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql("peP")
       expect(subject['items'].length).to eql(2)
       expect(subject['items'].map{|i| i['designation_name']}).to include("pepper")
@@ -564,7 +559,6 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       create :package, received_quantity: 1, designation_name: "couch", inventory_number: nil, state: 'missing'
       get :search_stockit_items, searchText: 'couch', showQuantityItems: 'true', state: 'received', withInventoryNumber: 'true'
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql('couch')
       expect(subject['items'].length).to eql(1)
       expect(subject['items'].map{|i| i['inventory_number']}).to include("11111")
@@ -582,11 +576,77 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       }
       get :search_stockit_items, params
       expect(response.status).to eq(200)
-      expect(subject['meta']['total_pages']).to eql(1)
       expect(subject['meta']['search']).to eql('111')
       expect(subject['items'].length).to eql(1)
       expect(subject['items'].map{|i| i['inventory_number']}).to include("111005")
     end
     
   end
+
+  context "page" do
+    subject { controller.page }
+    
+    before(:each) do
+      controller.params[:page] = page
+    end
+    
+    context "1st page" do
+      let(:page) { '1' }
+      it { expect(subject).to eql(1) }
+    end
+
+    context "2nd page" do
+      let(:page) { '2' }
+      it { expect(subject).to eql(2) }
+    end
+
+    context "nil page" do
+      let(:page) { nil }
+      it { expect(subject).to eql(1) }
+    end
+
+    context "blank page" do
+      let(:page) { '' }
+      it { expect(subject).to eql(1) }
+    end
+
+    context "blah page" do
+      let(:page) { 'blah' }
+      it { expect(subject).to eql(1) }
+    end
+  end
+
+  context "per_page" do
+    subject { controller.per_page }
+    
+    before(:each) do
+      controller.params[:per_page] = per_page
+    end
+    
+    context "20 per page" do
+      let(:per_page) { '20' }
+      it { expect(subject).to eql(20) }
+    end
+
+    context "30 per_page (limit is 25)" do
+      let(:per_page) { '30' }
+      it { expect(subject).to eql(25) }
+    end
+
+    context "nil per_page" do
+      let(:per_page) { nil }
+      it { expect(subject).to eql(25) }
+    end
+
+    context "blank per_page" do
+      let(:per_page) { '' }
+      it { expect(subject).to eql(25) }
+    end
+
+    context "blah per_page" do
+      let(:per_page) { 'blah' }
+      it { expect(subject).to eql(25) }
+    end
+  end
+
 end

--- a/spec/models/concerns/package_filtering_spec.rb
+++ b/spec/models/concerns/package_filtering_spec.rb
@@ -1,127 +1,105 @@
 require 'rails_helper'
 
-#testing package_filtering concern
 describe Package do
+  
   # testing dispatched packages
   context 'in_stock packages' do
     before(:each) do
-      create :package, inventory_number: "111000", state: 'received', quantity: 1
-      create :package, inventory_number: "111001", state: 'received', allow_web_publish: true, quantity: 1
-      create :package, inventory_number: "111002", state: 'received', quantity: 0
-      create(:package, :with_images, inventory_number: "111003", state: 'received', quantity: 1)
-      create(:package, :with_images, inventory_number: "111005", allow_web_publish: true, state: 'received', quantity: 1)
+      create(:package, state: 'received', quantity: 1)
+      create(:package, state: 'received', allow_web_publish: true, quantity: 1)
+      create(:package, state: 'received', quantity: 0)
+      create(:package, :with_images, state: 'received', quantity: 1)
+      create(:package, :with_images, allow_web_publish: true, state: 'received', quantity: 1)
     end
 
-    it 'does not filter out anything if no explicit arguments are provided/selected' do
+    subject { Package.filter('state' => state).count }
+
+    it 'does not filter out anything if no explicit arguments are provided' do
       expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter().count).to eq(5)
+      expect(Package.count).to eq(5)
+      expect(Package.filter.count).to eq(5)
     end
 
-    it 'returns in stock items where state is received and quantity > 0' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock']).count).to eq(4)
+    context 'returns in stock items where state is received and quantity > 0' do
+      let(:state) { 'in_stock' }
+      it { expect(subject).to eq(4) }
     end
 
-    it 'returns in_stock items with/without published status' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock', 'published_and_private']).count).to eq(4)
+    context 'returns in_stock items with/without published status' do
+      let(:state) { 'in_stock,published_and_private' }
+      it { expect(subject).to eq(4) }
     end
 
-    it 'returns in stock items with published status' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock', 'published']).count).to eq(2)
+    context 'returns in stock items with published status' do
+      let(:state) { 'in_stock,published' }
+      it { expect(subject).to eq(2) }
     end
 
-    it 'returns in stock items with un-published status' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock', 'private']).count).to eq(2)
+    context 'returns in stock items with un-published status' do
+      let(:state) { 'in_stock,private' }
+      it { expect(subject).to eq(2) }
     end
 
-     it 'returns in_stock items with/without images' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock', 'published_and_private', 'with_and_without_images']).count).to eq(4)
+    context 'returns in_stock items with/without images' do
+      let(:state) { 'in_stock,published_and_private,with_and_without_images' }
+      it { expect(subject).to eq(4) }
     end
 
-    it 'returns in stock items with images' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock', 'published', 'has_images']).count).to eq(1)
+    context 'returns in stock items with images' do
+      let(:state) { 'in_stock,published,has_images' }
+      it { expect(subject).to eq(1) }
     end
 
-    it 'returns in stock items without images' do
-      expect(Package.count).to eq(5)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['in_stock', 'private', 'no_images']).count).to eq(1)
+    context 'returns in stock items without images' do
+      let(:state) { 'in_stock,private,no_images' }
+      it { expect(subject).to eq(1) }
     end
   end
 
-  # testing designated packages
   context 'designated packages' do
     before(:each) do
-      @order_package = create(:orders_package, :with_state_designated, quantity: 1)
-      create(:package, :with_images, inventory_number: "111003", state: 'received', quantity: 1)
-      create(:package, :with_images, inventory_number: "111005", allow_web_publish: true, state: 'received', quantity: 1)
+      create(:orders_package, :with_state_designated, quantity: 1)
+      create(:package, :with_images, state: 'received', quantity: 1)
+      create(:package, :with_images, allow_web_publish: true, state: 'received', quantity: 1)
     end
-
-    it 'does not filter out anything if no explicit arguments are provided/selected' do
-      expect(Package.count).to eq(3)
-      expect(Package.where("inventory_number ILIKE '%111%'").count).to eq(2)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter().count).to eq(2)
-    end
-
     it 'filters out only designated packages' do
-      package_inventory = @order_package.package.update(inventory_number: '111006')
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['designated']).count).to eq(1)
+      expect(Package.filter.count).to eq(3)
+      expect(Package.filter('state' => 'designated').count).to eq(1)
     end
   end
 
-  # testing dispatched packages
   context 'dispatched packages' do
     before(:each) do
-      @order_package = create(:orders_package, :with_state_dispatched, quantity: 1)
-      create(:package, :with_images, inventory_number: "111003", state: 'received', quantity: 1)
-      create(:package, :with_images, inventory_number: "111005", allow_web_publish: true, state: 'received', quantity: 1)
+      create(:orders_package, :with_state_dispatched, quantity: 1)
+      create(:package, :with_images, state: 'received', quantity: 1)
+      create(:package, :with_images, allow_web_publish: true, state: 'received', quantity: 1)
     end
-
-    it 'does not filter out anything if no explicit arguments are provided/selected' do
-      expect(Package.count).to eq(3)
-      expect(Package.where("inventory_number ILIKE '%111%'").count).to eq(2)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter().count).to eq(2)
-    end
-
     it 'filters out only dispatched packages' do
-      package_inventory = @order_package.package.update(inventory_number: '111007')
-      expect(Package.where("inventory_number ILIKE '%111%'").filter(states: ['dispatched']).count).to eq(1)
+      expect(Package.filter.count).to eq(3)
+      expect(Package.filter('state' => 'dispatched').count).to eq(1)
     end
   end
 
   context 'filters based on location' do
     before(:each) do
-      @package_with_location = create(:package, :package_with_locations, inventory_number: "111003", state: 'received', quantity: 1)
-      create(:package, :with_images, inventory_number: "111005", allow_web_publish: true, state: 'received', quantity: 1)
-      create(:package, :with_images, inventory_number: "111006", allow_web_publish: true, state: 'received', quantity: 1)
+      create(:package, :with_images, allow_web_publish: true, state: 'received', quantity: 1)
+      create(:package, :with_images, allow_web_publish: true, state: 'received', quantity: 1)
     end
+    let(:package_with_location) { create(:package, :package_with_locations, state: 'received', quantity: 1) }
 
-    it 'does not filter out anything if no explicit arguments are provided/selected' do
-      expect(Package.count).to eq(3)
-      expect(Package.where("inventory_number ILIKE '%111%'").count).to eq(3)
-      expect(Package.where("inventory_number ILIKE '%111%'").filter().count).to eq(3)
+    it 'filters out item based on location' do
+      pkg_location_name = package_with_location.locations.pluck(:building, :area).first.join('-')
+      expect(Package.filter.count).to eq(3)
+      expect(Package.filter('location' => pkg_location_name).count).to eq(1)
     end
-
-    # it 'filters out item based on location' do
-    #   expect(Package.count).to eq(3)
-    #   pkg_location_name = @package_with_location.locations.pluck(:building, :area).first.join('-')
-    #   expect(Package.where("inventory_number ILIKE '%111%'")
-    #     .filter(states: ['in_stock'], location: pkg_location_name).count)
-    #     .to eq(1)
-    # end
   end
 
   context "search" do
     let(:item_id) { nil }
-    let(:options) { {} }
+    let(:state) { [] }
+    let(:options) { {search_text: search_text, item_id: item_id, state: state} }
     
-    subject { Package.search(search_text, item_id, options) }
+    subject { Package.search(options) }
 
     context 'should find items by inventory number' do
       let!(:pkg1) { create :package, received_quantity: 1, inventory_number: "456222" }


### PR DESCRIPTION
* Removed total_pages from search_stockit_it to improve performance (COUNTS are expensive).

Refactored PackageFiltering methods:
* to remove unneccessary SQL
* fixed a bug in state selections - modules do not like respond_to? methods.
* refactored specs