### PR TITLE
Offer factory update

### DIFF
--- a/spec/controllers/api/v1/gogovan_orders_controller_spec.rb
+++ b/spec/controllers/api/v1/gogovan_orders_controller_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Api::V1::GogovanOrdersController, type: :controller do
   let(:serialized_order) { Api::V1::GogovanOrderSerializer.new(gogovan_order).as_json }
   let(:serialized_order_json) { JSON.parse(serialized_order.to_json) }
   let(:parsed_body) { JSON.parse(response.body) }
-  let(:offer) { create(:offer, :with_transport) }
-  let(:ggv_order) { create(:gogovan_order, :with_delivery) }
+  let(:offer) { create(:offer, state: 'scheduled', delivery: delivery) }
+  let(:delivery) { create(:gogovan_delivery, gogovan_order: ggv_order)}
+  let(:ggv_order) { create(:gogovan_order) }
   let(:order_attributes) {
     {
       "pickupTime" => "Wed Nov 26 2014 21:30:00 GMT+0530 (IST)",
@@ -48,10 +49,6 @@ RSpec.describe Api::V1::GogovanOrdersController, type: :controller do
     }
   }
 
-  let(:order_details_hash) {
-    Hash[order_details['gogovan_order'].map{|(k,v)| [k.camelize(:lower),v]}]
-  }
-
   describe "POST gogovan_orders/calculate_price" do
     context "donor" do
       before { generate_and_set_token(user) }
@@ -66,8 +63,9 @@ RSpec.describe Api::V1::GogovanOrdersController, type: :controller do
 
   describe "GET gogovan_orders/driver_details" do
     before { generate_and_set_token(user) }
+    let(:ggv_uuid) { offer.delivery.gogovan_order.ggv_uuid }
     it "returns 200" do
-      get :driver_details, id: ggv_order.ggv_uuid
+      get :driver_details, id: ggv_uuid
       expect(response.status).to eq(200)
       expect(parsed_body.keys).to include("gogovan_orders")
     end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -49,6 +49,11 @@ FactoryBot.define do
       end
     end
 
+    trait :accepted do
+      with_received_packages
+      state 'accepted'
+    end
+
     trait :rejected do
       state              'rejected'
       association        :rejection_reason
@@ -61,6 +66,7 @@ FactoryBot.define do
       transient do
         demo_key { generate(:cloudinary_demo_images).keys.sample } # e.g. red_chair
       end
+      state 'accepted'
       donor_description { generate(:cloudinary_demo_images)[demo_key][:donor_description] }
       images            { create_list(:demo_image, rand(3)+1, demo_key.to_sym, favourite: true) }
       packages          { create_list(:package, rand(3)+1, notes: donor_description) }

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -10,49 +10,60 @@ FactoryBot.define do
     parking        { [false, true].sample }
     estimated_size { [1,2,3,4].sample.to_s }
     notes          { FFaker::Lorem.paragraph }
-    created_by     {|m| m.association(:user) }
-    reviewed_by_id nil
-    reviewed_at    nil
-    received_at    nil
-    review_completed_at nil
     saleable       true
+    association    :created_by, factory: :user
 
     trait :submitted do
       submitted_at { Time.now }
       state        'submitted'
     end
 
+    trait :under_review do
+      submitted
+      reviewed_at { Time.now }
+      state       'under_review'
+      association :reviewed_by, :reviewer, factory: :user
+    end
+
+    trait :reviewed do
+      under_review
+      review_completed_at { Time.now }
+      state       'reviewed'
+      association :reviewed_by, :reviewer, factory: :user
+    end
+
+    trait :scheduled do
+      reviewed
+      with_transport
+      state 'scheduled'
+    end
+    
     trait :received do
-      state "received"
+      scheduled
+      start_receiving_at { Time.now }
       received_at { Time.now }
+      association :received_by, :reviewer, factory: :user
+      state "received"
     end
 
     trait :closed do
-      reviewed_at { Time.now }
+      received
+      association :closed_by, :reviewer, factory: :user
       state "closed"
     end
 
     trait :cancelled do
+      reviewed
       cancelled_at { Time.now }
       state "cancelled"
+      association :cancellation_reason
+      cancel_reason "This offer is cancelled because it is not suitable."
     end
 
-    trait :reviewed do
-      reviewed_at { Time.now }
-      state       'reviewed'
-      association :reviewed_by, factory: :user
-      review_completed_at { Time.now }
-
-    end
-
-    trait :under_review do
-      reviewed_at { Time.now }
-      state       'under_review'
-      association :reviewed_by, factory: :user
-    end
-
-    trait :scheduled do
-      state 'scheduled'
+    trait :inactive do
+      submitted
+      inactive_at { Time.now }
+      state "inactive"
     end
 
     trait :with_items do

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -28,21 +28,26 @@ FactoryBot.define do
     trait :reviewed do
       under_review
       review_completed_at { Time.now }
+      with_transport
       state       'reviewed'
-      association :reviewed_by, :reviewer, factory: :user
     end
 
     trait :scheduled do
       reviewed
-      with_transport
+      with_delivery
       state 'scheduled'
+    end
+
+    trait :receiving do
+      scheduled
+      start_receiving_at { Time.now }
+      association :received_by, :reviewer, factory: :user
+      state "receiving"
     end
     
     trait :received do
-      scheduled
-      start_receiving_at { Time.now }
+      receiving
       received_at { Time.now }
-      association :received_by, :reviewer, factory: :user
       state "received"
     end
 
@@ -81,6 +86,15 @@ FactoryBot.define do
       end
       after(:create) do |offer, evaluator|
         evaluator.items_count.times { create :demo_item, offer: offer }
+      end
+    end
+
+    trait :with_delivery do
+      transient do
+        delivery_type { [:crossroads_delivery, :drop_off_delivery].sample }
+      end
+      after(:create) do |offer, evaluator|
+        create evaluator.delivery_type, offer: offer
       end
     end
 


### PR DESCRIPTION
Updated demo factories to correctly form offers.

Offer traits are now cascading and build on each other.
Reviewed_by, closed_by etc are set at the right times.

This ensures `rake demo:load` creates full objects