### PR TITLE
fix coming back to account details page and clicking on continue thro…

### DIFF
--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -40,7 +40,7 @@ module Api
       end
 
       def update
-        builder = OrganisationsUserBuilder.new(params["organisations_user"].to_hash).update
+        builder = OrganisationsUserBuilder.new(params["organisations_user"].to_hash).update(app_name)
         if builder["result"]
           save_and_render_object_with_errors(builder["organisations_user"])
         else

--- a/lib/classes/organisations_user_builder.rb
+++ b/lib/classes/organisations_user_builder.rb
@@ -50,7 +50,8 @@ class OrganisationsUserBuilder
     @user.request_from_browse = (app_name == BROWSE_APP)
   end
 
-  def update
+  def update(app_name)
+    assign_user_app_acessor(app_name)
     return fail_with_error(update_user["errors"]) if update_user && update_user["errors"]
     @organisations_user.update(position: @position, preferred_contact_number: @preferred_contact_number)
     return_success.merge!("organisations_user" => @organisations_user.reload)

--- a/spec/lib/classes/organisations_user_builder_spec.rb
+++ b/spec/lib/classes/organisations_user_builder_spec.rb
@@ -111,12 +111,12 @@ describe OrganisationsUserBuilder do
 
   context "update" do
     it "updates existing organisations user position" do
-      update_organisations_user_builder.update
+      update_organisations_user_builder.update('browse.goodcity')
       expect(OrganisationsUser.first.position).to eq(update_organisations_user_params[:position])
     end
 
     it "updates user details belonging to organisation" do
-      update_organisations_user_builder.update
+      update_organisations_user_builder.update('browse.goodcity')
       expect(OrganisationsUser.first.user.last_name).to eq(update_user_attributes[:last_name])
     end
   end


### PR DESCRIPTION
Hi Team, 

This PR fixes issue:

If the browsers back button is used to return to the 'Account Details page' and the user attempts to select the 'Continue' button, the 'Mobile is invalid Mobile can't be blank' error message appears. 

This fix we need to push to live and this whole class has a scope of refactoring which I am doing in another branch.

Please review.

Thanks.