### PR TITLE
GCW-2807-Add Infinite scroll on Items filters and search Item for Orders page.

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -144,7 +144,7 @@ module Api
           include_orders_packages: true,
           exclude_stockit_set_item: true,
           include_images: true).as_json
-        render json: {meta: { total_pages: records.total_pages, search: params['searchText'] } }.merge(packages)
+        render json: { meta: { total_pages: records.total_pages, search: params['searchText'] } }.merge(packages)
       end
 
       def designate_stockit_item(order_id)

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -135,7 +135,7 @@ module Api
           with_inventory_no: params['withInventoryNumber'] == 'true') if params['searchText'].present?
         params_for_filter = ['state', 'location'].each_with_object({}){|k, h| h[k] = params[k] if params[k].present?}
         records = records.filter(params_for_filter)
-        records = records.order('packages.id desc').offset(page - 1).limit(per_page)
+        records = records.order('packages.id desc').page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
         packages = ActiveModel::ArraySerializer.new(records,
           each_serializer: stock_serializer,
           root: "items",
@@ -144,7 +144,7 @@ module Api
           include_orders_packages: true,
           exclude_stockit_set_item: true,
           include_images: true).as_json
-        render json: {meta: { search: params['searchText'] } }.merge(packages)
+        render json: {meta: { total_pages: records.total_pages, search: params['searchText'] } }.merge(packages)
       end
 
       def designate_stockit_item(order_id)

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -731,5 +731,23 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       expect(response.status).to eq(200)
       expect(subject["items"].count).to eq(1)
     end
+
+    it "response should have total_pages, and search in meta data" do
+      create(:package, inventory_number: "F00001Q1")
+      create(:package, inventory_number: "F00001Q2")
+      create(:package, inventory_number: "F00001Q3")
+      searchText = 'F00001Q'
+      params = {
+        searchText: searchText,
+        stockRequest: true,
+        restrictMultiQuantity: 'true',
+        withInventoryNumber: 'true',
+        page:1,
+        per_page:25
+      }
+      get :search_stockit_items, params
+      expect(subject["meta"]["search"]).to eq(searchText)
+      expect(subject["meta"].keys).to include("total_pages")
+    end
   end
 end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2807

### What does this PR do?

FEATURE: Added infinite-scroll on Items and Orders item search page.
This PR adds pagination to the search package endpoint.

Please review this PR.