### PR TITLE
fix azure notifications with fcm

### DIFF
--- a/app/services/azure_notifications_service.rb
+++ b/app/services/azure_notifications_service.rb
@@ -39,6 +39,7 @@ class AzureNotificationsService
 
   def encoded_url(platform, handle)
     case platform
+    when "gcm" then URI::encode("GcmRegistrationId eq '#{handle}'")
     when "fcm" then URI::encode("GcmRegistrationId eq '#{handle}'")
     when "aps" then URI::encode("DeviceToken eq '#{handle.upcase}'")
     when "wns" then URI::encode("ChannelUri eq '#{handle}'")
@@ -49,7 +50,8 @@ class AzureNotificationsService
     # platform
     # https://msdn.microsoft.com/en-us/library/azure/dn223265.aspx
     case platform
-    when "fcm" then fcm_platform_xml(handle, tags)
+    when "fcm" then gcm_platform_xml(handle, tags)
+    when "gcm" then gcm_platform_xml(handle, tags)
     when "aps" then aps_platform_xml(handle, tags)
     when "wns" then wns_platform_xml(handle, tags)
     else ""
@@ -70,7 +72,7 @@ class AzureNotificationsService
     data
   end
 
-  def fcm_platform_xml(handle, tags)
+  def gcm_platform_xml(handle, tags)
     template = "{\"data\":{\"title\":\"#{notification_title}\", \"message\":\"$(message)\", \"notId\": \"$(notId)\", \"style\":\"inbox\", \"summaryText\":\"There are %n% notifications.\", #{payload} } }"
 
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>

--- a/app/services/azure_notifications_service.rb
+++ b/app/services/azure_notifications_service.rb
@@ -49,7 +49,7 @@ class AzureNotificationsService
     # platform
     # https://msdn.microsoft.com/en-us/library/azure/dn223265.aspx
     case platform
-    when "fcm" then gcm_platform_xml(handle, tags)
+    when "fcm" then fcm_platform_xml(handle, tags)
     when "aps" then aps_platform_xml(handle, tags)
     when "wns" then wns_platform_xml(handle, tags)
     else ""
@@ -70,7 +70,7 @@ class AzureNotificationsService
     data
   end
 
-  def gcm_platform_xml(handle, tags)
+  def fcm_platform_xml(handle, tags)
     template = "{\"data\":{\"title\":\"#{notification_title}\", \"message\":\"$(message)\", \"notId\": \"$(notId)\", \"style\":\"inbox\", \"summaryText\":\"There are %n% notifications.\", #{payload} } }"
 
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>

--- a/app/services/azure_notifications_service.rb
+++ b/app/services/azure_notifications_service.rb
@@ -39,7 +39,7 @@ class AzureNotificationsService
 
   def encoded_url(platform, handle)
     case platform
-    when "gcm" then URI::encode("GcmRegistrationId eq '#{handle}'")
+    when "fcm" then URI::encode("GcmRegistrationId eq '#{handle}'")
     when "aps" then URI::encode("DeviceToken eq '#{handle.upcase}'")
     when "wns" then URI::encode("ChannelUri eq '#{handle}'")
     end
@@ -49,7 +49,7 @@ class AzureNotificationsService
     # platform
     # https://msdn.microsoft.com/en-us/library/azure/dn223265.aspx
     case platform
-    when "gcm" then gcm_platform_xml(handle, tags)
+    when "fcm" then gcm_platform_xml(handle, tags)
     when "aps" then aps_platform_xml(handle, tags)
     when "wns" then wns_platform_xml(handle, tags)
     else ""
@@ -74,7 +74,7 @@ class AzureNotificationsService
     template = "{\"data\":{\"title\":\"#{notification_title}\", \"message\":\"$(message)\", \"notId\": \"$(notId)\", \"style\":\"inbox\", \"summaryText\":\"There are %n% notifications.\", #{payload} } }"
 
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-    <entry xmlns=\"http://www.w3.org/2005/Atom\">
+    <entry xmlns=\"http://www.w3.org/2005/Atom\"> 
       <content type=\"application/xml\">
         <GcmTemplateRegistrationDescription xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">
           <Tags>#{tags.join(',')}</Tags>


### PR DESCRIPTION
Hi Team,

This PR contains changes to make azure notifications compatible with fcm. Even if they have migrated to fcm tags are still gcm.

Consider doc: https://firebase.google.com/docs/cloud-messaging/send-message

Please review.

Thanks.

