### PR TITLE
Live updates for Appointment slots and Packages

### DIFF
--- a/app/controllers/api/v1/appointment_slot_presets_controller.rb
+++ b/app/controllers/api/v1/appointment_slot_presets_controller.rb
@@ -48,7 +48,7 @@ module Api
         if @appointment_slot_preset.update_attributes(appointment_slot_preset_params)
           render json: @appointment_slot_preset, serializer: serializer
         else
-          render json: @appointment_slot_preset.errors, status: 422
+          render json: { errors: @appointment_slot_preset.errors.full_messages }, status: 422
         end
       end
 
@@ -57,6 +57,8 @@ module Api
         @appointment_slot_preset.destroy
         render json: {}
       end
+
+      private
 
       def serializer
         Api::V1::AppointmentSlotPresetSerializer

--- a/app/controllers/api/v1/goodcity_requests_controller.rb
+++ b/app/controllers/api/v1/goodcity_requests_controller.rb
@@ -19,6 +19,14 @@ module Api
         end
       end
 
+      api :GET, '/v1/goodcity_requests', "List goodcity_requests"
+      def index
+        if params[:order_ids]
+          @goodcity_requests = @goodcity_requests.where(order_id: params[:order_ids].split(','))
+        end
+        render json: @goodcity_requests, each_serializer: serializer, status: 200
+      end
+
       api :POST, '/v1/goodcity_requests', "Create goodcity_request"
       param_group :goodcity_request
       def create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::API
   check_authorization
 
   # User.current is required to be set for OffersController.before_filter
-  before_action :set_locale, :current_user
+  before_action :set_locale, :set_device_id, :current_user
   helper_method :current_user
 
 
@@ -20,10 +20,18 @@ class ApplicationController < ActionController::API
     request.headers['X-GOODCITY-APP-SHA']
   end
 
+  def device_id
+    request.headers["X-GOODCITY-DEVICE-ID"]
+  end
+
   private
 
   def set_locale
     I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales) || "en"
+  end
+
+  def set_device_id
+    User.current_device_id = device_id
   end
 
   def current_user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -97,9 +97,12 @@ class Ability
 
   def goodcity_request_abilitites
     can :create, GoodcityRequest if can_create_goodcity_requests?
-    can [:index, :show, :update, :destroy], GoodcityRequest, created_by_id: @user_id
     if can_manage_goodcity_requests?
-      can [:create, :destroy, :update], GoodcityRequest
+      can [:index, :show, :create, :destroy, :update], GoodcityRequest
+    else
+      can [:index, :show, :update, :destroy], GoodcityRequest, GoodcityRequest.of_user(@user_id) do |r|
+        r.created_by_id == @user_id || r.order.created_by_id == @user_id
+      end
     end
   end
 

--- a/app/models/appointment_slot.rb
+++ b/app/models/appointment_slot.rb
@@ -1,7 +1,13 @@
 class AppointmentSlot < ActiveRecord::Base
+  include PushUpdatesMinimal
+
   validates :quota, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :no_duplicate, on: [:create, :update]
   before_save :clean_timestamp
+
+  after_save :push_changes
+  after_destroy :push_changes
+  push_targets [ Channel::STOCK_CHANNEL ]
 
   scope :upcoming, -> { where("timestamp >= ?", DateTime.now.beginning_of_day.utc.to_s(:db)) }
 

--- a/app/models/appointment_slot_preset.rb
+++ b/app/models/appointment_slot_preset.rb
@@ -23,7 +23,7 @@ class AppointmentSlotPreset < ActiveRecord::Base
       .count
 
     if conflicts.positive?
-      errors.add(:base, "An appointment slot already exists for this time")
+      errors.add(:base, I18n.t("appointment_slots.already_exists"))
     end
   end
 end

--- a/app/models/appointment_slot_preset.rb
+++ b/app/models/appointment_slot_preset.rb
@@ -1,8 +1,29 @@
 class AppointmentSlotPreset < ActiveRecord::Base
+  include PushUpdatesMinimal
+
+  validate :no_conflict, on: :update
+
   validates :day, numericality: { only_integer: true, greater_than: 0, less_than: 8  }
   validates :hours, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 24 }
   validates :minutes, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 60 }
   validates :quota, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
   scope :ascending, -> { order('hours ASC').order('minutes ASC') }
