### PR TITLE
send sms to only mobile numbers

### DIFF
--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -31,10 +31,15 @@ class TwilioService
   # options[:to] = "+85261111111"
   # options[:body] = "SMS body"
   def send_sms(options)
-    options = {to: @user.mobile}.merge(options)
+    to = @user.mobile.presence
+
+    options = { to: to }.merge(options)
+
+    return unless options[:to]
+
     if send_to_twilio?
       TwilioJob.perform_later(options)
-    elsif options[:to].presence
+    else
       message = "SlackSMS (to: #{options[:to]}, id: #{user.id}, full_name: #{user.full_name}) #{options[:body]}"
       SlackMessageJob.perform_later(message, ENV['SLACK_PIN_CHANNEL'])
     end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -31,11 +31,10 @@ class TwilioService
   # options[:to] = "+85261111111"
   # options[:body] = "SMS body"
   def send_sms(options)
-    to = @user.mobile.presence || @user.email.presence
-    options = {to: to}.merge(options)
+    options = {to: @user.mobile}.merge(options)
     if send_to_twilio?
       TwilioJob.perform_later(options)
-    elsif options[:to]
+    elsif options[:to].presence
       message = "SlackSMS (to: #{options[:to]}, id: #{user.id}, full_name: #{user.full_name}) #{options[:body]}"
       SlackMessageJob.perform_later(message, ENV['SLACK_PIN_CHANNEL'])
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       end
     end
 
+    trait :user_with_no_mobile do
+      mobile { nil }
+    end
+
     trait :with_multiple_roles_and_permissions do
       after(:create) do |user, evaluator|
         evaluator.roles_and_permissions.each_pair do |role_name, permissions|


### PR DESCRIPTION
Hi Team,

This PR will avoid calling Twilio job if user does not have a mobile number and will fix the issue of trying to send SMS on email id.

Please review.

Thanks.