### PR TITLE
Revert "GCW-2576 organisation missing fix"

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -78,7 +78,7 @@ module Api
 
       def update
         root = is_browse_app? ? "order" : "designation"
-        @order.assign_attributes(order_params.merge(organisation_params))
+        @order.assign_attributes(order_params)
         # use valid? to ensure submit event errors get caught
         if @order.valid? and @order.save
           render json: @order, root: root, serializer: serializer
@@ -225,13 +225,6 @@ module Api
 
       def eager_load_designation
         @order = Order.accessible_by(current_ability).with_eager_load.find(params[:id])
-      end
-
-      def organisation_params
-        {
-          stockit_organisation_id: params[:order][:organisation_id],
-          organisation_id: params[:order][:gc_organisation_id]
-        }
       end
     end
   end

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
         expect(parsed_body['designations'].count).to eq(Order.where.not(state: 'draft').count)
         expect(parsed_body['designations'].map { |it| it['state'] }).to_not include('draft')
       end
-
+      
       # Test turned off as currently hardcoded to 150
       # it 'returns the number of items specified for the page' do
       #   5.times { FactoryBot.create :order, :with_state_submitted } # There are now 7 no-draft orders in total
@@ -479,15 +479,6 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
 
     context "Updating properties" do
       before { generate_and_set_token(user) }
-
-      it "should not remove organisation from order" do
-        order_with_org = create :order, :with_state_submitted
-        booking_type1 = create :booking_type
-        org_id = order_with_org.organisation_id
-        put :update, id: order_with_org.id, order: { booking_type: booking_type1, gc_organisation_id: org_id }
-        expect(response.status).to eq(200)
-        expect(order_with_org.organisation_id).to eq(org_id)
-      end
 
       it "should update the staff note property" do
         expect(order.staff_note).to eq("")


### PR DESCRIPTION
This PR reverts organisation fix on api side, as it has broken order creation, will go ahead with the serializer fix on ember side.