### PR TITLE
Staff can create offers with no donor

### DIFF
--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -160,7 +160,10 @@ module Api
         attributes = [:language, :origin, :stairs, :parking, :estimated_size,
           :notes, :delivered_by, :state_event, :cancel_reason,
           :cancellation_reason_id, :saleable]
-        attributes << :created_by_id if User.current_user.staff?
+        attributes.concat [
+          :created_at, :created_by_id, :submitted_at, :state,
+          :reviewed_at, :reviewed_by_id
+        ] if User.current_user.staff?
         params.require(:offer).permit(attributes)
       end
 

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -39,7 +39,7 @@ module Api
       api :POST, '/v1/offers', "Create an offer"
       param_group :offer
       def create
-        @offer.created_by = current_user
+        @offer.created_by = current_user unless offer_params.has_key?(:created_by_id)
         save_and_render_object(@offer)
       end
 
@@ -160,6 +160,7 @@ module Api
         attributes = [:language, :origin, :stairs, :parking, :estimated_size,
           :notes, :delivered_by, :state_event, :cancel_reason,
           :cancellation_reason_id, :saleable]
+        attributes << :created_by_id if User.current_user.staff?
         params.require(:offer).permit(attributes)
       end
 

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -39,7 +39,7 @@ module Api
       api :POST, '/v1/offers', "Create an offer"
       param_group :offer
       def create
-        @offer.created_by = current_user unless offer_params.has_key?(:created_by_id)
+        @offer.created_by_id = current_user.id unless offer_params.has_key?(:created_by_id)
         save_and_render_object(@offer)
       end
 


### PR DESCRIPTION
If a staff member sends `created_by_id` in the payload, it'll be applied to the created offer.