### PR TITLE
added condition to check offer only messages and messages send to don…

### DIFF
--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -28,7 +28,7 @@ class SubscriptionsReminder
         .where("COALESCE(users.sms_reminder_sent_at, users.created_at) < (?)", delta.iso8601)
         .where('subscriptions.state': 'unread')
         .where("messages.created_at > COALESCE(users.sms_reminder_sent_at, users.created_at)")
-        .where("messages.offer_id IS NOT NULL OR messages.item_id IS NOT NULL and messages.order_id IS NULL")
+        .where("(messages.offer_id IS NOT NULL OR messages.item_id IS NOT NULL) and messages.order_id IS NULL")
         .where("offers.created_by_id = users.id")
         .where('messages.sender_id != users.id')
         .distinct

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -9,23 +9,29 @@ class SubscriptionsReminder
 
   private
 
-  # Users who 
+  # Users who
   #   haven't been reminded in last X hours
   #   have unread messages
   #   are donors with active offers
   #   aren't the author of the message
+  #   its not a private messages
+  #   its not order related messages
+  #   are donors with other roles such as reviewer will receive sms on offers where they are acting as \
+  #   donor
   # If sms_reminder_sent_at is NULL then use created_at so we don't SMS user immediately
   def user_candidates_for_reminder
     states = ['submitted', 'under_review', 'reviewed', 'scheduled', 'received',
       'receiving', 'inactive'] # NOT draft, closed or cancelled
     user_ids = Offer.where(state: states).distinct.pluck(:created_by_id)
-    User.joins(subscriptions: [:message]).
-      where('users.id IN (?)', user_ids).
-      where("COALESCE(users.sms_reminder_sent_at, users.created_at) < (?)", delta.iso8601).
-      where('subscriptions.state': 'unread').
-      where("messages.created_at > COALESCE(users.sms_reminder_sent_at, users.created_at)").
-      where('messages.sender_id != users.id').
-      distinct
+    User.joins(subscriptions: [:message, :offer])
+        .where('users.id IN (?)', user_ids)
+        .where("COALESCE(users.sms_reminder_sent_at, users.created_at) < (?)", delta.iso8601)
+        .where('subscriptions.state': 'unread')
+        .where("messages.created_at > COALESCE(users.sms_reminder_sent_at, users.created_at)")
+        .where("messages.offer_id IS NOT NULL OR messages.item_id IS NOT NULL and messages.order_id IS NULL")
+        .where("offers.created_by_id = users.id")
+        .where('messages.sender_id != users.id')
+        .distinct
   end
 
   def send_sms_reminder(user)

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -37,12 +37,21 @@ class SubscriptionsReminder
   def send_sms_reminder(user)
     sms_url = "#{Rails.application.secrets.base_urls['app']}/offers"
     TwilioService.new(user).send_unread_message_reminder(sms_url)
+    send_slack_sms(sms_url) if Rails.env.staging?
     Rails.logger.info("SMS reminder sent to user #{user.id}")
+  end
+
+  def send_slack_sms(sms_url)
+    message = "SlackSMS ('id: #{user.id} full_name: #{user.full_name}') #{unread_message_reminder(sms_url)}"
+    SlackMessageJob.perform_later(message, ENV["SLACK_PIN_CHANNEL"])
+  end
+
+  def unread_message_reminder(url)
+    I18n.t('twilio.unread_message_sms', url: url)
   end
 
   # E.g. 4.hours.ago
   def delta
     SUBSCRIPTION_REMINDER_TIME_DELTA.ago
   end
-
 end


### PR DESCRIPTION
Hi Team,

Additional changes to Send SMS reminder considering 
- No private messages.
- Offers only messages.
-  Donor having other roles will be notified for offers created by him. (i.e donor only offers.)

Please review.

Thanks.

