### PR TITLE
Improvements to speed up offer searches in admin app.

### DIFF
--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -72,7 +72,7 @@ module Api
       def search
         @offers = @offers.search(search_text: params['searchText'])
         @offers = @offers.order('created_at desc').limit(25)
-        render json: @offers, each_serializer: summary_serializer, summarize: true
+        render json: @offers.with_summary_eager_load.to_a, each_serializer: summary_serializer, summarize: true
       end
 
       api :GET, '/v1/offers/1', "List an offer"

--- a/app/models/concerns/offer_search.rb
+++ b/app/models/concerns/offer_search.rb
@@ -16,8 +16,10 @@ module OfferSearch
       if search_text.present?
         search_query = ['offers.notes', 'users.first_name', 'users.last_name',
            'users.email', 'users.mobile', 'items.donor_description',
-           'messages.body', 'package_types.name_en', 'package_types.name_zh_tw',
-           'gogovan_orders.driver_name', 'gogovan_orders.driver_mobile', 'gogovan_orders.driver_license'].
+           'messages.body', 
+           'package_types.name_en', 'package_types.name_zh_tw',
+           'gogovan_orders.driver_name', 'gogovan_orders.driver_mobile', 'gogovan_orders.driver_license'
+          ].
           map { |f| "#{f} ILIKE :search_text" }.
           join(" OR ")
         where(search_query, search_text: "%#{search_text}%")
@@ -37,3 +39,4 @@ module OfferSearch
 
   end
 end
+          

--- a/app/serializers/api/v1/offer_summary_serializer.rb
+++ b/app/serializers/api/v1/offer_summary_serializer.rb
@@ -16,7 +16,7 @@ module Api::V1
     has_one  :delivery, serializer: DeliverySerializer, root: :delivery
 
     def display_image_cloudinary_id
-      object.images.first.id
+      object.images.first.try(:cloudinary_id)
     end
 
     def display_image_cloudinary_id__sql

--- a/db/migrate/20190424063033_add_indexes_to_package_types.rb
+++ b/db/migrate/20190424063033_add_indexes_to_package_types.rb
@@ -1,0 +1,19 @@
+class AddIndexesToPackageTypes < ActiveRecord::Migration
+
+  def up
+    add_index :package_types, :allow_requests
+    add_index :package_types, :stockit_id
+    add_index :package_types, :visible_in_selects
+    execute "CREATE INDEX package_types_name_en_search_idx ON package_types USING gin (name_en gin_trgm_ops);"
+    execute "CREATE INDEX package_types_name_zh_tw_search_idx ON package_types USING gin (name_zh_tw gin_trgm_ops);"
+  end
+
+  def down
+    execute "DROP INDEX package_types_name_zh_tw_search_idx;"
+    execute "DROP INDEX package_types_name_en_search_idx;"
+    remove_index :package_types, :visible_in_selects
+    remove_index :package_types, :stockit_id
+    remove_index :package_types, :allow_requests
+  end
+
+end

--- a/db/migrate/20190424064348_add_body_index_on_messages.rb
+++ b/db/migrate/20190424064348_add_body_index_on_messages.rb
@@ -1,0 +1,9 @@
+class AddBodyIndexOnMessages < ActiveRecord::Migration
+  def up
+    execute "CREATE INDEX messages_body_search_idx ON messages USING gin (body gin_trgm_ops);"
+  end
+
+  def down
+    execute "DROP INDEX messages_body_search_idx;"
+  end
+end

--- a/db/migrate/20190424080441_add_notes_index_to_offers.rb
+++ b/db/migrate/20190424080441_add_notes_index_to_offers.rb
@@ -1,0 +1,9 @@
+class AddNotesIndexToOffers < ActiveRecord::Migration
+  def up
+    execute "CREATE INDEX offers_notes_search_idx ON offers USING gin (notes gin_trgm_ops);"
+  end
+
+  def down
+    execute "DROP INDEX offers_notes_search_idx;"
+  end
+end


### PR DESCRIPTION
Changes:

- Switches from `postgres_ext_serializers` to `summary_serializer` (PES was struggling with the 4 levels of  joins in the search query.)
- Added GIN indexes to improve ILIKE query speed
- Use eager_loading to grab all associated data in one query (per association)