### PR TITLE
Gcw 2431 remove permission id from users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,6 @@ class User < ActiveRecord::Base
 
   after_create :generate_auth_token
 
-  scope :donors,      -> { where(permission_id: nil) }
   scope :reviewers,   -> { where(roles: { name: 'Reviewer' }).joins(:roles) }
   scope :supervisors, -> { where(roles: { name: 'Supervisor' }).joins(:roles) }
   scope :order_fulfilment, -> { where(roles: { name: 'Order fulfilment' }).joins(:roles) }

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -3,7 +3,7 @@ module Api::V1
     include SerializeTimeValue
 
     embed :ids, include: true
-    attributes :id, :first_name, :last_name, :permission_id, :mobile, :title,
+    attributes :id, :first_name, :last_name, :mobile, :title,
       :created_at, :last_connected, :last_disconnected, :email, :user_roles_ids, :organisations_users_ids
 
     has_one :image, serializer: ImageSerializer

--- a/db/migrate/20190228150258_remove_permission_id_from_user.rb
+++ b/db/migrate/20190228150258_remove_permission_id_from_user.rb
@@ -1,0 +1,5 @@
+class RemovePermissionIdFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :permission_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190227162128) do
+ActiveRecord::Schema.define(version: 20190228150258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -762,7 +762,6 @@ ActiveRecord::Schema.define(version: 20190227162128) do
     t.string   "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "permission_id"
     t.integer  "image_id"
     t.datetime "last_connected"
     t.datetime "last_disconnected"
@@ -774,7 +773,6 @@ ActiveRecord::Schema.define(version: 20190227162128) do
 
   add_index "users", ["image_id"], name: "index_users_on_image_id", using: :btree
   add_index "users", ["mobile"], name: "index_users_on_mobile", using: :btree
-  add_index "users", ["permission_id"], name: "index_users_on_permission_id", using: :btree
 
   create_table "versions", force: :cascade do |t|
     t.string   "item_type",      null: false


### PR DESCRIPTION
Hi Team,

This PR removes a permission_id column from users and removes related code. We are no longer using permission_id at the user level as we have new role-permissions structure.

Please review.

Thanks.
