### PR TITLE
Don't send SMS reminders for initial 'thank you for your offer' message

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -130,6 +130,7 @@ class Offer < ActiveRecord::Base
 
     before_transition on: :submit do |offer, _transition|
       offer.submitted_at = Time.now
+      offer.created_by.update_attribute(:sms_reminder_sent_at, Time.now + 1.minute) # start the SMS reminder clock from here
     end
 
     before_transition on: :start_review do |offer, _transition|

--- a/app/services/subscriptions_reminder.rb
+++ b/app/services/subscriptions_reminder.rb
@@ -19,6 +19,8 @@ class SubscriptionsReminder
   #   its not order related messages
   #   are reviewers will receive SMS only on offers they have created (exclude offers they are subscribed too)
   # If sms_reminder_sent_at is NULL then use created_at so we don't SMS user immediately
+  # IMPORANT NOTE: When a user submits an offer, we set the sms_reminder_sent_at time to now + 1.minute
+  #   to avoid alerting on the system 'thank you for submitting your offer' message
   def user_candidates_for_reminder
     offer_states = ['submitted', 'under_review', 'reviewed', 'scheduled', 'received', 'receiving', 'inactive'] # NOT draft, closed or cancelled
     User.joins(subscriptions: [:message, :offer])

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Offer, type: :model do
   context "submitting an offer" do
     it "should set submitted_at" do
       expect( offer.submitted_at ).to be_nil
-      offer.update_attributes(state_event: "submit")
+      offer.submit!
       expect( offer.submitted_at ).to_not be_nil
     end
     it "should set sms_reminder_sent_at" do
       expect( offer.created_by.sms_reminder_sent_at ).to be_nil
       time = Time.now
-      offer.update_attributes(state_event: "submit")
+      offer.submit!
       expect( offer.created_by.sms_reminder_sent_at ).to be > time
     end
   end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -40,10 +40,18 @@ RSpec.describe Offer, type: :model do
     end
   end
 
-  it "should set submitted_at when submitted" do
-    expect( offer.submitted_at ).to be_nil
-    offer.update_attributes(state_event: "submit")
-    expect( offer.submitted_at ).to_not be_nil
+  context "submitting an offer" do
+    it "should set submitted_at" do
+      expect( offer.submitted_at ).to be_nil
+      offer.update_attributes(state_event: "submit")
+      expect( offer.submitted_at ).to_not be_nil
+    end
+    it "should set sms_reminder_sent_at" do
+      expect( offer.created_by.sms_reminder_sent_at ).to be_nil
+      time = Time.now
+      offer.update_attributes(state_event: "submit")
+      expect( offer.created_by.sms_reminder_sent_at ).to be > time
+    end
   end
 
   describe "Class Methods" do

--- a/spec/services/subscriptions_reminder_spec.rb
+++ b/spec/services/subscriptions_reminder_spec.rb
@@ -17,6 +17,7 @@ describe SubscriptionsReminder do
 
   subject { SubscriptionsReminder.new }
 
+  # All specs begin life with an offer+message and an order+message
   let!(:message) { create(:message, offer: offer, sender: reviewer).tap{|m| m.update_column(:created_at, message_created_at)} }
   let!(:message1) { create(:message, :with_order, order: order, sender: reviewer).tap{|m| m.update_column(:created_at, message_created_at)} }
 
@@ -156,6 +157,16 @@ describe SubscriptionsReminder do
         within_head_start_time = SUBSCRIPTION_REMINDER_HEAD_START.ago + 2.minutes
         donor.subscriptions.map(&:message).flatten.uniq.map{|m| m.update_column(:created_at, within_head_start_time)}
         donor.update_column(:sms_reminder_sent_at, before_delta.ago)
+        expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
+      end
+
+      # whilst this spec is also covered in offer_spec.rb we include it here for clarity as it is part of the SMS criteria
+      it "message was created before offer.submitted_at + 1 minute. (to avoid including system generated message)" do
+        Offer.update_all(state: 'draft') # exclude existing offers from this spec
+        offer1 = create(:offer, state: 'draft')
+        offer1.submit
+        expect(offer1.messages.count).to eq(1) # system 'Thank you for submitting your offer'
+        expect(offer1.messages.first.created_at).to be < offer1.created_by.sms_reminder_sent_at
         expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])
       end
 

--- a/spec/services/subscriptions_reminder_spec.rb
+++ b/spec/services/subscriptions_reminder_spec.rb
@@ -164,7 +164,7 @@ describe SubscriptionsReminder do
       it "message was created before offer.submitted_at + 1 minute. (to avoid including system generated message)" do
         Offer.update_all(state: 'draft') # exclude existing offers from this spec
         offer1 = create(:offer, state: 'draft')
-        offer1.submit
+        offer1.submit!
         expect(offer1.messages.count).to eq(1) # system 'Thank you for submitting your offer'
         expect(offer1.messages.first.created_at).to be < offer1.created_by.sms_reminder_sent_at
         expect(subject.send(:user_candidates_for_reminder).to_a).to eql([])


### PR DESCRIPTION
Start the SMS Reminder Sent At clock AFTER the initial system generated 'Thank you for your offer' message has gone out. We don't want to send user SMS about this message.