### PR TITLE
GoodCity correctly syncs when Stockit creates a new item

### DIFF
--- a/app/jobs/stockit_update_job.rb
+++ b/app/jobs/stockit_update_job.rb
@@ -7,6 +7,11 @@ class StockitUpdateJob < ActiveJob::Base
     if package
       response = Stockit::ItemSync.update(package)
 
+      # if Stockit can't find the item, it will create a new one and return the stockit_id
+      # We need to update the stockit_id of the GoodCity package in this case.
+      stockit_id = response['id']
+      package.update_attribute(stockit_id: stockit_id) unless stockit_id.blank?
+
       if response && (errors = response["errors"] || response[:errors])
         log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"
         errors.each { |attribute, error| log_text += " #{attribute}: #{error}" }

--- a/app/jobs/stockit_update_job.rb
+++ b/app/jobs/stockit_update_job.rb
@@ -10,7 +10,7 @@ class StockitUpdateJob < ActiveJob::Base
       # if Stockit can't find the item, it will create a new one and return the stockit_id
       # We need to update the stockit_id of the GoodCity package in this case.
       stockit_id = response['id']
-      package.update_attribute(stockit_id: stockit_id) unless stockit_id.blank?
+      package.update_attribute(:stockit_id, stockit_id) unless stockit_id.blank?
 
       if response && (errors = response["errors"] || response[:errors])
         log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"

--- a/spec/jobs/stockit_update_job_spec.rb
+++ b/spec/jobs/stockit_update_job_spec.rb
@@ -4,12 +4,27 @@ describe StockitUpdateJob, :type => :job do
 
   let(:package) { create(:package, :stockit_package) }
   let(:err) { {"errors" => {:connection_error => "Error"}} }
-
+  
   subject { StockitUpdateJob.new }
 
   it "should update the item in Stockit" do
     expect(Stockit::ItemSync).to receive(:update).with(package)
     subject.perform(package.id)
+  end
+
+  context "Stockit creates a new item" do
+    let(:new_item_id) { package.stockit_id + 1 }
+    let(:new_item_payload) { { "id" => new_item_id } }
+    it "should update stockit_id" do
+      expect(Stockit::ItemSync).to receive(:update).with(package).and_return(new_item_payload)
+      expect(package).to receive(:update_attribute).with(stockit_id: new_item_id)
+      subject.perform(package.id)
+    end
+    it "should not update stockit_id if it is blank" do
+      expect(Stockit::ItemSync).to receive(:update).with(package).and_return( { id: nil } )
+      expect(package).to_not receive(:update_attribute)
+      subject.perform(package.id)
+    end
   end
 
   it "should ignore packages that don't exist" do

--- a/spec/jobs/stockit_update_job_spec.rb
+++ b/spec/jobs/stockit_update_job_spec.rb
@@ -4,11 +4,12 @@ describe StockitUpdateJob, :type => :job do
 
   let(:package) { create(:package, :stockit_package) }
   let(:err) { {"errors" => {:connection_error => "Error"}} }
-  
+
   subject { StockitUpdateJob.new }
 
   it "should update the item in Stockit" do
-    expect(Stockit::ItemSync).to receive(:update).with(package)
+    payload = { id: package.id }
+    expect(Stockit::ItemSync).to receive(:update).with(package).and_return(payload)
     subject.perform(package.id)
   end
 
@@ -17,8 +18,8 @@ describe StockitUpdateJob, :type => :job do
     let(:new_item_payload) { { "id" => new_item_id } }
     it "should update stockit_id" do
       expect(Stockit::ItemSync).to receive(:update).with(package).and_return(new_item_payload)
-      expect(package).to receive(:update_attribute).with(stockit_id: new_item_id)
       subject.perform(package.id)
+      expect(package.reload.stockit_id).to eq(new_item_id)
     end
     it "should not update stockit_id if it is blank" do
       expect(Stockit::ItemSync).to receive(:update).with(package).and_return( { id: nil } )


### PR DESCRIPTION
If a Stockit update sync results in a create (not an update), ensure GoodCity records the new stockit_id.