### PR TITLE
Fix company edit and render error in case of failure

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -15,7 +15,7 @@ module Api
       def_param_group :company do
         param :company, Hash, required: true do
           param :name, String, desc: "name of the company"
-          param :crm_id, Integer, desc: "CRM Id"
+          param :crm_id, Integer, desc: "CRM Id", allow_nil: true
           param :created_by_id, Integer, desc: "Id of user who created company record"
         end
       end
@@ -40,7 +40,7 @@ module Api
         if @company.update_attributes(company_params)
           render json: @company, serializer: serializer
         else
-          render_errors
+          render_error(@company.errors.full_messages.join('. '))
         end
       end
 


### PR DESCRIPTION
### What does this PR do?

BUG: Fixes company edit, earlier, update was not working if we do not put CRM id while editing the company.

### Impacted Areas

Company edit, donor_details
