### PR TITLE
redirect users to packages controller if they hit `browse/fetch_packages`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace "api" do
     namespace "v1", defaults: { format: "json" } do
 
+      get "/browse/fetch_packages", to: "packages#index"
       post "auth/signup", to: "authentication#signup"
       post "auth/verify", to: "authentication#verify"
       post "auth/send_pin", to: "authentication#send_pin"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   namespace "api" do
     namespace "v1", defaults: { format: "json" } do
 
-      get "/browse/fetch_packages", to: "packages#index"
+      get "/browse/fetch_packages", to: "packages#index" #temporary redirect for old browse apps
       post "auth/signup", to: "authentication#signup"
       post "auth/verify", to: "authentication#verify"
       post "auth/send_pin", to: "authentication#send_pin"


### PR DESCRIPTION
For old mobile apps. Tested it using postman hit the api endpoint for 
`localhost:4000/api/v1/browse/fetch_packages` and `localhost:4000/api/v1/packages`
Working fine for me.