### PR TITLE
Remove unread messages count from serializers

### DIFF
--- a/app/serializers/api/v1/order_serializer.rb
+++ b/app/serializers/api/v1/order_serializer.rb
@@ -1,6 +1,6 @@
 module Api::V1
   class OrderSerializer < OrderShallowSerializer
-    attributes :item_ids, :cancellation_reason, :unread_messages_count
+    attributes :item_ids, :cancellation_reason
     has_one :created_by, serializer: UserProfileSerializer, root: :user
     has_one :stockit_contact, serializer: StockitContactSerializer
     has_one :stockit_organisation, serializer: StockitOrganisationSerializer, root: :organisation

--- a/app/serializers/api/v1/order_shallow_serializer.rb
+++ b/app/serializers/api/v1/order_shallow_serializer.rb
@@ -7,15 +7,7 @@ module Api::V1
       :gc_organisation_id, :processed_at, :processed_by_id, :cancelled_at, :cancelled_by_id,
       :process_completed_at, :process_completed_by_id, :closed_at, :closed_by_id, :dispatch_started_at,
       :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped, :beneficiary_id,
-      :address_id, :district_id, :booking_type_id, :staff_note, :unread_messages_count
-
-    def unread_messages_count
-      object.subscriptions.where(state: 'unread', user_id: object.created_by_id).count
-    end
-
-    def unread_messages_count__sql
-      "(select count(*) from subscriptions s where s.order_id = orders.id and s.state = 'unread' and s.user_id = orders.created_by_id)"
-    end
+      :address_id, :district_id, :booking_type_id, :staff_note
 
     def local_order_id
       (object.detail_type == "LocalOrder" || object.detail_type == "StockitLocalOrder") ? object.detail_id : nil


### PR DESCRIPTION
This PR removes the unread_messages_count attribute from order serialisers as its not required. 
Its calculated on the ember side.
Thanks 