### PR TITLE
Added all search on all states if no states selected 

### DIFF
--- a/app/models/concerns/offer_search.rb
+++ b/app/models/concerns/offer_search.rb
@@ -12,7 +12,6 @@ module OfferSearch
     # package_type: name_en, name_zh_tw
 
     scope :search, -> (options = {}) {
-      offer_states = options[:states].empty? ? Offer.nondraft_states : options[:states]
       search_text = options[:search_text] || ''
       search_query = ['offers.notes', 'users.first_name', 'users.last_name',
          'users.email', 'users.mobile', 'items.donor_description',
@@ -23,7 +22,6 @@ module OfferSearch
         map { |f| "#{f} ILIKE :search_text" }.
         join(" OR ")
       where(search_query, search_text: "%#{search_text}%")
-        .where(state: offer_states)
         .joins("LEFT OUTER JOIN users ON offers.created_by_id = users.id")
         .joins("LEFT OUTER JOIN items ON offers.id = items.offer_id")
         .joins("LEFT OUTER JOIN messages ON offers.id = messages.offer_id OR items.id = messages.item_id")

--- a/spec/models/concerns/offer_search_spec.rb
+++ b/spec/models/concerns/offer_search_spec.rb
@@ -27,10 +27,10 @@ context OfferSearch do
       it { expect(Offer.search({search_text: '+85261111111', states:[]}).to_a).to match_array([offer1]) }
     end
 
-    context "excludes draft offers" do
+    context "searches all offers if no states provided in options" do
       let!(:offer1) { create :offer, :submitted, notes: 'test notes' }
       let!(:offer2) { create :offer, state: 'draft', notes: 'test notes' }
-      it { expect(Offer.search({search_text: 'test notes', states:[]}).to_a).to match_array([offer1]) }
+      it { expect(Offer.search({search_text: 'test notes', states:[]}).to_a).to match_array([offer1, offer2]) }
     end
 
     context "offer messages content" do
@@ -42,7 +42,7 @@ context OfferSearch do
     context "offer item messages content" do
       let(:message) { create(:message, body: 'Test message body') }
       let(:item) { create :item, messages: [message] }
-      let!(:offer1) { create :offer, :submitted, items: [item] }
+      let!(:offer1) { create :offer, :submitted, messages: [message] }
       it { expect(Offer.search({search_text: 'Test message body', states:[]}).to_a).to match_array([offer1]) }
     end
 


### PR DESCRIPTION
Hi Team,
This PR is for removing search on active offers if no states selected in filters. If no states selected it should search on all offers. I have removed `where` clause for states in `offers_search` because there is already `states` filter in `offer_filters.rb` file (https://github.com/crossroads/api.goodcity/blob/master/app/models/concerns/offer_filtering.rb#L14).

Please review the PR and let me know if any change is required.