### PR TITLE
GCW- 2695- include company name &/or note in offer title and search

### DIFF
--- a/app/models/concerns/offer_search.rb
+++ b/app/models/concerns/offer_search.rb
@@ -15,13 +15,14 @@ module OfferSearch
       search_text = options[:search_text] || ''
       search_query = ['offers.notes', 'users.first_name', 'users.last_name',
          'users.email', 'users.mobile', 'items.donor_description',
-         'messages.body',
+         'messages.body', 'companies.name',
          'package_types.name_en', 'package_types.name_zh_tw',
          'gogovan_orders.driver_name', 'gogovan_orders.driver_mobile', 'gogovan_orders.driver_license'
         ].
         map { |f| "#{f} ILIKE :search_text" }.
         join(" OR ")
       where(search_query, search_text: "%#{search_text}%")
+        .joins("LEFT OUTER JOIN companies ON offers.company_id = companies.id")
         .joins("LEFT OUTER JOIN users ON offers.created_by_id = users.id")
         .joins("LEFT OUTER JOIN items ON offers.id = items.offer_id")
         .joins("LEFT OUTER JOIN messages ON offers.id = messages.offer_id OR items.id = messages.item_id")

--- a/app/serializers/api/v1/offer_summary_serializer.rb
+++ b/app/serializers/api/v1/offer_summary_serializer.rb
@@ -7,7 +7,7 @@ module Api::V1
       :received_at, :cancelled_at, :start_receiving_at,
       :submitted_items_count, :accepted_items_count, :rejected_items_count,
       :expecting_packages_count, :missing_packages_count, :received_packages_count,
-      :display_image_cloudinary_id
+      :display_image_cloudinary_id, :notes
 
     has_one  :closed_by, serializer: UserSummarySerializer, root: :user
     has_one  :created_by, serializer: UserSummarySerializer, root: :user
@@ -15,6 +15,7 @@ module Api::V1
     has_one  :received_by, serializer: UserSummarySerializer, root: :user
     has_one  :delivery, serializer: DeliverySerializer, root: :delivery
     has_many :messages, serializer: MessageSerializer
+    has_one  :company, serializer: CompanySerializer
 
     def include_messages?
       return false unless goodcity_user?
@@ -44,7 +45,7 @@ module Api::V1
     def accepted_items_count__sql
       "(SELECT COUNT(*) FROM items i WHERE i.offer_id = offers.id AND i.state = 'accepted')"
     end
-    
+
     def rejected_items_count
       object.rejected_items.size
     end

--- a/spec/models/concerns/offer_search_spec.rb
+++ b/spec/models/concerns/offer_search_spec.rb
@@ -71,6 +71,12 @@ context OfferSearch do
       it { expect(Offer.search({search_text: 'Test message', states:[]}).to_a).to match_array([offer]) }
     end
 
+    context "company" do
+      let(:company) { create(:company) }
+      let!(:offer1) { create :offer, :submitted, company: company }
+      let!(:offer2) { create :offer, :submitted }
+      it { expect(Offer.search({search_text: company.name, states:[]}).to_a).to match_array([offer1]) }
+    end
   end
 
 end

--- a/spec/serializers/api/v1/offer_summary_serializer_spec.rb
+++ b/spec/serializers/api/v1/offer_summary_serializer_spec.rb
@@ -1,15 +1,35 @@
 require 'rails_helper'
 
 context Api::V1::OfferSummarySerializer do
-
-  let(:offer)      { create(:offer, :with_items) }
+  let(:company) { create :company }
+  let(:offer)      { create(:offer, :with_items, company: company) }
   let(:serializer) { Api::V1::OfferSummarySerializer.new(offer, root: 'offer').as_json }
-  
+
   subject { JSON.parse( serializer.to_json ) }
 
-  it "should only have the user and images associations" do
+  it 'creates json' do
+    expect(subject['offer']['state']).to eq(offer.state)
+    expect(subject['offer']['notes']).to eq(offer.notes)
+    expect(subject['offer']['submitted_items_count']).to eq(offer.submitted_item_ids.size)
+    expect(subject['offer']['accepted_items_count']).to eq(offer.accepted_items.size)
+    expect(subject['offer']['rejected_items_count']).to eq(offer.rejected_items.size)
+    expect(subject['offer']['expecting_packages_count']).to eq(offer.expecting_packages.size)
+    expect(subject['offer']['missing_packages_count']).to eq(offer.missing_packages.size)
+    expect(subject['offer']['received_packages_count']).to eq(offer.received_packages.size)
+    expect(subject['offer']['display_image_cloudinary_id']).to eq(offer.images.first.cloudinary_id)
+    expect(subject['offer']['inactive_at']).to eq(offer.inactive_at)
+    expect(subject['offer']['submitted_at']).to eq(offer.submitted_at)
+    expect(subject['offer']['reviewed_at']).to eq(offer.reviewed_at)
+    expect(subject['offer']['review_completed_at']).to eq(offer.review_completed_at)
+    expect(subject['offer']['received_at']).to eq(offer.received_at)
+    expect(subject['offer']['cancelled_at']).to eq(offer.cancelled_at)
+    expect(subject['offer']['start_receiving_at']).to eq(offer.start_receiving_at)
+  end
+
+  it "should only have the user, companies and images associations" do
     expect(subject.keys).to include("user")
     expect(subject.keys).to include("offer")
+    expect(subject.keys).to include("companies")
     expect(subject.keys).not_to include("items")
     expect(subject.keys).not_to include("messages")
     expect(subject.keys).not_to include("gogovan_transport")


### PR DESCRIPTION
Hi Team,
This PR is for allowing search on company name for Offer search. Company name is also provided in `Offer Summary` serializer response. 
Please review the PR and let me know if any change is required.