### PR TITLE
GCW- 2421- Add total request count to order's contact summary

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class UsersController < Api::V1::ApiController
       load_and_authorize_resource :user, parent: false
+      skip_load_resource :user, :only => [:orders_count]
 
       resource_description do
         short 'List Users'
@@ -47,6 +48,10 @@ module Api
       def recent_users
         @users = User.recent_orders_created_for(User.current_user.id)
         render json: @users, each_serializer: serializer
+      end
+
+      def orders_count
+        render json: Order.counts_for(params[:id])
       end
 
       private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -332,7 +332,7 @@ class Ability
   def user_abilities
     can [:current_user_profile], User
     can [:show, :update], User, id: @user_id
-    can [:index, :show, :update, :recent_users], User if can_read_or_modify_user?
+    can [:index, :show, :update, :recent_users, :orders_count], User if can_read_or_modify_user?
   end
 
   def version_abilities

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -331,8 +331,8 @@ class Ability
 
   def user_abilities
     can [:current_user_profile], User
-    can [:show, :update], User, id: @user_id
-    can [:index, :show, :update, :recent_users, :orders_count], User if can_read_or_modify_user?
+    can [:show, :update, :orders_count], User, id: @user_id
+    can [:index, :show, :update, :recent_users], User if can_read_or_modify_user?
   end
 
   def version_abilities

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -96,6 +96,10 @@ class Order < ActiveRecord::Base
     ORDER_UNPROCESSED_STATES.include?(state)
   end
 
+  def self.counts_for(created_by_id)
+    group(:state).where(created_by_id: created_by_id).count
+  end
+
   def delete_orders_packages
     if self.orders_packages.exists?
       orders_packages.map(&:destroy)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -97,8 +97,7 @@ class Order < ActiveRecord::Base
   end
 
   def self.counts_for(created_by_id)
-    order_state_counts = group(:state).where(created_by_id: created_by_id).count
-    order_state_counts.except("draft")
+    where.not(state: 'draft').group(:state).where(created_by_id: created_by_id).count
   end
 
   def delete_orders_packages

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -97,7 +97,8 @@ class Order < ActiveRecord::Base
   end
 
   def self.counts_for(created_by_id)
-    group(:state).where(created_by_id: created_by_id).count
+    order_state_counts = group(:state).where(created_by_id: created_by_id).count
+    order_state_counts.except("draft")
   end
 
   def delete_orders_packages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,11 @@ Rails.application.routes.draw do
       resources :territories, only: [:index, :show]
       resources :goodcity_requests, only: [:index, :create, :update, :destroy]
       resources :donor_conditions, only: [:index, :show]
-      resources :users, only: [:index, :show, :update]
+      resources :users, only: [:index, :show, :update] do
+        member do
+          get :orders_count
+        end
+      end
       resources :addresses, only: [:create, :show]
       resources :contacts, only: [:create]
       resources :versions, only: [:index, :show]

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -3,6 +3,8 @@ require "rspec/mocks/standalone"
 
 RSpec.describe Order, type: :model do
   ALL_ORDER_STATES = ["draft", "submitted", "processing", "awaiting_dispatch", "dispatching", "cancelled", "closed"]
+  TOTAL_REQUESTS_STATES = ["submitted", "awaiting_dispatch", "closed", "cancelled"].freeze
+
   let(:user) { create :user }
 
   before {
@@ -75,6 +77,34 @@ RSpec.describe Order, type: :model do
     it{ is_expected.to have_db_column(:address_id).of_type(:integer)}
     it{ is_expected.to have_db_column(:booking_type_id).of_type(:integer)}
     it{ is_expected.to have_db_column(:staff_note).of_type(:string)}
+  end
+
+  describe '.counts_for' do
+    let(:user) { create :user }
+    let(:user1) { create :user }
+    TOTAL_REQUESTS_STATES.each do |state|
+      let!(:"#{state}_order_user") { create :order, :with_orders_packages, :"with_state_#{state}", created_by_id: user.id, status: nil }
+    end
+
+    it "will return submitted order for the user" do
+      expect(Order.counts_for(user.id)["submitted"]).to eq(1)
+    end
+
+    it "will return awaiting_dispatch order for the user" do
+      expect(Order.counts_for(user.id)["awaiting_dispatch"]).to eq(1)
+    end
+
+    it "will return closed order for the user" do
+      expect(Order.counts_for(user.id)["closed"]).to eq(1)
+    end
+
+    it "will return cancelled order for the user" do
+      expect(Order.counts_for(user.id)["cancelled"]).to eq(1)
+    end
+
+    it "will not return orders count of other user" do
+      expect(Order.counts_for(user1.id)).to eq({})
+    end
   end
 
   describe '.my_orders' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -3,7 +3,7 @@ require "rspec/mocks/standalone"
 
 RSpec.describe Order, type: :model do
   ALL_ORDER_STATES = ["draft", "submitted", "processing", "awaiting_dispatch", "dispatching", "cancelled", "closed"]
-  TOTAL_REQUESTS_STATES = ["submitted", "awaiting_dispatch", "closed", "cancelled"].freeze
+  TOTAL_REQUESTS_STATES = ["submitted", "awaiting_dispatch", "closed", "cancelled", "draft"].freeze
 
   let(:user) { create :user }
 
@@ -86,20 +86,25 @@ RSpec.describe Order, type: :model do
       let!(:"#{state}_order_user") { create :order, :with_orders_packages, :"with_state_#{state}", created_by_id: user.id, status: nil }
     end
 
-    it "will return submitted order for the user" do
+    it "will return submitted orders count for the user" do
       expect(Order.counts_for(user.id)["submitted"]).to eq(1)
     end
 
-    it "will return awaiting_dispatch order for the user" do
+    it "will return awaiting_dispatch orders count for the user" do
       expect(Order.counts_for(user.id)["awaiting_dispatch"]).to eq(1)
     end
 
-    it "will return closed order for the user" do
+    it "will return closed orders count for the user" do
       expect(Order.counts_for(user.id)["closed"]).to eq(1)
     end
 
-    it "will return cancelled order for the user" do
+    it "will return cancelled orders count for the user" do
       expect(Order.counts_for(user.id)["cancelled"]).to eq(1)
+    end
+
+    it "will not return draft orders count for the user" do
+      expect(Order.counts_for(user.id).keys).to_not include('draft')
+      expect(Order.counts_for(user.id)["draft"]).to eq(nil)
     end
 
     it "will not return orders count of other user" do


### PR DESCRIPTION
Hi Team,
This PR is for ticket GCW-2421- Adding total request counts. Since, we have common routes for fetching orders data in nested routes. Which will results in unnecessary request i.e orders_count, for data which is not required in other pages. So, I have added separate ajax request for orders_count on orders_summary page instead of adding it in users or orders payload.
Please review the PR and let me know if any change is required.