### PR TITLE
GCW-2781 Add & sync status column to package_types table & use in stock app

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -21,11 +21,7 @@ module Api
       end
 
       def create
-        if @company.save
-          render json: @company, serializer: serializer, status: 201
-        else
-          render json: { errors: @company.errors.full_messages.map { |message| { message: message } } }, status: 422
-        end
+        save_and_render_object_with_errors(@company)
       end
 
       def index

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -15,7 +15,7 @@ module Api
       def_param_group :company do
         param :company, Hash, required: true do
           param :name, String, desc: "name of the company"
-          param :crm_id, Integer, desc: "CRM Id"
+          param :crm_id, Integer, desc: "CRM Id", allow_nil: true
           param :created_by_id, Integer, desc: "Id of user who created company record"
         end
       end
@@ -40,7 +40,7 @@ module Api
         if @company.update_attributes(company_params)
           render json: @company, serializer: serializer
         else
-          render_errors
+          render_error(@company.errors.full_messages.join('. '))
         end
       end
 

--- a/app/controllers/api/v1/inventory_numbers_controller.rb
+++ b/app/controllers/api/v1/inventory_numbers_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       api :PUT, "/v1/inventory_numbers", "Delete inventory_number"
       def remove_number
-        InventoryNumber.find_by(code: params[:code]).destroy
+        InventoryNumber.find_by(code: params[:code]).try(:destroy)
         render json: {}
       end
     end

--- a/app/controllers/api/v1/package_types_controller.rb
+++ b/app/controllers/api/v1/package_types_controller.rb
@@ -35,7 +35,7 @@ module Api
       private
 
       def package_type_params
-        params.require(:package_type).permit(:stockit_id, :code, :name_en, :name_zh_tw, :visible_in_selects, :allow_requests)
+        params.require(:package_type).permit(:stockit_id, :code, :name_en, :name_zh_tw, :visible_in_selects, :allow_requests, :allow_stock)
       end
 
       def serializer

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -135,7 +135,7 @@ module Api
           with_inventory_no: params['withInventoryNumber'] == 'true') if params['searchText'].present?
         params_for_filter = ['state', 'location'].each_with_object({}){|k, h| h[k] = params[k] if params[k].present?}
         records = records.filter(params_for_filter)
-        records = records.order('packages.id desc').offset(page - 1).limit(per_page)
+        records = records.order('packages.id desc').page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
         packages = ActiveModel::ArraySerializer.new(records,
           each_serializer: stock_serializer,
           root: "items",
@@ -144,7 +144,7 @@ module Api
           include_orders_packages: true,
           exclude_stockit_set_item: true,
           include_images: true).as_json
-        render json: {meta: { search: params['searchText'] } }.merge(packages)
+        render json: { meta: { total_pages: records.total_pages, search: params['searchText'] } }.merge(packages)
       end
 
       def designate_stockit_item(order_id)

--- a/app/jobs/stockit_update_job.rb
+++ b/app/jobs/stockit_update_job.rb
@@ -9,13 +9,15 @@ class StockitUpdateJob < ActiveJob::Base
 
       # if Stockit can't find the item, it will create a new one and return the stockit_id
       # We need to update the stockit_id of the GoodCity package in this case.
-      stockit_id = response['id']
-      package.update_column(:stockit_id, stockit_id) unless stockit_id.blank?
+      if response
+        stockit_id = response['id']
+        package.update_column(:stockit_id, stockit_id) unless stockit_id.blank?
 
-      if response && (errors = response["errors"] || response[:errors])
-        log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"
-        errors.each { |attribute, error| log_text += " #{attribute}: #{error}" }
-        logger.error log_text
+        if (errors = response["errors"] || response[:errors])
+          log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"
+          errors.each { |attribute, error| log_text += " #{attribute}: #{error}" }
+          logger.error log_text
+        end
       end
     end
   end

--- a/app/models/appointment_slot.rb
+++ b/app/models/appointment_slot.rb
@@ -47,7 +47,7 @@ class AppointmentSlot < ActiveRecord::Base
       sl.quota.positive?
     } unless slots.empty?
 
-    return [] if Holiday.is_holiday(date)
+    return [] if Holiday.is_holiday?(date)
 
     # Generate slots based on preset if no special slot have been specified for that date
     AppointmentSlotPreset

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -10,7 +10,7 @@ class Holiday < ActiveRecord::Base
   scope :within_days, ->(days) {
     between_times(Time.zone.now.beginning_of_day, Time.zone.now.end_of_day + days) }
 
-  def self.is_holiday(date)
+  def self.is_holiday?(date)
     Holiday.where(" date(holiday AT TIME ZONE 'HKT') = ?", date.to_date).count > 0
   end
 

--- a/app/models/package_type.rb
+++ b/app/models/package_type.rb
@@ -27,7 +27,7 @@ class PackageType < ActiveRecord::Base
 
   translates :name, :other_terms
 
-  scope :visible, -> { where(visible_in_selects: true) }
+  scope :visible, -> { where(allow_stock: true) }
 
   private
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,9 @@ en:
   notification:
     new_offer: New offer submitted by %{name}
     new_order: "New order from %{organisation_name_en}: %{contact_name}"
