### PR TITLE
No schedule on public holidays

### DIFF
--- a/app/controllers/api/v1/deliveries_controller.rb
+++ b/app/controllers/api/v1/deliveries_controller.rb
@@ -98,6 +98,10 @@ module Api
         param :mobile, String
       end
       def confirm_delivery
+        if Holiday.is_holiday(scheduled_date)
+          return render_error(I18n.t('schedule.holiday_conflict', date: scheduled_date));
+        end
+
         @delivery = Delivery.find_by(id: params["delivery"]["id"])
         @delivery.delete_old_associations
         @delivery.gogovan_order = GogovanOrder.book_order(current_user,
@@ -145,6 +149,13 @@ module Api
           schedule_attributes: schedule_attributes,
           contact_attributes: [:name, :mobile,
             address_attributes: address_attributes])
+      end
+
+      def scheduled_date
+        scheduled_at = get_delivery_details.dig(:schedule_attributes, :scheduled_at)
+        scheduled_at.present? ?
+          Date.parse(scheduled_at) :
+          nil
       end
 
       def address_attributes

--- a/app/controllers/api/v1/deliveries_controller.rb
+++ b/app/controllers/api/v1/deliveries_controller.rb
@@ -160,7 +160,7 @@ module Api
       end
 
       def validate_schedule
-        if scheduled_date.nil?
+        if scheduled_date.blank?
           render_error(I18n.t('schedule.bad_date'))
           return false
         end

--- a/app/controllers/api/v1/deliveries_controller.rb
+++ b/app/controllers/api/v1/deliveries_controller.rb
@@ -136,7 +136,7 @@ module Api
         offer_id = params[:delivery][:offer_id]
         Delivery.where(offer_id: offer_id).each do |delivery|
           authorize!(:destroy, delivery)
-          delivery.destroy
+        delivery.destroy
         end
       end
 
@@ -161,11 +161,11 @@ module Api
 
       def validate_schedule
         if scheduled_date.nil?
-          render_error(I18n.t('schedule.bad_date'));
+          render_error(I18n.t('schedule.bad_date'))
           return false
         end
 
-        if Holiday.is_holiday(scheduled_date)
+        if Holiday.is_holiday?(scheduled_date)
           render_error(I18n.t('schedule.holiday_conflict', date: scheduled_date));
           return false
         end

--- a/app/models/appointment_slot.rb
+++ b/app/models/appointment_slot.rb
@@ -47,7 +47,7 @@ class AppointmentSlot < ActiveRecord::Base
       sl.quota.positive?
     } unless slots.empty?
 
-    return [] if Holiday.is_holiday(date)
+    return [] if Holiday.is_holiday?(date)
 
     # Generate slots based on preset if no special slot have been specified for that date
     AppointmentSlotPreset

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -10,7 +10,7 @@ class Holiday < ActiveRecord::Base
   scope :within_days, ->(days) {
     between_times(Time.zone.now.beginning_of_day, Time.zone.now.end_of_day + days) }
 
-  def self.is_holiday(date)
+  def self.is_holiday?(date)
     Holiday.where(" date(holiday AT TIME ZONE 'HKT') = ?", date.to_date).count > 0
   end
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,8 +1,18 @@
 class Schedule < ActiveRecord::Base
   has_many :deliveries, inverse_of: :schedule
 
+  validate :no_public_holiday_conflict
+
   def formatted_date_and_slot
     "#{slot_name},
     #{scheduled_at.strftime("%a #{scheduled_at.day.ordinalize}")}"
+  end
+
+  private
+
+  def no_public_holiday_conflict
+    if Holiday.is_holiday(scheduled_at)
+      errors.add(:base, I18n.t('schedule.holiday_conflict', date: scheduled_at.to_date))
+    end
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,18 +1,8 @@
 class Schedule < ActiveRecord::Base
   has_many :deliveries, inverse_of: :schedule
 
-  validate :no_public_holiday_conflict
-
   def formatted_date_and_slot
     "#{slot_name},
     #{scheduled_at.strftime("%a #{scheduled_at.day.ordinalize}")}"
