### PR TITLE
GCW-2511 sorted orders

### DIFF
--- a/app/models/concerns/order_filtering.rb
+++ b/app/models/concerns/order_filtering.rb
@@ -7,15 +7,6 @@ module OrderFiltering
   end
 
   module ClassMethods
-    def priority
-      join_order_transports.where <<-SQL
-        (state = 'submitted' AND submitted_at::timestamptz <= timestamptz '#{one_day_ago}') OR
-        (state = 'processing' AND processed_at::timestamptz < timestamptz '#{last_6pm}') OR
-        (state = 'awaiting_dispatch' AND order_transports.scheduled_at::timestamptz < timestamptz '#{Time.zone.now}') OR
-        (state = 'dispatching' AND dispatch_started_at::timestamptz < timestamptz '#{last_6pm}')
-      SQL
-    end
-
     #
     # Returns orders filtered using the following options :
     #   - states[] A list of string matching the 'state' column of the order
@@ -37,11 +28,32 @@ module OrderFiltering
     #
     def filter(states: [], types: [], priority: false)
       res = where(nil)
+      res = res.join_order_transports
       res = res.where("state IN (?)", states) unless states.empty?
       res = res.where_types(types) unless types.empty?
       res = res.priority if priority.present?
-      res.distinct
+      res = res.order_by_urgency if (states & Order::ACTIVE_STATES).present?
+      res
     end
+
+    def priority
+      where <<-SQL
+        (state = 'submitted' AND submitted_at::timestamptz <= timestamptz '#{one_day_ago}') OR
+        (state = 'processing' AND processed_at::timestamptz < timestamptz '#{last_6pm}') OR
+        (state = 'awaiting_dispatch' AND order_transports.scheduled_at::timestamptz < timestamptz '#{Time.zone.now}') OR
+        (state = 'dispatching' AND dispatch_started_at::timestamptz < timestamptz '#{last_6pm}')
+      SQL
+    end
+
+    def join_order_transports
+      joins("LEFT OUTER JOIN order_transports ON order_transports.order_id = orders.id")
+    end
+
+    def order_by_urgency
+      order('order_transports.scheduled_at ASC')
+    end
+
+    # TYPES
 
     def where_types(types)
       types = types.select { |t| respond_to?("#{t}_sql") }
@@ -51,14 +63,8 @@ module OrderFiltering
         method = "#{t}_sql"
         "(#{send(method)})"
       end
-      join_order_transports.where(queries.compact.join(" OR "))
+      where(queries.compact.join(" OR "))
     end
-
-    def join_order_transports
-      joins("LEFT OUTER JOIN order_transports ON order_transports.order_id = orders.id")
-    end
-
-    # TYPES
 
     def appointment_sql
       "orders.booking_type_id = #{BookingType.appointment.id}"

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -49,6 +49,8 @@ class Order < ActiveRecord::Base
 
   INACTIVE_STATES = ['cancelled', 'closed', 'draft'].freeze
 
+  ACTIVE_STATES = ['submitted', 'processing', 'awaiting_dispatch', 'dispatching'].freeze
+
   MY_ORDERS_AUTHORISED_STATES = ['submitted', 'closed', 'cancelled', 'processing', 'awaiting_dispatch', 'dispatching'].freeze
 
   scope :non_draft_orders, -> { where.not("state = 'draft' AND detail_type = 'GoodCity'") }


### PR DESCRIPTION
This PR adds sorting to orders search

The sorting **only** applies when searching for orders in active states.
This is will eventually be replaced by additional UI Filters to control sorting, but the staff here is finding it difficult to find urgent orders so we're adding that small workaround for now.