+  schedule:
+    bad_date: The selected date is either missing or invalid, please try again.
+    holiday_conflict: Crossroads will be closed on the %{date} due to a public holiday. Please select a different date.
   offer:
     thank_message: Thank you for your offer, our team will start reviewing it
       soon. The reviewer will message you if they have questions about any of

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -55,6 +55,9 @@ zh-tw:
   notification:
     new_offer: "%{name} 的新捐獻。"
     new_order: "New order from %{organisation_name_zh_tw}: %{contact_name}"
+  schedule:
+    bad_date: The selected date is either missing or invalid, please try again.
+    holiday_conflict: Crossroads will be closed on the %{date} due to a public holiday. Please select a different date.
   offer:
     thank_message: 感謝您的捐獻，我們的團隊很快就會開始審查。假如審查員有任何關於捐獻物資的疑問，他們會以訊息向您查詢。由於儲存空間有限，社區的需要亦經常改變，我們可能無法接收部分物資。為此，我們深感遺憾，並先就此道歉。當審查完成時，您就能立刻安排已接受的物資的運輸。假如您有任何疑問，請隨時回覆此信息。
     ggv_cancel_message: GoGoVan已取消預約於 %{time} 的貨車，請重新安排運輸。

--- a/db/migrate/20190913102426_add_allow_stock_to_package_types.rb
+++ b/db/migrate/20190913102426_add_allow_stock_to_package_types.rb
@@ -1,0 +1,5 @@
+class AddAllowStockToPackageTypes < ActiveRecord::Migration
+  def change
+    add_column :package_types, :allow_stock, :boolean, default: false
+  end
+end

--- a/db/package_categories_package_type.yml
+++ b/db/package_categories_package_type.yml
@@ -1019,3 +1019,1543 @@
   :code: FWT
   :lv1: Furniture
   :lv2: Sets