-  end
-
-  private
-
-  def no_public_holiday_conflict
-    if Holiday.is_holiday(scheduled_at)
-      errors.add(:base, I18n.t('schedule.holiday_conflict', date: scheduled_at.to_date))
-    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,8 +56,8 @@ en:
     new_offer: New offer submitted by %{name}
     new_order: "New order from %{organisation_name_en}: %{contact_name}"
   schedule:
-    holiday_conflict: Crossroads will be closed on the %{date} due to a public
-      holiday. Please select a different date.
+    bad_date: The selected date is either missing or invalid, please try again.
+    holiday_conflict: Crossroads will be closed on the %{date} due to a public holiday. Please select a different date.
   offer:
     thank_message: Thank you for your offer, our team will start reviewing it
       soon. The reviewer will message you if they have questions about any of

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,9 @@ en:
   notification:
     new_offer: New offer submitted by %{name}
     new_order: "New order from %{organisation_name_en}: %{contact_name}"
+  schedule:
+    holiday_conflict: Crossroads will be closed on the %{date} due to a public
+      holiday. Please select a different date.
   offer:
     thank_message: Thank you for your offer, our team will start reviewing it
       soon. The reviewer will message you if they have questions about any of

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -56,6 +56,7 @@ zh-tw:
     new_offer: "%{name} 的新捐獻。"
     new_order: "New order from %{organisation_name_zh_tw}: %{contact_name}"
   schedule:
+    bad_date: The selected date is either missing or invalid, please try again.
     holiday_conflict: Crossroads will be closed on the %{date} due to a public holiday. Please select a different date.
   offer:
     thank_message: 感謝您的捐獻，我們的團隊很快就會開始審查。假如審查員有任何關於捐獻物資的疑問，他們會以訊息向您查詢。由於儲存空間有限，社區的需要亦經常改變，我們可能無法接收部分物資。為此，我們深感遺憾，並先就此道歉。當審查完成時，您就能立刻安排已接受的物資的運輸。假如您有任何疑問，請隨時回覆此信息。

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -55,6 +55,8 @@ zh-tw:
   notification:
     new_offer: "%{name} 的新捐獻。"
     new_order: "New order from %{organisation_name_zh_tw}: %{contact_name}"
+  schedule:
+    holiday_conflict: Crossroads will be closed on the %{date} due to a public holiday. Please select a different date.
   offer:
     thank_message: 感謝您的捐獻，我們的團隊很快就會開始審查。假如審查員有任何關於捐獻物資的疑問，他們會以訊息向您查詢。由於儲存空間有限，社區的需要亦經常改變，我們可能無法接收部分物資。為此，我們深感遺憾，並先就此道歉。當審查完成時，您就能立刻安排已接受的物資的運輸。假如您有任何疑問，請隨時回覆此信息。
     ggv_cancel_message: GoGoVan已取消預約於 %{time} 的貨車，請重新安排運輸。

--- a/spec/controllers/api/v1/deliveries_controller_spec.rb
+++ b/spec/controllers/api/v1/deliveries_controller_spec.rb
@@ -167,16 +167,18 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
           create :holiday, holiday: date, year: date.year
         end
 
-        it "should fail to modify the delivery" do
-          expect(Gogovan).not_to receive(:cancel_order)
-          expect(GogovanOrder).not_to receive(:book_order)
-          post :confirm_delivery, delivery: new_delivery, gogovanOrder: ggv_order
+        context "as a user" do
+          it "should fail to modify the delivery" do
+            expect(Gogovan).not_to receive(:cancel_order)
+            expect(GogovanOrder).not_to receive(:book_order)
+            post :confirm_delivery, delivery: new_delivery, gogovanOrder: ggv_order
 
-          expect(response.status).to eq(422)
-          expect(subject['errors'].length).to eq(1)
-          expect(subject['errors'][0]['message']).to eq(
-            'Crossroads will be closed on the 2015-04-17 due to a public holiday. Please select a different date.'
-          )
+            expect(response.status).to eq(422)
+            expect(subject['errors'].length).to eq(1)
+            expect(subject['errors'][0]['message']).to eq(
+              'Crossroads will be closed on the 2015-04-17 due to a public holiday. Please select a different date.'
+            )
+          end
         end
       end
 

