### PR TITLE
Fix package 500 error

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -36,12 +36,12 @@ module Api
 
       api :GET, "/v1/packages", "get all packages for the item"
       def index
-        @packages = @packages.browse_inventorized.union(@packages.browse_non_inventorized) if is_browse_app?
+        @packages = @packages.browse_public_packages if is_browse_app?
         @packages = @packages.find(params[:ids].split(",")) if params[:ids].present?
         @packages = @packages.search({search_text: params['searchText']})
           .page(page).per(per_page) if params['searchText']
         render json: @packages, each_serializer: serializer, include_orders_packages: is_stock_app?, is_browse_app: is_browse_app?
-       end
+      end
 
       api :GET, '/v1/packages/1', "Details of a package"
       def show

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -250,10 +250,6 @@ class Ability
         :undesignate_partial_item, :dispatch_stockit_item, :move_stockit_item,
         :move_partial_quantity, :move_full_quantity, :print_inventory_label,
         :undispatch_stockit_item, :stockit_item_details, :split_package], Package
-    elsif can_search_browse_packages?
-      can [:index, :show], Package, { allow_web_publish: true}
-    else
-      can [:index, :show, :create, :update], Package, item: { offer: { created_by_id: @user_id } }
     end
     can [:show], Package,  orders_packages: { order: { created_by_id: @user_id }}
     can [:show], Package,  requested_packages: { user_id: @user_id }

--- a/spec/models/abilities/package_abilities_spec.rb
+++ b/spec/models/abilities/package_abilities_spec.rb
@@ -57,35 +57,6 @@ describe "Package abilities" do
     end
   end
 
-  context "when Owner" do
-    let(:user)  { create :user }
-    let(:offer) { create :offer, created_by: user }
-    let(:item)  { create :item, offer: offer, state: state }
-
-    context "and package belongs to draft item" do
-      let(:can)     { [:index, :show, :create, :update, :destroy] }
-      let(:cannot)  { [:manage] }
-      it{ can.each do |do_action|
-        is_expected.to be_able_to(do_action, package)
-      end}
-      it{ cannot.each do |do_action|
-        is_expected.to_not be_able_to(do_action, package)
-      end}
-    end
-
-    context "and package belongs to submitted item" do
-      let(:state)   { 'submitted' }
-      let(:can)     { [:index, :show, :create, :update] }
-      let(:cannot)  { [:destroy, :manage] }
-      it{ can.each do |do_action|
-        is_expected.to be_able_to(do_action, package)
-      end}
-      it{ cannot.each do |do_action|
-        is_expected.to_not be_able_to(do_action, package)
-      end}
-    end
-  end
-
   context "when not Owner" do
     let(:user)    { create :user }
     it{ unpermitted_actions.each { |do_action| is_expected.to_not be_able_to(do_action, package) } }


### PR DESCRIPTION
It's very hard to describe all the things that were going wrong, but I'll try.

@steveyken could you fill in any important info worth knowing : )

## The problems

We were seeing the following 2 main crashes

* The union was failing with `Cannot union relation with includes`
* Cancan abilities were conflicting with ext_serializers (duplicate and missing joins)

## The fixes

* Remove the `can_search_browse_packages` permission, it served no purpose to begin with --> that actually revealed some of the underlying issues
* Replace the union with a single query doing an `OR`
* Remove the ability for donors to index their packages -- > ideally we do want to keep that, but we couldn't really figure out how to fix the Cancan/serializers issue. Given that donors currently never index their packages it's safe to remove for the time being

@abhinav098 you know the errors pretty well, once that is merged could you give it a go and see if we're good to go ?