### PR TITLE
send sms only if to mobile number is present

### DIFF
--- a/app/jobs/twilio_job.rb
+++ b/app/jobs/twilio_job.rb
@@ -3,8 +3,10 @@ class TwilioJob < ActiveJob::Base
 
   # e.g. options = { to: @user.mobile, body: body }
   def perform(options)
-    twilio_conf = Rails.application.secrets.twilio
-    client = Twilio::REST::Client.new(twilio_conf['account_sid'], twilio_conf['auth_token'])
-    client.account.messages.create({ from: twilio_conf['phone_number'] }.merge(options))
+    if options[:to].present?
+      twilio_conf = Rails.application.secrets.twilio
+      client = Twilio::REST::Client.new(twilio_conf['account_sid'], twilio_conf['auth_token'])
+      client.account.messages.create({ from: twilio_conf['phone_number'] }.merge(options))
+    end
   end
 end


### PR DESCRIPTION
Hi Team,

This PR will avoid sending SMS if the user does not have a mobile number. As we are now allowing user creation without mobile number from stock app. If we create any order on behalf of such user then it's not valid to try sending SMS to such user.

Please review.

Thanks. 