+
+  after_save :push_changes
+  after_destroy :push_changes
+  push_targets [ Channel::STOCK_CHANNEL ]
+
+  private
+
+  def no_conflict
+    conflicts = AppointmentSlotPreset
+      .where({ day: self.day, hours: self.hours, minutes: self.minutes })
+      .where.not({ id: self.id })
+      .count
+
+    if conflicts > 0
+      errors.add(:base, "An appointment slot already exists for this time")
+    end
+  end
 end

--- a/app/models/appointment_slot_preset.rb
+++ b/app/models/appointment_slot_preset.rb
@@ -18,11 +18,11 @@ class AppointmentSlotPreset < ActiveRecord::Base
 
   def no_conflict
     conflicts = AppointmentSlotPreset
-      .where({ day: self.day, hours: self.hours, minutes: self.minutes })
+      .where({ day: day, hours: hours, minutes: minutes })
       .where.not({ id: self.id })
       .count
 
-    if conflicts > 0
+    if conflicts.positive?
       errors.add(:base, "An appointment slot already exists for this time")
     end
   end

--- a/app/models/concerns/push_updates_minimal.rb
+++ b/app/models/concerns/push_updates_minimal.rb
@@ -34,7 +34,7 @@ module PushUpdatesMinimal
 
   def serialize(record)
     associations = record.class.reflections.keys.map(&:to_sym)
-    "Api::V1::#{record.class}Serializer".constantize.new(record, { exclude: associations })
+    "Api::V1::#{record.class}Serializer".safe_constantize.new(record, { exclude: associations })
   end
 
   def user

--- a/app/models/concerns/push_updates_minimal.rb
+++ b/app/models/concerns/push_updates_minimal.rb
@@ -1,0 +1,42 @@
+module PushUpdatesMinimal
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_reader :target_channels
+
+    private
+
+    def push_targets(channels = [])
+      @target_channels = channels
+    end
+  end
+
+  def push_changes
+    record = self
+    operation = read_operation record
+    data = { item: serialize(record), sender: user, operation: operation }
+    PushService.new.send_update_store target_channels, data
+  end
+
+  def target_channels
+    self.class.target_channels
+  end
+
+  private
+
+  def serialize(record)
+    associations = record.class.reflections.keys.map(&:to_sym)
+    "Api::V1::#{record.class}Serializer".constantize.new(record, { exclude: associations })
+  end
+
+  def user
+    Api::V1::UserSerializer.new(User.current_user, { user_summary: true })
+  end
+
+  def read_operation(record)
+    if record.destroyed?
+      return :delete
+    end
+    record.id_changed? ? :create : :update
+  end
+end

--- a/app/models/concerns/push_updates_minimal.rb
+++ b/app/models/concerns/push_updates_minimal.rb
@@ -3,11 +3,15 @@ module PushUpdatesMinimal
 
   module ClassMethods
     attr_reader :target_channels
+    attr_reader :target_channels_func
 
     private
 
-    def push_targets(channels = [])
+    def push_targets(channels = [], &block)
       @target_channels = channels
+      if block_given?
+        @target_channels_func = block
+      end
     end
   end
 
@@ -19,6 +23,9 @@ module PushUpdatesMinimal
   end
 
   def target_channels
+    if self.class.target_channels_func
+      return self.class.target_channels_func.call(self)
+    end
     self.class.target_channels
   end
 

--- a/app/models/concerns/push_updates_minimal.rb
+++ b/app/models/concerns/push_updates_minimal.rb
@@ -45,6 +45,6 @@ module PushUpdatesMinimal
     if record.destroyed?
       return :delete
     end
-    record.id_changed? ? :create : :update
+    record.new_record? ? :create : :update
   end
 end

--- a/app/models/concerns/push_updates_minimal.rb
+++ b/app/models/concerns/push_updates_minimal.rb
@@ -16,10 +16,11 @@ module PushUpdatesMinimal
   end
 
   def push_changes
-    record = self
-    operation = read_operation record
-    data = { item: serialize(record), sender: user, operation: operation }
-    PushService.new.send_update_store target_channels, data
+    PushService.new.send_update_store target_channels, {
+      item: serialize(self),
+      sender: user,
+      operation: read_operation(self)
+    }
   end
 
   def target_channels