--- a/spec/controllers/api/v1/deliveries_controller_spec.rb
+++ b/spec/controllers/api/v1/deliveries_controller_spec.rb
@@ -168,12 +168,15 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
         end
 
         it "should fail to modify the delivery" do
-          expect(Gogovan).to receive(:cancel_order).with(old_delivery.gogovan_order.booking_id).and_return(200)
-          expect(GogovanOrder).to receive(:book_order).with(user, ggv_order).and_return(gogovan_order)
+          expect(Gogovan).not_to receive(:cancel_order)
+          expect(GogovanOrder).not_to receive(:book_order)
           post :confirm_delivery, delivery: new_delivery, gogovanOrder: ggv_order
 
           expect(response.status).to eq(422)
-          pp subject
+          expect(subject['errors'].length).to eq(1)
+          expect(subject['errors'][0]['message']).to eq(
+            'Crossroads will be closed on the 2015-04-17 due to a public holiday. Please select a different date.'
+          )
         end
       end
 

--- a/spec/controllers/api/v1/deliveries_controller_spec.rb
+++ b/spec/controllers/api/v1/deliveries_controller_spec.rb
@@ -161,6 +161,22 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
           "contactAttributes" => ggv_contact }
       }
 
+      context "to a public holiday" do
+        before do
+          date = Date.parse(schedule["scheduledAt"]);
+          create :holiday, holiday: date, year: date.year
+        end
+
+        it "should fail to modify the delivery" do
+          expect(Gogovan).to receive(:cancel_order).with(old_delivery.gogovan_order.booking_id).and_return(200)
+          expect(GogovanOrder).to receive(:book_order).with(user, ggv_order).and_return(gogovan_order)
+          post :confirm_delivery, delivery: new_delivery, gogovanOrder: ggv_order
+
+          expect(response.status).to eq(422)
+          pp subject
+        end
+      end
+
       it "should confirm delivery by removing old associated records" do
         ActiveRecord::Base.connection.reset_pk_sequence!("schedules")
         expect(Gogovan).to receive(:cancel_order).with(old_delivery.gogovan_order.booking_id).and_return(200)

--- a/spec/controllers/api/v1/deliveries_controller_spec.rb
+++ b/spec/controllers/api/v1/deliveries_controller_spec.rb
@@ -180,6 +180,36 @@ RSpec.describe Api::V1::DeliveriesController, type: :controller do
         end
       end
 
+      context "with bad data" do
+        it "should fail to modify the delivery if scheduled_at is nil" do
+          new_delivery['scheduleAttributes']['scheduled_at'] = nil
+
+          expect(Gogovan).not_to receive(:cancel_order)
+          expect(GogovanOrder).not_to receive(:book_order)
+          post :confirm_delivery, delivery: new_delivery, gogovanOrder: ggv_order
+
+          expect(response.status).to eq(422)
+          expect(subject['errors'].length).to eq(1)
+          expect(subject['errors'][0]['message']).to eq(
+            'The selected date is either missing or invalid, please try again.'
+          )
+        end
+
+        it "should fail to modify the delivery if scheduled_at is invalid" do
+          new_delivery['scheduleAttributes']['scheduled_at'] = 'not a date'
+
+          expect(Gogovan).not_to receive(:cancel_order)
+          expect(GogovanOrder).not_to receive(:book_order)
+          post :confirm_delivery, delivery: new_delivery, gogovanOrder: ggv_order
+
+          expect(response.status).to eq(422)
+          expect(subject['errors'].length).to eq(1)
+          expect(subject['errors'][0]['message']).to eq(
+            'The selected date is either missing or invalid, please try again.'
+          )
+        end
+      end
+
       it "should confirm delivery by removing old associated records" do
         ActiveRecord::Base.connection.reset_pk_sequence!("schedules")
         expect(Gogovan).to receive(:cancel_order).with(old_delivery.gogovan_order.booking_id).and_return(200)


### PR DESCRIPTION
### What does this PR do?

BUG: We suspect some timezone issue allows people to schedule deliveries on public holidays, this adds a backend check to ensure this never happens.

NOTE: I originally went with a model validation, but then realized the controller makes a ggv modification straight away, so I sneaked the verification in the controller to avoid that happening.

### Impacted Areas

Donor app > Transport schedule
