### PR TITLE
Restrict user to view other user's order

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -201,7 +201,7 @@ class Ability
 
   def order_abilities
     can :create, Order
-    can [:index, :show, :update, :destroy], Order, created_by_id: @user_id
+    can [:index, :show, :update, :destroy, :transition], Order, { created_by_id: @user_id }
     if can_manage_orders? || @api_user
       can [:create, :index, :show, :update, :transition, :destroy, :summary], Order
       can :index, ProcessChecklist

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -201,7 +201,7 @@ class Ability
 
   def order_abilities
     can :create, Order
-    can [:index, :show, :update, :destroy, :transition], Order, { created_by_id: @user_id }
+    can %i[index show update destroy transition], Order, created_by_id: @user_id
     if can_manage_orders? || @api_user
       can [:create, :index, :show, :update, :transition, :destroy, :summary], Order
       can :index, ProcessChecklist

--- a/db/permissions_roles.yml
+++ b/db/permissions_roles.yml
@@ -60,7 +60,6 @@ Supervisor:
 api-write: []
 Charity:
 - can_login_to_browse
-- can_manage_orders
 - can_manage_orders_packages
 - can_search_browse_packages
 - can_create_goodcity_requests

--- a/lib/tasks/remove_can_manage_order_permission_from_charity_users.rake
+++ b/lib/tasks/remove_can_manage_order_permission_from_charity_users.rake
@@ -1,0 +1,7 @@
+namespace :goodcity do
+  task remove_can_manage_order_permission_from_charity_users: :environment do
+    role_permission = Permission.find_by(name:"can_manage_orders").role_permissions.where(role_id: Role.find_by(name: "Charity").id).first
+
+    role_permission.destroy if role_permission
+  end
+end

--- a/lib/tasks/remove_can_manage_order_permission_from_charity_users.rake
+++ b/lib/tasks/remove_can_manage_order_permission_from_charity_users.rake
@@ -1,7 +1,0 @@
-namespace :goodcity do
-  task remove_can_manage_order_permission_from_charity_users: :environment do
-    role_permission = Permission.find_by(name:"can_manage_orders").role_permissions.where(role_id: Role.find_by(name: "Charity").id).first
-
-    role_permission.destroy if role_permission
-  end
-end

--- a/lib/tasks/remove_permission_from_role.rake
+++ b/lib/tasks/remove_permission_from_role.rake
@@ -1,10 +1,10 @@
 # to run this rake task run the following command.
-# rake goodcity:remove_permission_from_role permission=permission_name role=role_name
+# rake 'goodcity:remove_permission_from_role[can_manage_orders, Charity]'
 
 namespace :goodcity do
-  task remove_permission_from_role: :environment do
-    Permission.find_by(name: ENV["permission"])
-      .role_permissions.where(role_id: Role.find_by(name: ENV["role"]).id)
-      .first&.destroy
+  task :remove_permission_from_role, [:permission, :role_name] => [:environment] do |task, args|
+    Permission.find_by(name: args.permission)
+    .role_permissions.where(role_id: Role.find_by(name: args.role_name).id)
+    .first&.destroy
   end
 end

--- a/lib/tasks/remove_permission_from_role.rake
+++ b/lib/tasks/remove_permission_from_role.rake
@@ -2,9 +2,13 @@
 # rake 'goodcity:remove_permission_from_role[can_manage_orders, Charity]'
 
 namespace :goodcity do
-  task :remove_permission_from_role, [:permission, :role_name] => [:environment] do |task, args|
-    Permission.find_by(name: args.permission)
-    .role_permissions.where(role_id: Role.find_by(name: args.role_name).id)
-    .first&.destroy
+  task :remove_permission_from_role, %i[permission role_name] => [:environment] do |task, args|
+    role_id = Role.find_by(name: args.role_name)&.id
+    permission_id = Permission.find_by(name: args.permission)&.id
+    if role_id && permission_id
+      RolePermission.find_by(role_id: role_id, permission_id: permission_id)&.destroy
+    else
+      puts "Permission not found for this role"
+    end
   end
 end

--- a/lib/tasks/remove_permission_from_role.rake
+++ b/lib/tasks/remove_permission_from_role.rake
@@ -1,0 +1,10 @@
+# to run this rake task run the following command.
+# rake goodcity:remove_permission_from_role permission=permission_name role=role_name
+
+namespace :goodcity do
+  task remove_permission_from_role: :environment do
+    Permission.find_by(name: ENV["permission"])
+      .role_permissions.where(role_id: Role.find_by(name: ENV["role"]).id)
+      .first&.destroy
+  end
+end


### PR DESCRIPTION
This PR is a fix for the issue which was discussed in the call. (i.e Restrict user to view other user's order)
`rake 'goodcity:remove_permission_from_role[permission_name, role_name]'`
eg: 
`rake 'goodcity:remove_permission_from_role[can_manage_orders, Charity]'`