### PR TITLE
Add allow_web_publish to package serializer

### DIFF
--- a/app/serializers/api/v1/package_serializer.rb
+++ b/app/serializers/api/v1/package_serializer.rb
@@ -10,7 +10,8 @@ module Api::V1
     attributes :id, :quantity, :length, :width, :height, :notes,
       :item_id, :state, :received_at, :rejected_at, :inventory_number,
       :created_at, :updated_at, :package_type_id, :designation_id, :sent_on,
-      :offer_id, :designation_name, :grade, :donor_condition_id, :received_quantity
+      :offer_id, :designation_name, :grade, :donor_condition_id, :received_quantity,
+      :allow_web_publish
 
     def designation_id
       object.order_id


### PR DESCRIPTION
Since browse is now starting to use the standard package serializer, I'm adding some props that seem to be missing