### PR TITLE
Batch loading of organisations and users

### DIFF
--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -39,7 +39,11 @@ module Api::V1
     end
 
     def find_record_and_render_json(serializer)
-      records = @organisations.search(params["searchText"]).limit(25)
+      if params['ids'].present?
+        records = @organisations.where(id: params['ids'])
+      else
+        records = @organisations.search(params["searchText"]).limit(25)
+      end
       data = ActiveModel::ArraySerializer.new(records, each_serializer: serializer, root: "gc_organisations").as_json
       render json: { "meta": { "search": params["searchText"] } }.merge(data)
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       api :GET, '/v1/users', "List all users"
-      param :ids, Array, of: Integer, desc: "Filter by user ids e.g. ids = [1,2,3,4]"
+      param :ids, Array, desc: "Filter by user ids e.g. ids = [1,2,3,4]"
       description <<-EOS
         Note: in accordance with permissions, users will only be able to list users they are allowed to see.
         For a donor, this will be just themselves. For administrators, this will be all users.
@@ -21,7 +21,7 @@ module Api
       def index
         return search_user_and_render_json if params[:searchText].present?
         @users = @users.except_stockit_user
-        @users = @users.find(params[:ids].split(",")) if params[:ids].present?
+        @users = @users.find(ids_param) if ids_param.present?
         render json: @users, each_serializer: serializer
       end
 
@@ -67,6 +67,13 @@ module Api
         attributes = [:last_connected, :last_disconnected]
         attributes.concat([:user_role_ids]) if User.current_user.supervisor?
         params.require(:user).permit(attributes)
+      end
+
+      def ids_param
+        ids = params[:ids]
+        return nil if ids.nil?
+        return ids.split(',') if ids.is_a?(String)
+        ids.map(&:to_i)
       end
     end
   end

--- a/app/serializers/api/v1/organisation_serializer.rb
+++ b/app/serializers/api/v1/organisation_serializer.rb
@@ -7,6 +7,5 @@ module Api::V1
       :updated_at
 
     has_many :organisations_users, serializer: OrganisationsUserSerializer
-    has_many :orders, serializer: OrderSerializer, root: :designations
   end
 end

--- a/spec/controllers/api/v1/gc_organisations_controller_spec.rb
+++ b/spec/controllers/api/v1/gc_organisations_controller_spec.rb
@@ -48,6 +48,31 @@ RSpec.describe Api::V1::GcOrganisationsController, type: :controller do
       expect(parsed_body['gc_organisations'].first['name_en']).to eql(organisation.name_en)
       expect(parsed_body['gc_organisations'].first['name_zh_tw']).to eql(organisation.name_zh_tw)
     end
+
+    it "returns serialized organisations from an ID list" do
+      create_list(:organisation, 2)
+      more_organisations = create_list(:organisation, 3)
+      ids =  more_organisations.map(&:id)
+
+      get :index, ids: ids
+      expect(parsed_body['gc_organisations'].length ).to eq(ids.length)
+
+      received_ids = parsed_body['gc_organisations'].map { |o| o["id"] }
+      expect(received_ids).to eq(ids)
+    end
+
+    it "returns serialized organisations names an ID list" do
+      create_list(:organisation, 2)
+      more_organisations = create_list(:organisation, 3)
+      ids =  more_organisations.map(&:id)
+      names =  more_organisations.map(&:name_en)
+
+      get :index, ids: ids
+      expect(parsed_body['gc_organisations'].length ).to eq(ids.length)
+
+      received_names = parsed_body['gc_organisations'].map { |o| o["name_en"] }
+      expect(received_names).to eq(names)
+    end
   end
 
   describe "GET GC Organisation" do


### PR DESCRIPTION
As I was looking for performance issues with @steveyken  I found the following : 

- `OrganisationSerializer` included the `orders` association, which in turn created a **huge** payload
- The Stock app was fetching `organisations` one by one on the orders search page
- The Stock app was fetching `users` one by one on the orders search page

This PR applies the following fixes : 

- Remove the `orders` association from `OrganisationSerializer` , it's extremely heavy and is very unlikely to be needed
- Allow batch loading of `organisations` with `GET /organisations?ids[]=1&ids[]=2`
- Fix existing batch loading of `users`, there was a small String vs Integer type issue. Also the code was doing a `.split(,)` which is not necessary in the case of an array. So it handles both cases now