### PR TITLE
Add rake for fix missing organizations from orders

### DIFF
--- a/lib/tasks/fix_missing_organisations.rake
+++ b/lib/tasks/fix_missing_organisations.rake
@@ -7,14 +7,14 @@ namespace :goodcity do
     #get all the gc orders without organisation and not draft draft orders
     Order.where("orders.state <> ? and orders.organisation_id IS NULL and orders.created_by_id IS NOT NULL and code ILIKE ?","draft", "GC-%").find_each do |order|
       creator_organisations = order.created_by&.organisations
-      next unless creator_organisations
+      next if creator_organisations.blank?
       if order.update(organisation_id: creator_organisations.first.id)
         count += 1
         print "."
       end
     end
     log.info(": #{count} orders updated")
-    puts "#{count} orders updated"
     log.close
+    puts "#{count} orders updated"
   end
 end

--- a/lib/tasks/fix_missing_organisations.rake
+++ b/lib/tasks/fix_missing_organisations.rake
@@ -1,11 +1,14 @@
-#rake goodcity:fix_missing_organisations
+# rake goodcity:fix_missing_organisations
 
 namespace :goodcity do
   task fix_missing_organisations: :environment do
     count = 0
     log = Goodcity::RakeLogger.new("fix_missing_organisations")
-    #get all the gc orders without organisation and not draft draft orders
-    Order.where("orders.state <> ? and orders.organisation_id IS NULL and orders.created_by_id IS NOT NULL and code ILIKE ?","draft", "GC-%").find_each do |order|
+    # get all the gc orders without organisation and not draft draft orders
+    Order
+      .where(organisation_id: nil)
+      .where.not(created_by_id: nil, state: 'draft')
+      .where("code ILIKE ?", "GC-%").find_each do |order|
       creator_organisations = order.created_by&.organisations
       next if creator_organisations.blank?
       if order.update(organisation_id: creator_organisations.first.id)

--- a/lib/tasks/fix_missing_organisations.rake
+++ b/lib/tasks/fix_missing_organisations.rake
@@ -1,0 +1,20 @@
+#rake goodcity:fix_missing_organisations
+
+namespace :goodcity do
+  task fix_missing_organisations: :environment do
+    count = 0
+    log = Goodcity::RakeLogger.new("fix_missing_organisations")
+    #get all the gc orders without organisation and not draft draft orders
+    Order.where("orders.state <> ? and orders.organisation_id IS NULL and orders.created_by_id IS NOT NULL and code ILIKE ?","draft", "GC-%").find_each do |order|
+      creator_organisations = order.created_by&.organisations
+      next unless creator_organisations
+      if order.update(organisation_id: creator_organisations.first.id)
+        count += 1
+        print "."
+      end
+    end
+    log.info(": #{count} orders updated")
+    puts "#{count} orders updated"
+    log.close
+  end
+end


### PR DESCRIPTION
Earlier I was thinking of handling the scenario for users having multiple organisations as well, but looking at this data, i don't think we need that anymore.
```
Staging Data 
o = Order.where("organisation_id IS NULL and code ILIKE ?","GC-%").where.not(state: "draft").map(&:created_by).map(&:organisations).map(&:count)
 => [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] 
```
```
Prod Data => 
Order.where("organisation_id IS NULL and code ILIKE ?","GC-%").where.not(state: "draft").map(&:created_by).compact.map(&:organisations).map(&:count)
 => [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] 
```