### PR TITLE
Remove hardcoded donor conditions

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -53,8 +53,7 @@ module Api
           include_order: true,
           include_orders_packages: true,
           exclude_stockit_set_item: @package.set_item_id.blank? ? true : false,
-          include_images: @package.set_item_id.blank?,
-          include_stock_condition: is_stock_app?
+          include_images: @package.set_item_id.blank?
       end
 
       api :POST, "/v1/packages", "Create a package"
@@ -140,8 +139,7 @@ module Api
           include_packages: false,
           include_orders_packages: true,
           exclude_stockit_set_item: true,
-          include_images: true,
-          include_stock_condition: is_stock_app?).as_json
+          include_images: true).as_json
         render json: {meta: { search: params['searchText'] } }.merge(packages)
       end
 

--- a/app/serializers/api/v1/donor_condition_serializer.rb
+++ b/app/serializers/api/v1/donor_condition_serializer.rb
@@ -3,28 +3,7 @@ module Api::V1
     attributes :id, :name
 
     def name__sql
-      if @options[:include_stock_condition]
-        "(CASE WHEN donor_conditions.id=1 THEN 'New'
-              WHEN donor_conditions.id=2 THEN 'Mixed'
-              WHEN donor_conditions.id=3 THEN 'Used'
-              WHEN donor_conditions.id=4 THEN 'Broken'
-        END)"
-      else
-        "name_#{current_language}"
-      end
-    end
-
-    def name
-      if @options[:include_stock_condition]
-        case object.id
-          when 1 then 'New'
-          when 2 then 'Mixed'
-          when 3 then 'Used'
-          when 4 then 'Broken'
-        end
-      else
-        object.name
-      end
+      "name_#{current_language}"
     end
   end
 end


### PR DESCRIPTION
The API was sending different labels for donor_conditions in some cases, which caused inconsistencies with the browse app (As reported by Nokia). This PR normalizes the texts 

Couple of general rules to note about the code that was removed : 
```
 "(CASE WHEN donor_conditions.id=1 THEN 'New'
              WHEN donor_conditions.id=2 THEN 'Mixed'
              WHEN donor_conditions.id=3 THEN 'Used'
              WHEN donor_conditions.id=4 THEN 'Broken'
        END)"
```

* We cannot hardcode IDs anywhere, since we can never guarantee that they match. e.g If the table was ever re-seeded or edited, we would likely have different IDs

* We want to avoid hardcoded strings in the code as they are hard to track and make it very hard to ensure consistency ('New', 'Mixed', etc)

Pretty basic stuff, but I thought I'd point it out anyways 😄 
