### PR TITLE
GCW-2824 fix inventory number remove end-point breaks sometimes

### DIFF
--- a/app/controllers/api/v1/inventory_numbers_controller.rb
+++ b/app/controllers/api/v1/inventory_numbers_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       api :PUT, "/v1/inventory_numbers", "Delete inventory_number"
       def remove_number
-        InventoryNumber.find_by(code: params[:code]).destroy
+        InventoryNumber.find_by(code: params[:code]).try(:destroy)
         render json: {}
       end
     end

--- a/spec/controllers/api/v1/inventory_numbers_controller_spec.rb
+++ b/spec/controllers/api/v1/inventory_numbers_controller_spec.rb
@@ -26,5 +26,13 @@ RSpec.describe Api::V1::InventoryNumbersController, type: :controller do
       expect(response.status).to eq(200)
       expect(parsed_body).to eq( {} )
     end
+
+    it 'returns blank response if inventory_number do not exist in db' do
+      expect {
+        post :remove_number, code: rand(1000..9999)
+      }.to change(InventoryNumber, :count).by(0)
+      expect(response.status).to eq(200)
+      expect(parsed_body).to eq({})
+    end
   end
 end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2824

### What does this PR do?
It fixes the rollbar issue: https://rollbar.com/crossroads_it/api.goodcity/items/395/

STEPS TO REPRODUCE BUG: 
- Receive item with an inventory number. 
- Click on the receive button. (try creating with inventory number which already exists so it will return 422 from API)
- Now try clicking on cancel button on-screen and nothing happens and it returns above rollbar issue. 


### Impacted Areas
Cancel feature on a page -> Receive with inventory number on admin app.


Please review.

Thanks.



