### PR TITLE
GCW-2808-On Item Search State Filter on applying Image "No Images" gives "Something went wrong"

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -135,7 +135,7 @@ module Api
           with_inventory_no: params['withInventoryNumber'] == 'true') if params['searchText'].present?
         params_for_filter = ['state', 'location'].each_with_object({}){|k, h| h[k] = params[k] if params[k].present?}
         records = records.filter(params_for_filter)
-        records = records.order('id desc').offset(page - 1).limit(per_page)
+        records = records.order('packages.id desc').offset(page - 1).limit(per_page)
         packages = ActiveModel::ArraySerializer.new(records,
           each_serializer: stock_serializer,
           root: "items",


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2808

### What does this PR do?

BUG: On applying "No Image" Filter on Item search page, gives something went wrong. 

### Impacted Areas

Items > Select State Filter > Apply "No Image" filter.

Please review the PR.