### PR TITLE
GCW-2782 fix stockit_update_job and socket_io job going into loop

### DIFF
--- a/app/jobs/stockit_update_job.rb
+++ b/app/jobs/stockit_update_job.rb
@@ -10,7 +10,7 @@ class StockitUpdateJob < ActiveJob::Base
       # if Stockit can't find the item, it will create a new one and return the stockit_id
       # We need to update the stockit_id of the GoodCity package in this case.
       stockit_id = response['id']
-      package.update_attribute(:stockit_id, stockit_id) unless stockit_id.blank?
+      package.update_column(:stockit_id, stockit_id) unless stockit_id.blank?
 
       if response && (errors = response["errors"] || response[:errors])
         log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"


### PR DESCRIPTION
Hi Team,

This PR fixes stockit_update_job and socket jobs going in loop.

Reason: 
update_attrubute fires callbacks and only skips validations unlinke  in rails 2.
https://maxivak.com/update_attribute-and-update_attributes-ruby-on-rails/

Please review.

Thanks.