+256:
+  :code: AZ
+  :lv1: Small goods & bulk items
+  :lv2: Food
+257:
+  :code: B
+  :lv1: Furniture
+  :lv2: Beds
+258:
+  :code: BB
+  :lv1: Furniture
+  :lv2: Beds
+259:
+  :code: BB
+  :lv1: Furniture
+  :lv2: Baby / child
+260:
+  :code: BBX
+  :lv1: Furniture
+  :lv2: Beds
+261:
+  :code: BBX
+  :lv1: Furniture
+  :lv2: Baby / child
+262:
+  :code: BC
+  :lv1: Furniture
+  :lv2: Beds
+263:
+  :code: BC
+  :lv1: Furniture
+  :lv2: Baby / child
+264:
+  :code: BD
+  :lv1: Furniture
+  :lv2: Beds
+265:
+  :code: BK
+  :lv1: Furniture
+  :lv2: Beds
+266:
+  :code: BL
+  :lv1: Furniture
+  :lv2: Beds
+267:
+  :code: BS
+  :lv1: Furniture
+  :lv2: Beds
+268:
+  :code: BT
+  :lv1: Furniture
+  :lv2: Beds
+269:
+  :code: CB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+270:
+  :code: CB
+  :lv1: Household
+  :lv2: Textiles / clothes
+271:
+  :code: CB
+  :lv1: Small goods & bulk items
+  :lv2: Household textiles
+272:
+  :code: CBB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+273:
+  :code: CBB
+  :lv1: Household
+  :lv2: Textiles / clothes
+274:
+  :code: CBB
+  :lv1: Small goods & bulk items
+  :lv2: Household textiles
+275:
+  :code: CBC
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+276:
+  :code: CBC
+  :lv1: Household
+  :lv2: Textiles / clothes
+277:
+  :code: CBC
+  :lv1: Small goods & bulk items
+  :lv2: Household textiles
+278:
+  :code: CBP
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+279:
+  :code: CBP
+  :lv1: Household
+  :lv2: Textiles / clothes
+280:
+  :code: CBP
+  :lv1: Small goods & bulk items
+  :lv2: Household textiles
+281:
+  :code: CBS
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+282:
+  :code: CBS
+  :lv1: Household
+  :lv2: Textiles / clothes
+283:
+  :code: CBS
+  :lv1: Small goods & bulk items
+  :lv2: Household textiles
+284:
+  :code: CBX
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+285:
+  :code: CBX
+  :lv1: Household
+  :lv2: Textiles / clothes
+286:
+  :code: CCB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+287:
+  :code: CCB
+  :lv1: Household
+  :lv2: Textiles / clothes
+288:
+  :code: CH
+  :lv1: Recreation
+  :lv2: Other
+289:
+  :code: CH
+  :lv1: Household
+  :lv2: Textiles / clothes
+290:
+  :code: CHC
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+291:
+  :code: CHC
+  :lv1: Household
+  :lv2: Textiles / clothes
+292:
+  :code: CHF
+  :lv1: Household
+  :lv2: Textiles / clothes
+293:
+  :code: CHP
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+294:
+  :code: CHP
+  :lv1: Household
+  :lv2: Textiles / clothes
+295:
+  :code: CHS
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+296:
+  :code: CHS
+  :lv1: Household
+  :lv2: Textiles / clothes
+297:
+  :code: CHT
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+298:
+  :code: CHT
+  :lv1: Household
+  :lv2: Textiles / clothes
+299:
+  :code: CHX
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+300:
+  :code: CHX
+  :lv1: Household
+  :lv2: Textiles / clothes
+301:
+  :code: CLA
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+302:
+  :code: CLA
+  :lv1: Household
+  :lv2: Textiles / clothes
+303:
+  :code: CLB
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+304:
+  :code: CLB
+  :lv1: Household
+  :lv2: Textiles / clothes
+305:
+  :code: CLC
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+306:
+  :code: CLC
+  :lv1: Household
+  :lv2: Textiles / clothes
+307:
+  :code: CLD
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+308:
+  :code: CLD
+  :lv1: Household
+  :lv2: Textiles / clothes
+309:
+  :code: CLE
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+310:
+  :code: CLE
+  :lv1: Household
+  :lv2: Textiles / clothes
+311:
+  :code: CLF
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+312:
+  :code: CLF
+  :lv1: Household
+  :lv2: Textiles / clothes
+313:
+  :code: CLR
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+314:
+  :code: CLR
+  :lv1: Household
+  :lv2: Textiles / clothes
+315:
+  :code: CLS
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+316:
+  :code: CLS
+  :lv1: Household
+  :lv2: Textiles / clothes
+317:
+  :code: CLT
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+318:
+  :code: CLT
+  :lv1: Household
+  :lv2: Textiles / clothes
+319:
+  :code: CLX
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+320:
+  :code: CLX
+  :lv1: Household
+  :lv2: Textiles / clothes
+321:
+  :code: CLZA
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+322:
+  :code: CLZA
+  :lv1: Household
+  :lv2: Textiles / clothes
+323:
+  :code: CLZB
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+324:
+  :code: CLZB
+  :lv1: Household
+  :lv2: Textiles / clothes
+325:
+  :code: CLZC
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+326:
+  :code: CLZC
+  :lv1: Household
+  :lv2: Textiles / clothes
+327:
+  :code: CLZM
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+328:
+  :code: CLZM
+  :lv1: Household
+  :lv2: Textiles / clothes
+329:
+  :code: CLZN
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+330:
+  :code: CLZN
+  :lv1: Household
+  :lv2: Textiles / clothes
+331:
+  :code: CLZU
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+332:
+  :code: CLZU
+  :lv1: Household
+  :lv2: Textiles / clothes
+333:
+  :code: CLZV
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+334:
+  :code: CLZV
+  :lv1: Household
+  :lv2: Textiles / clothes
+335:
+  :code: CLZW
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+336:
+  :code: CLZW
+  :lv1: Household
+  :lv2: Textiles / clothes
+337:
+  :code: CLZX
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+338:
+  :code: CLZX
+  :lv1: Household
+  :lv2: Textiles / clothes
+339:
+  :code: CTL
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+340:
+  :code: CTL
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+341:
+  :code: CX
+  :lv1: Household
+  :lv2: Textiles / clothes
+342:
+  :code: CX
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+343:
+  :code: D
+  :lv1: Small goods & bulk items
+  :lv2: Tools
+344:
+  :code: DB
+  :lv1: Small goods & bulk items
+  :lv2: Tools
+345:
+  :code: DE
+  :lv1: Small goods & bulk items
+  :lv2: Tools
+346:
+  :code: EH
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+347:
+  :code: EH
+  :lv1: Electrical
+  :lv2: Household
+348:
+  :code: EK
+  :lv1: Electrical
+  :lv2: Kitchen
+349:
+  :code: EK
+  :lv1: Household
+  :lv2: Appliances
+350:
+  :code: EK
+  :lv1: Electrical
+  :lv2: Household
+351:
+  :code: EKC
+  :lv1: Electrical
+  :lv2: Household
+352:
+  :code: EKD
+  :lv1: Electrical
+  :lv2: Household
+353:
+  :code: EKF
+  :lv1: Electrical
+  :lv2: Household
+354:
+  :code: EKH
+  :lv1: Electrical
+  :lv2: Household
+355:
+  :code: EKI
+  :lv1: Electrical
+  :lv2: Household
+356:
+  :code: EKJ
+  :lv1: Electrical
+  :lv2: Household
+357:
+  :code: EKK
+  :lv1: Electrical
+  :lv2: Household
+358:
+  :code: EKL
+  :lv1: Electrical
+  :lv2: Household
+359:
+  :code: EKM
+  :lv1: Electrical
+  :lv2: Household
+360:
+  :code: EKP
+  :lv1: Electrical
+  :lv2: Household
+361:
+  :code: EKR
+  :lv1: Electrical
+  :lv2: Household
+362:
+  :code: EKS
+  :lv1: Electrical
+  :lv2: Household
+363:
+  :code: EKT
+  :lv1: Electrical
+  :lv2: Household
+364:
+  :code: EKX
+  :lv1: Electrical
+  :lv2: Household
+365:
+  :code: EO
+  :lv1: Electrical
+  :lv2: Office appliances
+366:
+  :code: EOM
+  :lv1: Electrical
+  :lv2: Office appliances
+367:
+  :code: EOM
+  :lv1: Electrical
+  :lv2: Computer
+368:
+  :code: EOP
+  :lv1: Electrical
+  :lv2: Computer
+369:
+  :code: EU
+  :lv1: Electrical
+  :lv2: Audio visual
+370:
+  :code: EUC
+  :lv1: Electrical
+  :lv2: Audio visual
+371:
+  :code: EUN
+  :lv1: Electrical
+  :lv2: Audio visual
+372:
+  :code: EUP
+  :lv1: Electrical
+  :lv2: Audio visual
+373:
+  :code: EUU
+  :lv1: Electrical
+  :lv2: Audio visual
+374:
+  :code: EV
+  :lv1: Electrical
+  :lv2: Audio visual
+375:
+  :code: EVC
+  :lv1: Electrical
+  :lv2: Audio visual
+376:
+  :code: EVP
+  :lv1: Furniture
+  :lv2: Office furniture
+377:
+  :code: EVQ
+  :lv1: Furniture
+  :lv2: Office furniture
+378:
+  :code: EVS
+  :lv1: Furniture
+  :lv2: Office furniture
+379:
+  :code: EXB
+  :lv1: Household
+  :lv2: Hygiene items
+380:
+  :code: EXB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+381:
+  :code: EXS
+  :lv1: Electrical
+  :lv2: Household
+382:
+  :code: EZB
+  :lv1: Household
+  :lv2: Appliances
+383:
+  :code: EZC
+  :lv1: Household
+  :lv2: Appliances
+384:
+  :code: EZH
+  :lv1: Household
+  :lv2: Appliances
+385:
+  :code: EZO
+  :lv1: Household
+  :lv2: Appliances
+386:
+  :code: EZT
+  :lv1: Household
+  :lv2: Appliances
+387:
+  :code: EZV
+  :lv1: Household
+  :lv2: Appliances
+388:
+  :code: FB
+  :lv1: Furniture
+  :lv2: Storage
+389:
+  :code: FBO
+  :lv1: Furniture
+  :lv2: Other furniture
+390:
+  :code: FBP
+  :lv1: Furniture
+  :lv2: Other furniture
+391:
+  :code: FBR
+  :lv1: Furniture
+  :lv2: Other furniture
+392:
+  :code: FC
+  :lv1: Furniture
+  :lv2: Seating
+393:
+  :code: FCO
+  :lv1: Furniture
+  :lv2: Other furniture
+394:
+  :code: FD
+  :lv1: Furniture
+  :lv2: Desk
+395:
+  :code: FD
+  :lv1: Furniture
+  :lv2: Other furniture
+396:
+  :code: FDO
+  :lv1: Furniture
+  :lv2: Other furniture
+397:
+  :code: FDP
+  :lv1: Furniture
+  :lv2: Other furniture
+398:
+  :code: FDT
+  :lv1: Furniture
+  :lv2: Desk
+399:
+  :code: FDT
+  :lv1: Furniture
+  :lv2: Other furniture
+400:
+  :code: FS
+  :lv1: Furniture
+  :lv2: Shelves
+401:
+  :code: FS
+  :lv1: Furniture
+  :lv2: Storage
+402:
+  :code: FSB
+  :lv1: Furniture
+  :lv2: Storage
+403:
+  :code: FSC
+  :lv1: Furniture
+  :lv2: Storage
+404:
+  :code: FSD
+  :lv1: Furniture
+  :lv2: Storage
+405:
+  :code: FSD
+  :lv1: Furniture
+  :lv2: Other furniture
+406:
+  :code: FSO
+  :lv1: Furniture
+  :lv2: Storage
+407:
+  :code: FSR
+  :lv1: Furniture
+  :lv2: Shelves
+408:
+  :code: FSS
+  :lv1: Furniture
+  :lv2: Shelves
+409:
+  :code: FSX
+  :lv1: Furniture
+  :lv2: Storage
+410:
+  :code: FT
+  :lv1: Furniture
+  :lv2: Table
+411:
+  :code: FTO
+  :lv1: Furniture
+  :lv2: Other furniture
+412:
+  :code: FW
+  :lv1: Furniture
+  :lv2: Sets
+413:
+  :code: FXB
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+414:
+  :code: FXH
+  :lv1: Furniture
+  :lv2: Storage
+415:
+  :code: FXM
+  :lv1: Household
+  :lv2: Other household
+416:
+  :code: FXU
+  :lv1: Furniture
+  :lv2: Sets
+417:
+  :code: GCB
+  :lv1: Household
+  :lv2: Baby
+418:
+  :code: GCB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+419:
+  :code: GCB
+  :lv1: Furniture
+  :lv2: Seating
+420:
+  :code: HA
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+421:
+  :code: HA
+  :lv1: Household
+  :lv2: Hygiene items
+422:
+  :code: HB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+423:
+  :code: HD
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+424:
+  :code: HK
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+425:
+  :code: HN
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+426:
+  :code: HP
+  :lv1: Household
+  :lv2: Baby
+427:
+  :code: HPB
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+428:
+  :code: HPB
+  :lv1: Household
+  :lv2: Hygiene items
+429:
+  :code: HPC
+  :lv1: Furniture
+  :lv2: Seating
+430:
+  :code: HPH
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+431:
+  :code: HPH
+  :lv1: Furniture
+  :lv2: Seating
+432:
+  :code: HPW
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+433:
+  :code: HPX
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+434:
+  :code: HPX
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+435:
+  :code: HX
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+436:
+  :code: HX
+  :lv1: Household
+  :lv2: Hygiene items
+437:
+  :code: HXB
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+438:
+  :code: HXT
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+439:
+  :code: HY
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+440:
+  :code: HY
+  :lv1: Household
+  :lv2: Hygiene items
+441:
+  :code: HZK
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+442:
+  :code: HZO
+  :lv1: Household
+  :lv2: Kitchen, bedroom, bathroom, dining
+443:
+  :code: HZT
+  :lv1: Small goods & bulk items
+  :lv2: Clothing & accessories
+444:
+  :code: MD
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+445:
+  :code: MDA
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+446:
+  :code: MDB
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+447:
+  :code: MDC
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+448:
+  :code: MDD
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+449:
+  :code: MDE
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+450:
+  :code: MDG
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+451:
+  :code: MDH
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+452:
+  :code: MDL
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+453:
+  :code: MDM
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+454:
+  :code: MDN
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+455:
+  :code: MDP
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+456:
+  :code: MDQ
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+457:
+  :code: MDR
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+458:
+  :code: MDS
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+459:
+  :code: MDU
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+460:
+  :code: MDV
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+461:
+  :code: MDW
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+462:
+  :code: MDY
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+463:
+  :code: ME
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+464:
+  :code: MEB
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+465:
+  :code: MEF
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+466:
+  :code: MEG
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+467:
+  :code: MEH
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+468:
+  :code: MEL
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+469:
+  :code: MEL0
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+470:
+  :code: MEL1
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+471:
+  :code: MEL2
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+472:
+  :code: MEL3
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+473:
+  :code: MEN
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+474:
+  :code: MES
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+475:
+  :code: MES0
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+476:
+  :code: MES1
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+477:
+  :code: MES2
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+478:
+  :code: MES3
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+479:
+  :code: MES4
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+480:
+  :code: MES5
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+481:
+  :code: MES6
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+482:
+  :code: MES7
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+483:
+  :code: MES8
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+484:
+  :code: MES9
+  :lv1: Small goods & bulk items
+  :lv2: Glasses
+485:
+  :code: MF
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+486:
+  :code: MFA
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+487:
+  :code: MFB
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+488:
+  :code: MFC
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+489:
+  :code: MFD
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+490:
+  :code: MFE
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+491:
+  :code: MFE
+  :lv1: Furniture
+  :lv2: Storage
+492:
+  :code: MFF
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+493:
+  :code: MFF
+  :lv1: Furniture
+  :lv2: Storage
+494:
+  :code: MFG
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+495:
+  :code: MFG
+  :lv1: Furniture
+  :lv2: Seating
+496:
+  :code: MFH
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+497:
+  :code: MFI
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+498:
+  :code: MFP
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+499:
+  :code: MFS
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+500:
+  :code: MFT
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+501:
+  :code: MFT
+  :lv1: Furniture
+  :lv2: Storage
+502:
+  :code: MFV
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+503:
+  :code: MFW
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+504:
+  :code: MFX
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+505:
+  :code: MG
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+506:
+  :code: MGA
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+507:
+  :code: MGB
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+508:
+  :code: MGE
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+509:
+  :code: MGF
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+510:
+  :code: MGG
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+511:
+  :code: MGM
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+512:
+  :code: MGN
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+513:
+  :code: MGO
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+514:
+  :code: MGP
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+515:
+  :code: MGS
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+516:
+  :code: MGT
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+517:
+  :code: MGU
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+518:
+  :code: MGV
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+519:
+  :code: MGW
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+520:
+  :code: MI
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+521:
+  :code: ML
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+522:
+  :code: MP
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+523:
+  :code: MS
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+524:
+  :code: MSA
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+525:
+  :code: MSC
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+526:
+  :code: MSD
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+527:
+  :code: MSE
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+528:
+  :code: MSN
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+529:
+  :code: MSO
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+530:
+  :code: MST
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+531:
+  :code: MSU
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+532:
+  :code: MSX
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+533:
+  :code: MT
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+534:
+  :code: MV
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+535:
+  :code: MVB
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+536:
+  :code: MVC
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+537:
+  :code: MVE
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+538:
+  :code: MVG
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+539:
+  :code: MVM
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+540:
+  :code: MVO
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+541:
+  :code: MVP
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+542:
+  :code: MVS
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+543:
+  :code: MVT
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+544:
+  :code: MVW
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+545:
+  :code: MVW
+  :lv1: Small goods & bulk items
+  :lv2: Books
+546:
+  :code: MVX
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+547:
+  :code: MW
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+548:
+  :code: MZ
+  :lv1: Small goods & bulk items
+  :lv2: Medical
+549:
+  :code: 'NO'
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+550:
+  :code: NOA
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+551:
+  :code: NOP
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+552:
+  :code: NOX
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+553:
+  :code: NQ
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+554:
+  :code: NQA
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+555:
+  :code: NQP
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+556:
+  :code: NQX
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+557:
+  :code: NX
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+558:
+  :code: NZ
+  :lv1: Small goods & bulk items
+  :lv2: Stationery
+559:
+  :code: PC
+  :lv1: Small goods & bulk items
+  :lv2: Books
+560:
+  :code: PCP
+  :lv1: Small goods & bulk items
+  :lv2: Books
+561:
+  :code: PCS
+  :lv1: Small goods & bulk items
+  :lv2: Books
+562:
+  :code: PCX
+  :lv1: Small goods & bulk items
+  :lv2: Books
+563:
+  :code: PD
+  :lv1: Small goods & bulk items
+  :lv2: Books
+564:
+  :code: PDA
+  :lv1: Small goods & bulk items
+  :lv2: Books
+565:
+  :code: PDB
+  :lv1: Small goods & bulk items
+  :lv2: Books
+566:
+  :code: PDC
+  :lv1: Small goods & bulk items
+  :lv2: Books
+567:
+  :code: PDD
+  :lv1: Small goods & bulk items
+  :lv2: Books
+568:
+  :code: PE
+  :lv1: Small goods & bulk items
+  :lv2: Books
+569:
+  :code: PEP
+  :lv1: Small goods & bulk items
+  :lv2: Books
+570:
+  :code: PES
+  :lv1: Small goods & bulk items
+  :lv2: Books
+571:
+  :code: PET
+  :lv1: Small goods & bulk items
+  :lv2: Books
+572:
+  :code: PF
+  :lv1: Small goods & bulk items
+  :lv2: Books
+573:
+  :code: PFA
+  :lv1: Small goods & bulk items
+  :lv2: Books
+574:
+  :code: PFC
+  :lv1: Small goods & bulk items
+  :lv2: Books
+575:
+  :code: PFE
+  :lv1: Small goods & bulk items
+  :lv2: Books
+576:
+  :code: PG
+  :lv1: Small goods & bulk items
+  :lv2: Books
+577:
+  :code: PGC
+  :lv1: Small goods & bulk items
+  :lv2: Books
+578:
+  :code: PGD
+  :lv1: Small goods & bulk items
+  :lv2: Books
+579:
+  :code: PGF
+  :lv1: Small goods & bulk items
+  :lv2: Books
+580:
+  :code: PGG
+  :lv1: Small goods & bulk items
+  :lv2: Books
+581:
+  :code: PGR
+  :lv1: Small goods & bulk items
+  :lv2: Books
+582:
+  :code: PL
+  :lv1: Small goods & bulk items
+  :lv2: Books
+583:
+  :code: PM
+  :lv1: Small goods & bulk items
+  :lv2: Books
+584:
+  :code: PMC
+  :lv1: Small goods & bulk items
+  :lv2: Books
+585:
+  :code: PME
+  :lv1: Small goods & bulk items
+  :lv2: Books
+586:
+  :code: PMX
+  :lv1: Small goods & bulk items
+  :lv2: Books
+587:
+  :code: PV
+  :lv1: Recreation
+  :lv2: Other
+588:
+  :code: PVC
+  :lv1: Recreation
+  :lv2: Other
+589:
+  :code: PVE
+  :lv1: Recreation
+  :lv2: Other
+590:
+  :code: PVX
+  :lv1: Recreation
+  :lv2: Other
+591:
+  :code: PW
+  :lv1: Recreation
+  :lv2: Other
+592:
+  :code: PWC
+  :lv1: Recreation
+  :lv2: Other
+593:
+  :code: PWE
+  :lv1: Recreation
+  :lv2: Other
+594:
+  :code: PWX
+  :lv1: Recreation
+  :lv2: Other
+595:
+  :code: PX
+  :lv1: Recreation
+  :lv2: Other
+596:
+  :code: RC
+  :lv1: Recreation
+  :lv2: Other
+597:
+  :code: RCM
+  :lv1: Recreation
+  :lv2: Other
+598:
+  :code: RCT
+  :lv1: Recreation
+  :lv2: Other
+599:
+  :code: REW
+  :lv1: Recreation
+  :lv2: Sport
+600:
+  :code: REX
+  :lv1: Recreation
+  :lv2: Sport
+601:
+  :code: RM
+  :lv1: Recreation
+  :lv2: Music
+602:
+  :code: RP
+  :lv1: Recreation
+  :lv2: Playground
+603:
+  :code: RP
+  :lv1: Recreation
+  :lv2: Sport
+604:
+  :code: RPA
+  :lv1: Recreation
+  :lv2: Sport
+605:
+  :code: RPB
+  :lv1: Recreation
+  :lv2: Sport
+606:
+  :code: RPR
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+607:
+  :code: RPX
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+608:
+  :code: TB
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+609:
+  :code: TB
+  :lv1: Household
+  :lv2: Baby
+610:
+  :code: TE
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+611:
+  :code: TG
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+612:
+  :code: TL
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+613:
+  :code: TM
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+614:
+  :code: TM
+  :lv1: Recreation
+  :lv2: Music
+615:
+  :code: TP
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+616:
+  :code: TPX
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+617:
+  :code: TR
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+618:
+  :code: TRF
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+619:
+  :code: TRG
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+620:
+  :code: TRG
+  :lv1: Recreation
+  :lv2: Sport
+621:
+  :code: TS
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+622:
+  :code: TT
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+623:
+  :code: TV
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+624:
+  :code: TW
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+625:
+  :code: TX
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+626:
+  :code: TZ
+  :lv1: Small goods & bulk items
+  :lv2: Toys
+627:
+  :code: TZR
+  :lv1: Recreation
+  :lv2: Sport
+628:
+  :code: V
+  :lv1: Electrical
+  :lv2: Computer
+629:
+  :code: VMC
+  :lv1: Electrical
+  :lv2: Computer
+630:
+  :code: VNS
+  :lv1: Electrical
+  :lv2: Computer
+631:
+  :code: VPM
+  :lv1: Electrical
+  :lv2: Computer
+632:
+  :code: VS
+  :lv1: Electrical
+  :lv2: Computer
+633:
+  :code: VSH
+  :lv1: Electrical
+  :lv2: Computer
+634:
+  :code: VSN
+  :lv1: Electrical
+  :lv2: Computer
+635:
+  :code: VXC
+  :lv1: Electrical
+  :lv2: Computer
+636:
+  :code: VXH
+  :lv1: Electrical
+  :lv2: Computer
+637:
+  :code: VZC
+  :lv1: Electrical
+  :lv2: Computer
+638:
+  :code: VZM
+  :lv1: Electrical
+  :lv2: Computer
+639:
+  :code: VZP
+  :lv1: Electrical
+  :lv2: Computer
+640:
+  :code: VZX
+  :lv1: Electrical
+  :lv2: Computer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190917110924) do
+ActiveRecord::Schema.define(version: 20190925110227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,49 @@ ActiveRecord::Schema.define(version: 20190917110924) do
     t.integer  "updated_by_id"
   end
 
+  create_table "computer_accessories", force: :cascade do |t|
+    t.string   "brand"
+    t.string   "model"
+    t.string   "serial_num"
+    t.integer  "country_id"
+    t.string   "size"
+    t.string   "interface"
+    t.string   "comp_voltage"
+    t.string   "comp_test_status"
+    t.integer  "updated_by_id"
+    t.integer  "stockit_id"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  create_table "computers", force: :cascade do |t|
+    t.string   "brand"
+    t.string   "model"
+    t.string   "serial_num"
+    t.integer  "country_id"
+    t.string   "size"
+    t.string   "cpu"
+    t.string   "ram"
+    t.string   "hdd"
+    t.string   "optical"
+    t.string   "video"
+    t.string   "sound"
+    t.string   "lan"
+    t.string   "wireless"
+    t.string   "usb"
+    t.string   "comp_voltage"
+    t.string   "comp_test_status"
+    t.string   "os"
+    t.string   "os_serial_num"
+    t.string   "ms_office_serial_num"
+    t.string   "mar_os_serial_num"
+    t.string   "mar_ms_office_serial_num"
+    t.integer  "updated_by_id"
+    t.integer  "stockit_id"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
   create_table "contacts", force: :cascade do |t|
     t.string   "name"
     t.string   "mobile"
@@ -171,6 +214,24 @@ ActiveRecord::Schema.define(version: 20190917110924) do
     t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "electricals", force: :cascade do |t|
+    t.string   "brand"
+    t.string   "model"
+    t.string   "serial_number"
+    t.integer  "country_id"
+    t.string   "standard"
+    t.integer  "voltage"
+    t.integer  "frequency"
+    t.string   "power"
+    t.string   "system_or_region"
+    t.string   "test_status"
+    t.date     "tested_on"
+    t.integer  "updated_by_id"
+    t.integer  "stockit_id"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
   end
 
   create_table "gogovan_orders", force: :cascade do |t|
@@ -529,7 +590,9 @@ ActiveRecord::Schema.define(version: 20190917110924) do
     t.integer  "stockit_id"
     t.integer  "location_id"
     t.boolean  "allow_requests",     default: true
+    t.boolean  "allow_stock",        default: false
     t.boolean  "allow_pieces",       default: false
+    t.string   "subform"
   end
 
   add_index "package_types", ["allow_requests"], name: "index_package_types_on_allow_requests", using: :btree
@@ -575,14 +638,18 @@ ActiveRecord::Schema.define(version: 20190917110924) do
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
+    t.boolean  "last_allow_web_published"
     t.integer  "weight"
     t.integer  "pieces"
+    t.integer  "detail_id"
+    t.string   "detail_type"
   end
 
   add_index "packages", ["allow_web_publish"], name: "index_packages_on_allow_web_publish", using: :btree
   add_index "packages", ["box_id"], name: "index_packages_on_box_id", using: :btree
   add_index "packages", ["case_number"], name: "index_packages_on_case_number", using: :gin
   add_index "packages", ["designation_name"], name: "index_packages_on_designation_name", using: :gin
+  add_index "packages", ["detail_type", "detail_id"], name: "index_packages_on_detail_type_and_detail_id", using: :btree
   add_index "packages", ["donor_condition_id"], name: "index_packages_on_donor_condition_id", using: :btree
   add_index "packages", ["inventory_number"], name: "inventory_numbers_search_idx", using: :gin
   add_index "packages", ["item_id"], name: "index_packages_on_item_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -886,7 +886,7 @@ ActiveRecord::Schema.define(version: 20190925110227) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))", using: :btree
+  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))", using: :btree
   add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
   add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,6 @@ ActiveRecord::Schema.define(version: 20190917110924) do
   enable_extension "plpgsql"
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
-  enable_extension "pgcrypto"
 
   create_table "addresses", force: :cascade do |t|
     t.string   "flat"
