### PR TITLE
Look in packages table for existing inventory numbers.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     net-ssh (5.0.2)
     netrc (0.11.0)
     newrelic_rpm (5.2.0.345)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)

--- a/app/models/inventory_number.rb
+++ b/app/models/inventory_number.rb
@@ -15,10 +15,17 @@ class InventoryNumber < ActiveRecord::Base
   def self.missing_code
     sql_for_missing_code = sanitize_sql_array([
       "SELECT s.i AS first_missing_code
-        FROM generate_series(1,?) s(i)
-        WHERE NOT EXISTS (SELECT 1 FROM inventory_numbers WHERE CAST(code AS INTEGER) = s.i)
-        ORDER BY first_missing_code
-        LIMIT 1", count])
+       FROM generate_series(1,?) s(i)
+       WHERE NOT EXISTS (
+         SELECT 1 FROM (
+           SELECT inventory_number FROM packages WHERE inventory_number ~ '^\d+$' 
+           UNION 
+           SELECT code as inventory_number from inventory_numbers ORDER BY inventory_number
+         ) as inventory_number
+       WHERE CAST(inventory_number AS INTEGER) = s.i)
+       ORDER BY first_missing_code
+       LIMIT 1", self.count])
+
     missing_number = ActiveRecord::Base.connection.exec_query(sql_for_missing_code).first || {}
     (missing_number["first_missing_code"] || 0).to_i
   end

--- a/spec/models/inventory_number_spec.rb
+++ b/spec/models/inventory_number_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe InventoryNumber, type: :model do
     end
 
     it "assigns count of inventory code during create" do
-      InventoryNumber.create(code: 1)
-      InventoryNumber.create(code: 2)
-      InventoryNumber.create(code: 3)
+      InventoryNumber.create(code: "000001")
+      InventoryNumber.create(code: "000002")
+      InventoryNumber.create(code: "000003")
       InventoryNumber.create_with_next_code!
-      expect(InventoryNumber.last.code).to eql(InventoryNumber.count.to_s.rjust(6, "0"))
+      expect(InventoryNumber.last.code).to eql("000004")
     end
   end
 
@@ -37,13 +37,21 @@ RSpec.describe InventoryNumber, type: :model do
 
   context "missing_code" do
     it "locates missing entry" do
-      InventoryNumber.create(code: 1)
-      InventoryNumber.create(code: 3)
+      InventoryNumber.create(code: "000001")
+      InventoryNumber.create(code: "000003")
       expect(InventoryNumber.missing_code).to eql(2)
     end
     it "returns 0 if empty table" do
       expect(InventoryNumber.missing_code).to eql(0)
     end
+
+    it "missing in inventory numbers table but exists in the packages table" do
+      InventoryNumber.create(code: "000001")
+      create(:package, inventory_number: "000001")
+      create(:package, inventory_number: "000002")
+      expect(InventoryNumber.missing_code).to eql(3)
+    end
+
   end
 
 end

--- a/spec/models/inventory_number_spec.rb
+++ b/spec/models/inventory_number_spec.rb
@@ -42,14 +42,16 @@ RSpec.describe InventoryNumber, type: :model do
       expect(InventoryNumber.missing_code).to eql(2)
     end
     it "returns 0 if empty table" do
-      expect(InventoryNumber.missing_code).to eql(0)
+      expect(InventoryNumber.missing_code).to eql(0) # no missing code
+      expect(InventoryNumber.next_code).to eql("000001")
     end
 
     it "missing in inventory numbers table but exists in the packages table" do
       InventoryNumber.create(code: "000001")
       create(:package, inventory_number: "000001")
       create(:package, inventory_number: "000002")
-      expect(InventoryNumber.missing_code).to eql(3)
+      expect(InventoryNumber.missing_code).to eql(0) # no missing code
+      expect(InventoryNumber.next_code).to eql("000003")
     end
 
   end


### PR DESCRIPTION
This is the fix to ensure that inventory numbers reserved in the packages table are taken into account when choosing the next one.

There is one spec failure because the code is returning '000000' as the next number. If you create a package with inventory number '000000' then the spec passes. I think we should adjust the code to start counting from 1 rather than 0.

@patrixr  can I hand this to you?