### PR TITLE
FIX=> orders_packages added in orders response for browse app

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -59,7 +59,7 @@ module Api
           serializer: serializer,
           root: root,
           exclude_code_details: true,
-          include_packages: bool_param(:include_packages, true),
+          include_packages: bool_param(:include_packages, false),
           include_order: false,
           include_territory: true,
           include_images: true,

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       goodcity_requests { create_list :goodcity_request, 1}
     end
 
+    trait :with_orders_purposes do
+      orders_purposes { create_list :orders_purpose, 2}
+    end
+
     trait :with_stockit_id do
       sequence(:stockit_id) { |n| n }
     end


### PR DESCRIPTION
Hi Team,
This PR is for adding orders_packages in response of orders `show` action along with associated specs. Specs has been added considering both `STOCK` and `BROWSE` app.
Please review the PR and let me know if any change is required.