### PR TITLE
fix package_category importer not creating any records in db

### DIFF
--- a/lib/classes/package_category_importer.rb
+++ b/lib/classes/package_category_importer.rb
@@ -27,10 +27,10 @@ class PackageCategoryImporter
       package_category = PackageCategory.find_by(name_en: value[:lv2])
 
       if package && package_category
-        PackageCategoriesPackageType.first_or_create(
+        PackageCategoriesPackageType.where(
           package_type_id:     package.id,
           package_category_id: package_category.id
-        )
+        ).first_or_create
       end
     end
   end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2529

### What does this PR do?

BUG: It fixes the issue of package_category_importer is not creating records in DB.

> PackageCategoriesPackageType.first_or_create(package_type_id:     package.id, package_category_id: package_category.id)

In this syntax, it checks table has a record or not. It does not consider our condition. Even if any single record exists in db then it will not create a new record.

> PackageCategoriesPackageType.where(package_type_id:  package.id, package_category_id: package_category.id).first_or_create

For this it checks for condition first and then if record with that condition do not exists in db then it creates new one.

### Linked PR's:

https://github.com/crossroads/api.goodcity/pull/833

Please review.

Thanks.
