### PR TITLE
Gcw 2362 remove booking type id from order transports

### DIFF
--- a/app/controllers/api/v1/order_transports_controller.rb
+++ b/app/controllers/api/v1/order_transports_controller.rb
@@ -25,7 +25,7 @@ module Api
         params.require(:order_transport).permit(:order_id, :scheduled_at,
           :timeslot, :transport_type, :contact_id, :gogovan_order_id,
           :need_english, :need_cart, :need_carry, :need_over_6ft,
-          :gogovan_transport_id, :remove_net, :booking_type_id,
+          :gogovan_transport_id, :remove_net, 
           contact_attributes: [:name, :mobile, { address_attributes: [:district_id] }])
       end
 

--- a/app/serializers/api/v1/order_transport_serializer.rb
+++ b/app/serializers/api/v1/order_transport_serializer.rb
@@ -3,7 +3,7 @@ module Api::V1
     embed :ids, include: true
     attributes :id, :order_id, :scheduled_at, :timeslot, :gogovan_transport_id,
       :transport_type, :need_english, :need_cart, :need_carry, :designation_id,
-      :need_over_6ft, :remove_net, :need_over_six_ft, :booking_type_id
+      :need_over_6ft, :remove_net, :need_over_six_ft
 
     has_one :contact, serializer: ContactSerializer
     has_one :gogovan_order, serializer: GogovanOrderSerializer

--- a/db/migrate/20190311144106_remove_booking_type_id_from_order_transport.rb
+++ b/db/migrate/20190311144106_remove_booking_type_id_from_order_transport.rb
@@ -1,0 +1,5 @@
+class RemoveBookingTypeIdFromOrderTransport < ActiveRecord::Migration
+  def change
+    remove_column :order_transports, :booking_type_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190308142745) do
+ActiveRecord::Schema.define(version: 20190311144106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -338,10 +338,8 @@ ActiveRecord::Schema.define(version: 20190308142745) do
     t.boolean  "need_over_6ft",        default: false
     t.integer  "gogovan_transport_id"
     t.string   "remove_net"
-    t.integer  "booking_type_id"
   end
 
-  add_index "order_transports", ["booking_type_id"], name: "index_order_transports_on_booking_type_id", using: :btree
   add_index "order_transports", ["contact_id"], name: "index_order_transports_on_contact_id", using: :btree
   add_index "order_transports", ["gogovan_order_id"], name: "index_order_transports_on_gogovan_order_id", using: :btree
   add_index "order_transports", ["gogovan_transport_id"], name: "index_order_transports_on_gogovan_transport_id", using: :btree

--- a/spec/models/order_transport_spec.rb
+++ b/spec/models/order_transport_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe OrderTransport, type: :model do
     it{ is_expected.to have_db_column(:gogovan_order_id).of_type(:integer)}
     it{ is_expected.to have_db_column(:gogovan_transport_id).of_type(:integer)}
     it{ is_expected.to have_db_column(:order_id).of_type(:integer)}
-    it{ is_expected.to have_db_column(:booking_type_id).of_type(:integer)}
     it{ is_expected.to have_db_column(:created_at).of_type(:datetime)}
     it{ is_expected.to have_db_column(:updated_at).of_type(:datetime)}
     it{ is_expected.to have_db_column(:need_english).of_type(:boolean)}


### PR DESCRIPTION
Hi Team,

This PR removes booking_type_id from OrderTransport table as it is no longer required as we are saving booking_type against order now.

Please review.

Thanks.