--- a/app/models/goodcity_request.rb
+++ b/app/models/goodcity_request.rb
@@ -1,7 +1,22 @@
 class GoodcityRequest < ActiveRecord::Base
+  include PushUpdatesMinimal
+
   has_paper_trail class_name: 'Version'
   belongs_to :package_type
   belongs_to :order
   belongs_to :created_by, class_name: 'User'
   validates  :quantity, numericality: { greater_than_or_equal_to: 1 }
+
+  after_save :push_changes
+  after_destroy :push_changes
+  push_targets do |record|
+    [
+      Channel.private_channels_for(record.created_by, BROWSE_APP),
+      Channel::ORDER_CHANNEL
+    ]
+  end
+
+  scope :of_user, ->(uid) {
+    joins(:order).where('goodcity_requests.created_by_id = :id OR orders.created_by_id = :id', id: uid)
+  }
 end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -49,8 +49,6 @@ class Package < ActiveRecord::Base
     chans
   end
 
-  after_touch { update_client_store :update }
-
   validates :package_type_id, :quantity, presence: true
   validates :quantity, numericality: { greater_than_or_equal_to: 0 }
   validates :received_quantity, numericality: { greater_than: 0 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,6 +179,14 @@ class User < ActiveRecord::Base
     RequestStore.store[:current_user] = user
   end
 
+  def self.current_device_id
+    RequestStore.store[:current_device_id]
+  end
+
+  def self.current_device_id=(device_id)
+    RequestStore.store[:current_device_id] = device_id
+  end
+
   def self.system_user
     User.system.order(:id).first
   end

--- a/app/services/channel.rb
+++ b/app/services/channel.rb
@@ -36,6 +36,7 @@ class Channel
         channels << REVIEWER_CHANNEL if user.reviewer? and app_name == ADMIN_APP
         channels << SUPERVISOR_CHANNEL if user.supervisor? and app_name == ADMIN_APP
         channels << ORDER_FULFILMENT_CHANNEL if user.order_fulfilment? and app_name == STOCK_APP
+        channels << STOCK_CHANNEL if app_name == STOCK_APP
       end
       channels << BROWSE_CHANNEL if app_name == BROWSE_APP
       channels.flatten.compact.uniq

--- a/app/services/push_service.rb
+++ b/app/services/push_service.rb
@@ -1,8 +1,9 @@
 class PushService
   def send_update_store(channels, data)
     channels = [channels].flatten.uniq
+    payload = default_payload.merge(data)
     if channels.any?
-      SocketioSendJob.perform_later(channels, "update_store", data.to_json, false)
+      SocketioSendJob.perform_later(channels, "update_store", payload.to_json, false)
     end
   end
 
@@ -14,5 +15,11 @@ class PushService
       SocketioSendJob.perform_later(channels, "notification", data.to_json)
       AzureNotifyJob.perform_later(channels, data, app_name)
     end
+  end
+
+  private
+
+  def default_payload
+    { device_id: User.current_device_id || '' }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,3 +80,5 @@ en:
         blank: "Mobile can't be blank"
     existing_user:
       present: "User already exists in this organisation"
+  appointment_slots:
+    already_exists: "An appointment slot already exists for this time"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -75,3 +75,5 @@ zh-tw:
         blank: "Mobile can't be blank"
     existing_user:
       present: "User already exists in this organisation"
+  appointment_slots:
+    already_exists: "An appointment slot already exists for this time"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
       resources :rejection_reasons, only: [:index, :show]
       resources :cancellation_reasons, only: [:index, :show]
       resources :territories, only: [:index, :show]
-      resources :goodcity_requests, only: [:create, :update, :destroy]
+      resources :goodcity_requests, only: [:index, :create, :update, :destroy]
       resources :donor_conditions, only: [:index, :show]
       resources :users, only: [:index, :show, :update]
       resources :addresses, only: [:create, :show]

--- a/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
       end
 
       it 'returns all preset slots' do
-        5.times { FactoryBot.create :appointment_slot_preset }        
+        5.times { FactoryBot.create :appointment_slot_preset }
         get :index
         expect(parsed_body['appointment_slot_presets'].count).to eq(AppointmentSlotPreset.count)
       end
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
         expect(response.status).to eq(401)
       end
     end
-    
+
     context 'When logged in as a user without can_manage_settings permission' do
       before { generate_and_set_token(no_permission_user) }
        it "denies update of an appointment slot preset" do
@@ -112,6 +112,13 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
         put :update, id: new_preset.id, appointment_slot_preset: { day: 7 }
         expect(response.status).to eq(200)
         expect(parsed_body['appointment_slot_preset']['day']).to eq(7)
+      end
+
+      it "prevents updating a slot with a time that already exists" do
+        p1 = FactoryBot.create(:appointment_slot_preset, hours: 23, minutes: 0, day: 2)
+        p2 = FactoryBot.create(:appointment_slot_preset, hours: 22, minutes: 0, day: 2)
+        put :update, id: p2.id, appointment_slot_preset: { hours: p1.hours }
+        expect(response.status).to eq(422)
       end
     end
   end

--- a/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
         p1 = FactoryBot.create(:appointment_slot_preset, hours: 23, minutes: 0, day: 2)
         p2 = FactoryBot.create(:appointment_slot_preset, hours: 22, minutes: 0, day: 2)
         put :update, id: p2.id, appointment_slot_preset: { hours: p1.hours }
+        expect(parsed_body['errors']).to eq(["An appointment slot already exists for this time"])
         expect(response.status).to eq(422)
       end
     end

--- a/spec/controllers/api/v1/authentication_controller_spec.rb
+++ b/spec/controllers/api/v1/authentication_controller_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
         set_stock_app_header
         get :current_user_rooms
       end
-      let(:expected_channels) { ["user_#{order_fulfilment.id}_stock", 'order_fulfilment'] }
+      let(:expected_channels) { ["user_#{order_fulfilment.id}_stock", 'order_fulfilment', 'stock'] }
       it { expect(parsed_body).to eql(expected_channels) }
     end
 

--- a/spec/controllers/api/v1/goodcity_requests_contoller_spec.rb
+++ b/spec/controllers/api/v1/goodcity_requests_contoller_spec.rb
@@ -3,9 +3,68 @@ require 'rails_helper'
 RSpec.describe Api::V1::GoodcityRequestsController, type: :controller do
 
   let(:user)  { create(:user, :with_can_manage_goodcity_requests_permission, role_name: 'Supervisor') }
+  let(:charity_user) { create :user, :charity }
   let(:goodcity_request) { create(:goodcity_request) }
   let(:goodcity_request_params) { FactoryBot.attributes_for(:goodcity_request) }
   let(:parsed_body) { JSON.parse(response.body ) }
+  let(:requests_fetched) do
+    parsed_body['goodcity_requests'].map {|r| GoodcityRequest.find(r['id']) }
+  end
+
+  describe "GET goodicty_request" do
+
+    before do
+      generate_and_set_token(user)
+    end
+
+    it "returns 200" do
+      get :index
+      expect(response.status).to eq(200)
+    end
+
+    it "supports filtering requests by order id" do
+      (1..3).each { |i| create :order, id: i }
+      (1..3).each { |i| create :goodcity_request, order: Order.find(i) }
+      get :index, order_ids: '1,2'
+      expect(requests_fetched.length).to eq(2)
+      requests_fetched.each do |r|
+        expect(r.order_id).to be_in([1,2])
+      end
+    end
+
+    context "As a charity user" do
+
+      let(:order) { create :order, created_by: charity_user }
+      let(:anonymous_order) { create :order }
+
+      before do
+        generate_and_set_token(charity_user)
+      end
+
+      it "returns the goodcity requests created by the current user" do
+        create :goodcity_request
+        create :goodcity_request, created_by: charity_user
+        create :goodcity_request, created_by: charity_user
+        get :index
+        expect(requests_fetched.length).to eq(2)
+        requests_fetched.each do |r|
+          expect(r.created_by_id).to eq(charity_user.id)
+        end
+      end
+
+      it "also returns the goodcity requests of the user's orders" do
+        o = create :order, created_by: charity_user
+        create :goodcity_request
+        create :goodcity_request, order: o
+        create :goodcity_request, order: o
+        get :index
+        expect(requests_fetched.length).to eq(2)
+        requests_fetched.each do |r|
+          expect(r.order.created_by_id).to eq(charity_user.id)
+        end
+      end
+    end
+  end
 
   describe "POST goodcity_request/1" do
     before { generate_and_set_token(user) }

--- a/spec/factories/packages.rb
+++ b/spec/factories/packages.rb
@@ -25,8 +25,10 @@ FactoryBot.define do
 
     trait :package_with_locations do
       after(:create) do |package|
-        package_location = create :packages_location, package: package, quantity: package.received_quantity
+        package_location = create :packages_location, package_id: package.id, quantity: package.received_quantity
         package.location_id = package_location.location_id
+        package.packages_locations ||= []
+        package.packages_locations << package_location
         package.save
       end
     end
@@ -53,6 +55,11 @@ FactoryBot.define do
     trait :published do
       with_inventory_number
       allow_web_publish true
+    end
+
+    trait :unpublished do
+      with_inventory_number
+      allow_web_publish false
     end
 
     trait :with_images do

--- a/spec/models/appointment_slot_preset_spec.rb
+++ b/spec/models/appointment_slot_preset_spec.rb
@@ -8,5 +8,29 @@ RSpec.describe AppointmentSlotPreset, type: :model do
     it { is_expected.to have_db_column(:minutes).of_type(:integer) }
     it { is_expected.to have_db_column(:quota).of_type(:integer) }
   end
-  
+
+  describe 'Live updates' do
+    let(:push_service) { PushService.new }
+    let!(:appointment_slot_preset) { create(:appointment_slot_preset, hours: 1) }
+
+    before(:each) do
+      allow(PushService).to receive(:new).and_return(push_service)
+    end
+
+    it "should call push_changes upon change" do
+      expect(appointment_slot_preset).to receive(:push_changes)
+      appointment_slot_preset.hours = 2
+      appointment_slot_preset.save
+    end
+
+
+    it "should only send changes to the stock channel" do
+      expect(push_service).to receive(:send_update_store) do |channels, data|
+        expect(channels.length).to eq(1)
+        expect(channels).to include(Channel::STOCK_CHANNEL)
+      end
+      appointment_slot_preset.hours = 2
+      appointment_slot_preset.save
+    end
+  end
 end

--- a/spec/models/appointment_slot_spec.rb
+++ b/spec/models/appointment_slot_spec.rb
@@ -7,5 +7,28 @@ RSpec.describe AppointmentSlot, type: :model do
     it { is_expected.to have_db_column(:quota).of_type(:integer) }
     it { is_expected.to have_db_column(:note).of_type(:string) }
   end
-  
+
+  describe 'Live updates' do
+    let(:push_service) { PushService.new }
+    let!(:appointment_slot) { create(:appointment_slot, timestamp: Time.now) }
+
+    before(:each) do
+      allow(PushService).to receive(:new).and_return(push_service)
+    end
+
+    it "should call push_changes upon change" do
+      expect(appointment_slot).to receive(:push_changes)
+      appointment_slot.timestamp = Time.now + 1.day
+      appointment_slot.save
+    end
+
+    it "should only send changes to the Stock channel" do
+      expect(push_service).to receive(:send_update_store) do |channels, data|
+        expect(channels.length).to eq(1)
+        expect(channels).to include(Channel::STOCK_CHANNEL)
+      end
+      appointment_slot.timestamp = Time.now + 1.day
+      appointment_slot.save
+    end
+  end
 end

--- a/spec/models/order_transport_spec.rb
+++ b/spec/models/order_transport_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe OrderTransport, type: :model do
 
     it "should send changes to the browse app of the social worker" do
       expect(push_service).to receive(:send_update_store) do |channels, data|
-        expect(channels).to include(user_browse_channel)
+        expect(channels.flatten).to include(user_browse_channel)
       end
       order_transport.scheduled_at = Time.now + 10.days
       order_transport.save

--- a/spec/models/order_transport_spec.rb
+++ b/spec/models/order_transport_spec.rb
@@ -53,4 +53,49 @@ RSpec.describe OrderTransport, type: :model do
 
   end
 
+  describe "Live updates" do
+    let!(:push_service) { PushService.new }
+    let!(:user) { create :user }
+    let!(:order) { create :order, created_by: user }
+    let!(:order_transport) { create :order_transport, order: order }
+    let(:user_browse_channel) { "user_#{user.id}_browse" }
+
+    before(:each) do
+      allow(PushService).to receive(:new).and_return(push_service)
+    end
+
+    it "should call push_changes upon change" do
+      expect(order_transport).to receive(:push_changes)
+      order_transport.scheduled_at = Time.now + 10.days
+      order_transport.save
+    end
+
+    it "should send changes to the browse app of the social worker" do
+      expect(push_service).to receive(:send_update_store) do |channels, data|
+        expect(channels).to include(user_browse_channel)
+      end
+      order_transport.scheduled_at = Time.now + 10.days
+      order_transport.save
+    end
+
+    it "should not send changes to any other browse user" do
+      expect(push_service).to receive(:send_update_store) do |channels, data|
+        channels -= [ user_browse_channel]
+        channels.each do |c|
+          expect(c).not_to include('browse')
+        end
+      end
+      order_transport.scheduled_at = Time.now + 10.days
+      order_transport.save
+    end
+
+    it "should send changes to the stock app via the ORDER_CHANNEL" do
+      expect(push_service).to receive(:send_update_store) do |channels, data|
+        expect(channels.length).to eq(2)
+        expect(channels).to include(Channel::ORDER_CHANNEL)
+      end
+      order_transport.scheduled_at = Time.now + 10.days
+      order_transport.save
+    end
+  end
 end

--- a/spec/services/channel_spec.rb
+++ b/spec/services/channel_spec.rb
@@ -23,7 +23,7 @@ describe Channel do
     context 'order_fulfilment on stock app' do
       let(:app_name) { STOCK_APP }
       let(:user) { create :user, :order_fulfilment }
-      let(:expected_channels) { ["user_#{user.id}_stock", 'order_fulfilment'] }
+      let(:expected_channels) { ["user_#{user.id}_stock", 'order_fulfilment', 'stock'] }
       it { expect(subject).to eql(expected_channels) }
     end
 

--- a/spec/services/push_service_spec.rb
+++ b/spec/services/push_service_spec.rb
@@ -5,12 +5,16 @@ describe PushService do
   let(:service) { PushService.new }
   let(:channels) { ['user_1'] }
   let(:admin_channel) { 'user_1_admin' }
-  let(:data)    { {message: message} }
+  let(:device_id) { '123' }
+  let(:data)    { {device_id: device_id, message: message} }
   let(:message) { "New message" }
   let(:time)     { Time.now }
 
 
-  before { allow(Time).to receive(:now).and_return(time) }
+  before do
+    User.current_device_id = device_id
+    allow(Time).to receive(:now).and_return(time)
+  end
 
   context "send_update_store" do
     context "should send updates" do


### PR DESCRIPTION
This pull request adds live updates to : 
- appointment slots
- appointment slot presets
- packages 

### Changes

#### Prevent appointment preset duplicates

Modifying the time of a preset will be rejected if that time is alredy used in a different preset

#### New push class

You'll notice I created a push class named `PushUpdatesMinimal` 
It's meant to be a much simpler version of the existing push updates, the idea is that it is a _configurable concern_ , instead of having one concern per model

Currently the only thing configurable is the channels we broadcast to.
Hopefully it'll grow to one day be robust enough to replace some of the current push update classes which are growing in complexity.

Notes:  
- The name of the class might change, I just needed to make the distinction with the current PushUpdate
- Any architectural suggestions are most welcome.

How to use :

```
class MyModel < ActiveRecord::Base
  include PushUpdatesMinimal

  after_save :push_changes # trigger callback here ...
  after_destroy :push_changes # ... and here. The concern will detect what kind of operation took place
  push_targets [ Channel::STOCK_CHANNEL ] # Here we set the target channels to send to
end
```

For more advanced cases :

```
class MyOtherModel < ActiveRecord::Base
  include PushUpdatesMinimal

  after_save :push_changes
  after_destroy :push_changes
  push_targets do |record| 
      chans  = [ Channel::STOCK_CHANNEL ]
      chans << 'foo' if record.bar
      chans
  end
end
```

#### Device ID

You'll also notice the addition of the **X-GOODCITY-DEVICE-ID** header.
We'll need to send that from the application side (already added to stock)