@@ -576,7 +575,6 @@ ActiveRecord::Schema.define(version: 20190917110924) do
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
-    t.boolean  "last_allow_web_published"
     t.integer  "weight"
     t.integer  "pieces"
   end

--- a/lib/classes/package_category_importer.rb
+++ b/lib/classes/package_category_importer.rb
@@ -27,7 +27,7 @@ class PackageCategoryImporter
       package_category = PackageCategory.find_by(name_en: value[:lv2])
 
       if package && package_category
-        PackageCategoriesPackageType.create(
+        PackageCategoriesPackageType.first_or_create(
           package_type_id:     package.id,
           package_category_id: package_category.id
         )

--- a/lib/tasks/package_types.rake
+++ b/lib/tasks/package_types.rake
@@ -27,9 +27,46 @@ namespace :goodcity do
     end
   end
 
+
   desc 'Update PackageType/PackageCategory mapping'
   task update_package_types_package_categories: :environment do
     PackageCategoryImporter.import_package_relation
   end
 
+  # rake goodcity:update_allow_stock_to_stockit_codes_status
+  desc 'Update PackageType `allow_stock` according to `Codes.status` from Stockit'
+  task update_allow_stock_to_stockit_codes_status: :environment do
+    STATUS_AND_ALLOW_STOCK_MAPPING = {
+      "Active" => true,
+      "Inactive" => false
+    }.freeze
+    log = Goodcity::RakeLogger.new("update_allow_stock_to_stockit_codes_status")
+    updated_record_count = 0
+    failed_record_count = 0
+    failed_package_type_ids = []
+    codes_json = Stockit::CodeSync.index
+    stockit_codes = JSON.parse(codes_json["codes"]) || {}
+    stockit_codes.each do |code|
+      if active?(code["status"]) and package_type = get_package_type(code["id"])
+        if package_type.update_column(:allow_stock, true)
+          updated_record_count += 1
+        else
+          failed_record_count += 1
+          failed_package_type_ids << package_type.id
+        end
+      end
+    end
+    log.info("TOTAL Record = #{stockit_codes.count}")
+    log.info("TOTAL UPDATED RECORD = #{updated_record_count}")
+    log.info("TOTAL FAILED UPDATES = #{failed_record_count}")
+    log.info("LIST OF FAILED RECORDS = #{failed_package_type_ids}")
+  end
+
+  def get_package_type(id)
+    PackageType.find_by(stockit_id: id)
+  end
+
+  def active?(status)
+    STATUS_AND_ALLOW_STOCK_MAPPING[status]
+  end
 end

--- a/lib/tasks/package_types.rake
+++ b/lib/tasks/package_types.rake
@@ -27,4 +27,9 @@ namespace :goodcity do
     end
   end
 
+  desc 'Update PackageType/PackageCategory mapping'
+  task update_package_types_package_categories: :environment do
+    PackageCategoryImporter.import_package_relation
+  end
+
 end

--- a/spec/controllers/api/v1/inventory_numbers_controller_spec.rb
+++ b/spec/controllers/api/v1/inventory_numbers_controller_spec.rb
@@ -26,5 +26,13 @@ RSpec.describe Api::V1::InventoryNumbersController, type: :controller do
       expect(response.status).to eq(200)
       expect(parsed_body).to eq( {} )
     end
+
+    it 'returns blank response if inventory_number do not exist in db' do
+      expect {
+        post :remove_number, code: rand(1000..9999)
+      }.to change(InventoryNumber, :count).by(0)
+      expect(response.status).to eq(200)
+      expect(parsed_body).to eq({})
+    end
   end
 end

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -731,5 +731,23 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(response.status).to eq(200)
       expect(subject["items"].count).to eq(1)
     end
+
+    it "response should have total_pages, and search in meta data" do
+      create(:package, inventory_number: "F00001Q1")
+      create(:package, inventory_number: "F00001Q2")
+      create(:package, inventory_number: "F00001Q3")
+      searchText = 'F00001Q'
+      params = {
+        searchText: searchText,
+        stockRequest: true,
+        restrictMultiQuantity: 'true',
+        withInventoryNumber: 'true',
+        page:1,
+        per_page:25
+      }
+      get :search_stockit_items, params
+      expect(subject["meta"]["search"]).to eq(searchText)
+      expect(subject["meta"].keys).to include("total_pages")
+    end
   end
 end

--- a/spec/models/package_type_spec.rb
+++ b/spec/models/package_type_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe PackageType, type: :model do
     it { is_expected.to have_db_column(:other_terms_en).of_type(:string) }
     it { is_expected.to have_db_column(:other_terms_zh_tw).of_type(:string) }
     it { is_expected.to have_db_column(:allow_pieces).of_type(:boolean) }
+    it { is_expected.to have_db_column(:allow_stock).of_type(:boolean) }
   end
 
   describe 'Associations' do

--- a/spec/models/package_type_spec.rb
+++ b/spec/models/package_type_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe PackageType, type: :model do
 
   describe 'scope' do
     describe "visible" do
-      it "returns records with visible_in_selects true value" do
-        expect(PackageType.visible.to_sql).to include("WHERE \"package_types\".\"visible_in_selects\" = 't'")
+      it "returns records with allow_stock true value" do
+        expect(PackageType.visible.to_sql).to include("WHERE \"package_types\".\"allow_stock\" = 't'")
       end
     end
   end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2781

### What does this PR do?

FEATURE: Sync StockIt's `codes.status` field with a new field in GoodCity `package_types.allow_stock`
Also added rake task to update `package_types.allow_stock` with Stockit `codes.status`.

### Impacted Areas
PackageType selection during in stock app will have types of `allow_stock` True.

### Linked PR's:
https://bitbucket.org/crfdevs/stockit/pull-requests/56/gcw-2781-add-sync-status-column-to/diff

Please review this PR.
