### PR TITLE
Rename of package_images to images

### DIFF
--- a/app/serializers/api/v1/package_serializer.rb
+++ b/app/serializers/api/v1/package_serializer.rb
@@ -3,7 +3,7 @@ module Api::V1
     embed :ids, include: true
 
     has_one :package_type, serializer: PackageTypeSerializer
-    has_many :images, serializer: ImageSerializer, root: :package_images
+    has_many :images, serializer: ImageSerializer
     has_many :packages_locations, serializer: PackagesLocationSerializer
     has_many :orders_packages, serializer: OrdersPackageSerializer
 


### PR DESCRIPTION
The name `package_images` was causing images not to be found on browse. Changing it for consistency