### PR TITLE
GCW-2823 fix StockitUpdateJob goes in retry loop

### DIFF
--- a/app/jobs/stockit_update_job.rb
+++ b/app/jobs/stockit_update_job.rb
@@ -9,13 +9,15 @@ class StockitUpdateJob < ActiveJob::Base
 
       # if Stockit can't find the item, it will create a new one and return the stockit_id
       # We need to update the stockit_id of the GoodCity package in this case.
-      stockit_id = response['id']
-      package.update_column(:stockit_id, stockit_id) unless stockit_id.blank?
+      if response
+        stockit_id = response['id']
+        package.update_column(:stockit_id, stockit_id) unless stockit_id.blank?
 
-      if response && (errors = response["errors"] || response[:errors])
-        log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"
-        errors.each { |attribute, error| log_text += " #{attribute}: #{error}" }
-        logger.error log_text
+        if (errors = response["errors"] || response[:errors])
+          log_text = "Inventory: #{package.inventory_number} Package: #{package_id}"
+          errors.each { |attribute, error| log_text += " #{attribute}: #{error}" }
+          logger.error log_text
+        end
       end
     end
   end


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2823

### What does this PR do?

FIXES BUG: I am seeing this job in retry queue [Production]. It's trying to update item on stockit but it do not relates to any item on stockit also it do not have any inventory number. So ideally code should not try to perform sync operation.

### Linked Slack conversation:
https://crossroads-hk.slack.com/archives/GBJAFNVFB/p1569311435095900

Please review.

Thanks.
