### PR TITLE
Remove unwanted slack reminders

### DIFF
--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -37,17 +37,7 @@ class SubscriptionsReminder
   def send_sms_reminder(user)
     sms_url = "#{Rails.application.secrets.base_urls['app']}/offers"
     TwilioService.new(user).send_unread_message_reminder(sms_url)
-    send_slack_sms(sms_url) if Rails.env.staging?
     Rails.logger.info("SMS reminder sent to user #{user.id}")
-  end
-
-  def send_slack_sms(sms_url)
-    message = "SlackSMS ('id: #{user.id} full_name: #{user.full_name}') #{unread_message_reminder(sms_url)}"
-    SlackMessageJob.perform_later(message, ENV["SLACK_PIN_CHANNEL"])
-  end
-
-  def unread_message_reminder(url)
-    I18n.t('twilio.unread_message_sms', url: url)
   end
 
   # E.g. 4.hours.ago

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -31,11 +31,12 @@ class TwilioService
   # options[:to] = "+85261111111"
   # options[:body] = "SMS body"
   def send_sms(options)
-    options = {to: @user.mobile}.merge(options)
+    to = @user.mobile.presence || @user.email.presence
+    options = {to: to}.merge(options)
     if send_to_twilio?
       TwilioJob.perform_later(options)
     elsif options[:to]
-      message = "SlackSMS (#{options[:to]}) #{options[:body]}"
+      message = "SlackSMS (to: #{options[:to]}, id: #{user.id} full_name: #{user.full_name}) #{options[:body]}"
       SlackMessageJob.perform_later(message, ENV['SLACK_PIN_CHANNEL'])
     end
   end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -36,7 +36,7 @@ class TwilioService
     if send_to_twilio?
       TwilioJob.perform_later(options)
     elsif options[:to]
-      message = "SlackSMS (to: #{options[:to]}, id: #{user.id} full_name: #{user.full_name}) #{options[:body]}"
+      message = "SlackSMS (to: #{options[:to]}, id: #{user.id}, full_name: #{user.full_name}) #{options[:body]}"
       SlackMessageJob.perform_later(message, ENV['SLACK_PIN_CHANNEL'])
     end
   end

--- a/lib/tasks/subscription_sms_sent_reminder_at.rake
+++ b/lib/tasks/subscription_sms_sent_reminder_at.rake
@@ -1,3 +1,4 @@
+#rake goodcity:update_sms_reminder_sent_at
 namespace :goodcity do
   desc 'Set all User.sms_reminder_sent_at values to now'
   task update_sms_reminder_sent_at: :environment do

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe TwilioService do
 
   let(:mobile) { generate(:mobile) }
-  let(:user)   { build :user, mobile: mobile }
+  let(:user)   { create :user, mobile: mobile }
   let(:twilio) { TwilioService.new(user) }
 
   context "initialize" do
@@ -105,7 +105,7 @@ describe TwilioService do
       expect(subject).to receive(:send_to_twilio?).and_return(false)
       expect(TwilioJob).to_not receive(:perform_later)
       channel = ENV['SLACK_PIN_CHANNEL']
-      message = "SlackSMS (#{user.mobile}) #{options[:body]}"
+      message = "SlackSMS (to: #{user.mobile}, id: #{user.id}, full_name: #{user.full_name}) #{options[:body]}"
       expect(SlackMessageJob).to receive(:perform_later).with(message, channel)
       subject.send(:send_sms, options)
     end


### PR DESCRIPTION
Hi Team,

I have removed extra slack message code added in subscription_reminders as I realized we already have code to manage that in twilio service.

I added id and name in slack message as it will help us in this case and can't see any drawback of adding it.

Please review.

Thanks.