### PR TITLE
Fix message subscription rules

### DIFF
--- a/spec/models/concerns/message_subscription_spec.rb
+++ b/spec/models/concerns/message_subscription_spec.rb
@@ -102,6 +102,7 @@ context MessageSubscription do
 
       context "should not subscribe other supervisors for subsequent messages" do
         let!(:supervisor) { create :user, :supervisor }
+        let!(:other_reviewer) { create :user, :reviewer }
 
         before { User.current_user = supervisor }
 
@@ -109,10 +110,12 @@ context MessageSubscription do
           # The unrelated supervisor receives the first message of the thread
           expect(message).to receive(:add_subscription).with('read', reviewer.id)
           expect(message).to receive(:add_subscription).with('unread', supervisor.id)
+          expect(message).to receive(:add_subscription).with('unread', other_reviewer.id)
           message.save
 
           # The unrelated supervisor doesn't receive subsequent message of the thread
           expect(message2).to receive(:add_subscription).with('read', reviewer.id) # sender
+          expect(message2).not_to receive(:add_subscription).with('unread', other_reviewer.id)
           expect(message2).not_to receive(:add_subscription).with('unread', supervisor.id)
           message2.save
         end


### PR DESCRIPTION
Here's a fix for the message subscription rule.

The issue being:

- The tests were written with a `supervisor` user, therefore not necessarily a reviewer
- On private messages, we only subscribe everyone on the first message, but this would cause this line to trigger for all subsequent messages `user_ids += User.reviewers.pluck(:id) if [self.sender_id] == user_ids`  -- Something not caught when testing with a supervisor
- Although one line was using `reviewers`, the other was using `supervisors`, so I consolidated everything under `staff`

cc - @steveyken 