### PR TITLE
Added delivery/schedule payload for scheduled offers.

### DIFF
--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -63,7 +63,10 @@ module Api
         @offers = filter_created_by(@offers)
         @offers = @offers.reviewed_by(params["reviewed_by_id"]) if params["reviewed_by_id"].present?
         @offers = (params[:summarize] == 'true') ? @offers.with_summary_eager_load : @offers.with_eager_load
-        render json: ActiveModel::ArraySerializer.new(@offers, each_serializer: select_serializer, include_orders_packages: false, exclude_messages: params["exclude_messages"] == "true", root: 'offers').as_json
+        @options = { each_serializer: select_serializer, include_orders_packages: false,
+          exclude_messages: params["exclude_messages"] == "true", root: 'offers' }
+        @options.merge!(summary: true) if params[:summarize] == 'true'
+        render json: ActiveModel::ArraySerializer.new(@offers, @options).as_json
       end
 
       api :GET, '/v1/offers/1', "List an offer"

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -36,7 +36,9 @@ class Offer < ActiveRecord::Base
   }
 
   scope :with_summary_eager_load, -> {
-    includes([:created_by, :reviewed_by, :received_by, :closed_by, :images])
+    includes([:created_by, :reviewed_by, :received_by, :closed_by, :images,
+      { delivery: [:schedule, :gogovan_order ] }
+    ])
   }
 
   scope :active_from_past_fortnight, -> {

--- a/app/serializers/api/v1/delivery_serializer.rb
+++ b/app/serializers/api/v1/delivery_serializer.rb
@@ -6,5 +6,11 @@ module Api::V1
     has_one :contact, serializer: ContactSerializer
     has_one :schedule, serializer: ScheduleSerializer
     has_one :gogovan_order, serializer: GogovanOrderSerializer
+
+    # include if nil or false.
+    # Used to exclude contacts in OfferSummarySerializer
+    def include_contact?
+      !(@options[:summary] == true)
+    end
   end
 end

--- a/app/serializers/api/v1/offer_summary_serializer.rb
+++ b/app/serializers/api/v1/offer_summary_serializer.rb
@@ -11,9 +11,17 @@ module Api::V1
     has_one  :reviewed_by, serializer: UserSummarySerializer, root: :user
     has_one  :received_by, serializer: UserSummarySerializer, root: :user
     has_one  :display_image, serializer: ImageSerializer, root: :images
+    has_one  :delivery, serializer: DeliverySerializer, root: :delivery
 
     def display_image
       object.images.first
     end
+
+    # For Admin app offer summary, only show 
+    # deliveries and schedules for actively scheduled offers
+    def include_delivery?
+      object.state.include?('scheduled')
+    end
+
   end
 end

--- a/spec/serializers/api/v1/delivery_serializer_spec.rb
+++ b/spec/serializers/api/v1/delivery_serializer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+context Api::V1::DeliverySerializer do
+
+  let(:delivery)   { build(:crossroads_delivery) }
+  let(:serializer) { Api::V1::DeliverySerializer.new(delivery).as_json }
+  let(:json)       { JSON.parse( serializer.to_json ) }
+
+  it "creates JSON" do
+    expect(json['delivery']['id']).to eql(delivery.id)
+    expect(json['delivery']['start']).to eql(delivery.start)
+    expect(json['delivery']['finish']).to eql(delivery.finish)
+    expect(json['delivery']['delivery_type']).to eql(delivery.delivery_type)
+    expect(json['contacts'].first['name']).to eql(delivery.contact.name)
+    expect(json['schedules'].first['slot_name']).to eql(delivery.schedule.slot_name)
+  end
+
+  context "doesn't include contact if summary = true" do
+    let(:serializer) { Api::V1::DeliverySerializer.new(delivery, summary: true).as_json }
+    it { expect(json.keys).to_not include('contacts') }
+  end
+
+end


### PR DESCRIPTION
If an offer is in scheduled state, then include the delivery and schedule information in the summary serializer payload.