### PR TITLE
GCW-2735 Search orders by beneficiary

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -342,6 +342,8 @@ class Order < ActiveRecord::Base
       stockit_contacts.first_name ILIKE (:query) OR stockit_contacts.last_name ILIKE (:query) OR
       stockit_contacts.mobile_phone_number LIKE (:query) OR
       stockit_contacts.phone_number LIKE (:query) OR
+      beneficiaries.first_name ILIKE (:query) OR beneficiaries.last_name ILIKE (:query) OR
+      CONCAT(beneficiaries.first_name, ' ', beneficiaries.last_name) ILIKE (:query) OR
       CONCAT(users.first_name, ' ', users.last_name) ILIKE (:query)
     SQL
     results = fetch_orders(to_designate_item)
@@ -364,6 +366,7 @@ class Order < ActiveRecord::Base
       LEFT OUTER JOIN stockit_contacts ON orders.stockit_contact_id = stockit_contacts.id
       LEFT OUTER JOIN stockit_organisations ON orders.stockit_organisation_id = stockit_organisations.id
       LEFT OUTER JOIN organisations ON orders.organisation_id = organisations.id
+      LEFT OUTER JOIN beneficiaries ON orders.beneficiary_id = beneficiaries.id
     SQL
   end
 

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -179,6 +179,39 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
         expect(parsed_body['meta']['search']).to eql('john smith')
       end
 
+      it "can search orders from a beneficiary's first name" do
+        beneficiary = FactoryBot.create :beneficiary, first_name: 'Frank', last_name: 'Sinatra'
+        FactoryBot.create :order, :with_state_submitted, beneficiary: beneficiary
+        get :index, searchText: 'Fra'
+        expect(response.status).to eq(200)
+        expect(parsed_body['designations'].count).to eq(1)
+        expect(parsed_body["designations"][0]['beneficiary_id']).to eq(beneficiary.id)
+        expect(parsed_body['meta']['total_pages']).to eql(1)
+        expect(parsed_body['meta']['search']).to eql('Fra')
+      end
+
+      it "can search orders from a beneficiary's last name" do
+        beneficiary = FactoryBot.create :beneficiary, first_name: 'Dave', last_name: 'Grohl'
+        FactoryBot.create :order, :with_state_submitted, beneficiary: beneficiary
+        get :index, searchText: 'Groh'
+        expect(response.status).to eq(200)
+        expect(parsed_body['designations'].count).to eq(1)
+        expect(parsed_body["designations"][0]['beneficiary_id']).to eq(beneficiary.id)
+        expect(parsed_body['meta']['total_pages']).to eql(1)
+        expect(parsed_body['meta']['search']).to eql('Groh')
+      end
+
+      it "can search orders from a beneficiary's full name" do
+        beneficiary = FactoryBot.create :beneficiary, first_name: 'Damon', last_name: 'Albarn'
+        FactoryBot.create :order, :with_state_submitted, beneficiary: beneficiary
+        get :index, searchText: 'Damon Alba'
+        expect(response.status).to eq(200)
+        expect(parsed_body['designations'].count).to eq(1)
+        expect(parsed_body["designations"][0]['beneficiary_id']).to eq(beneficiary.id)
+        expect(parsed_body['meta']['total_pages']).to eql(1)
+        expect(parsed_body['meta']['search']).to eql('Damon Alba')
+      end
+
       it "should be able to fetch designations without their associations" do
         get :index, shallow: 'true'
         expect(response.status).to eq(200)


### PR DESCRIPTION
HKD has requested the ability to search orders by beneficiary. This PR simply adds that.