### PR TITLE
GCW-2576 organisation missing fix

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -3,6 +3,7 @@ module Api
     class OrdersController < Api::V1::ApiController
       load_and_authorize_resource :order, parent: false
       before_action :eager_load_designation, only: :show
+      before_action :check_for_gc_organisation, only: :update
 
       resource_description do
         short 'Retrieve a list of designations, information about stock items that have been designated to a group or person.'
@@ -225,6 +226,16 @@ module Api
 
       def eager_load_designation
         @order = Order.accessible_by(current_ability).with_eager_load.find(params[:id])
+      end
+
+      def check_for_gc_organisation
+        return unless params[:order]
+
+        organisation_params = {
+          stockit_organisation_id: params[:order][:organisation_id],
+          organisation_id: params[:order][:gc_organisation_id]
+        }
+        order_params.merge(organisation_params)
       end
     end
   end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -77,9 +77,8 @@ module Api
       end
 
       def update
-        merged_order_params = merge_organisation_params_to_order_params(order_params)
         root = is_browse_app? ? "order" : "designation"
-        @order.assign_attributes(merged_order_params)
+        @order.assign_attributes(order_params.merge(organisation_params))
         # use valid? to ensure submit event errors get caught
         if @order.valid? and @order.save
           render json: @order, root: root, serializer: serializer
@@ -228,12 +227,11 @@ module Api
         @order = Order.accessible_by(current_ability).with_eager_load.find(params[:id])
       end
 
-      def merge_organisation_params_to_order_params(order_params)
-        organisation_params = {
+      def organisation_params
+        {
           stockit_organisation_id: params[:order][:organisation_id],
           organisation_id: params[:order][:gc_organisation_id]
         }
-        order_params.merge(organisation_params)
       end
     end
   end

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
         expect(parsed_body['designations'].count).to eq(Order.where.not(state: 'draft').count)
         expect(parsed_body['designations'].map { |it| it['state'] }).to_not include('draft')
       end
-      
+
       # Test turned off as currently hardcoded to 150
       # it 'returns the number of items specified for the page' do
       #   5.times { FactoryBot.create :order, :with_state_submitted } # There are now 7 no-draft orders in total
@@ -479,6 +479,15 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
 
     context "Updating properties" do
       before { generate_and_set_token(user) }
+
+      it "should not remove organisation from order" do
+        order_with_org = create :order, :with_state_submitted
+        booking_type1 = create :booking_type
+        org_id = order_with_org.organisation_id
+        put :update, id: order_with_org.id, order: { booking_type: booking_type1, gc_organisation_id: org_id }
+        expect(response.status).to eq(200)
+        expect(order_with_org.organisation_id).to eq(org_id)
+      end
 
       it "should update the staff note property" do
         expect(order.staff_note).to eq("")


### PR DESCRIPTION
Hi Team, this PR includes fixes for organisation missing on few orders.
The issue which was there was due to the reason of json params we were getting from the Ember side.

Whenever we update anything in the order from the logistics tab, the updateRecord method was called which caused the use of serializer method. In the params, organisation_id was sent null and due to that organisation was removed from the order, and similarly for stockit_organisation, it was updating the GC organisation id in the order.

In the params coming from client, we're sending `gc_organisation_id` which does not exist on orders table, so we need to manipulate the params so that we don't mess up the existing organisation_id present in the order.

I have modified the order_params just how the api likes it. This PR will be merging stockit_organisation_id(`organisation_id` from ember) and organisation_id(`gc_organisation_id` from client) params coming from the client to orders_params, so that it wont cause the above mentioned issue.

Please review.
Thanks