### PR TITLE
Gcw 2781 add and sync allow stock for package type

### DIFF
--- a/app/controllers/api/v1/package_types_controller.rb
+++ b/app/controllers/api/v1/package_types_controller.rb
@@ -35,7 +35,7 @@ module Api
       private
 
       def package_type_params
-        params.require(:package_type).permit(:stockit_id, :code, :name_en, :name_zh_tw, :visible_in_selects, :allow_requests)
+        params.require(:package_type).permit(:stockit_id, :code, :name_en, :name_zh_tw, :visible_in_selects, :allow_requests, :allow_stock)
       end
 
       def serializer

--- a/app/models/package_type.rb
+++ b/app/models/package_type.rb
@@ -27,7 +27,7 @@ class PackageType < ActiveRecord::Base
 
   translates :name, :other_terms
 
-  scope :visible, -> { where(visible_in_selects: true) }
+  scope :visible, -> { where(allow_stock: true) }
 
   private
 

--- a/db/migrate/20190913102426_add_allow_stock_to_package_types.rb
+++ b/db/migrate/20190913102426_add_allow_stock_to_package_types.rb
@@ -1,0 +1,5 @@
+class AddAllowStockToPackageTypes < ActiveRecord::Migration
+  def change
+    add_column :package_types, :allow_stock, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190917110924) do
+ActiveRecord::Schema.define(version: 20190913102426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -530,6 +530,7 @@ ActiveRecord::Schema.define(version: 20190917110924) do
     t.integer  "location_id"
     t.boolean  "allow_requests",     default: true
     t.boolean  "allow_pieces",       default: false
+    t.boolean  "allow_stock",        default: false
   end
 
   add_index "package_types", ["allow_requests"], name: "index_package_types_on_allow_requests", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190913102426) do
+ActiveRecord::Schema.define(version: 20190917110924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -529,8 +529,8 @@ ActiveRecord::Schema.define(version: 20190913102426) do
     t.integer  "stockit_id"
     t.integer  "location_id"
     t.boolean  "allow_requests",     default: true
-    t.boolean  "allow_pieces",       default: false
     t.boolean  "allow_stock",        default: false
+    t.boolean  "allow_pieces",       default: false
   end
 
   add_index "package_types", ["allow_requests"], name: "index_package_types_on_allow_requests", using: :btree
@@ -820,7 +820,7 @@ ActiveRecord::Schema.define(version: 20190913102426) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))", using: :btree
+  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))", using: :btree
   add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
   add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree

--- a/lib/tasks/package_types.rake
+++ b/lib/tasks/package_types.rake
@@ -32,4 +32,26 @@ namespace :goodcity do
     PackageCategoryImporter.import_package_relation
   end
 
+  #rake goodcity:update_allow_stock_to_stockit_codes_status
+  desc 'Update PackageType `allow_stock` according to `Codes.status` from Stockit'
+  task update_allow_stock_to_stockit_codes_status: :environment do
+    STATUS_AND_ALLOW_STOCK_MAPPING = {
+      "Active" => true,
+      "Inactive" => false
+    }
+    codes_json = Stockit::CodeSync.index
+    stockit_codes = JSON.parse(codes_json["codes"]) || {}
+    stockit_codes.each do |code|
+      if active?(code["status"])
+        package_type = PackageType.find_by(stockit_id: code["id"])
+        if package_type
+          package_type.update_column(:allow_stock, true)
+        end
+      end
+    end
+  end
+
+  def active?(status)
+    STATUS_AND_ALLOW_STOCK_MAPPING[status]
+  end
 end

--- a/lib/tasks/package_types.rake
+++ b/lib/tasks/package_types.rake
@@ -38,17 +38,31 @@ namespace :goodcity do
     STATUS_AND_ALLOW_STOCK_MAPPING = {
       "Active" => true,
       "Inactive" => false
-    }
+    }.freeze
+    log = Goodcity::RakeLogger.new("update_allow_stock_to_stockit_codes_status")
+    updated_record_count = 0
+    failed_record_count = 0
+    failed_package_type_ids = []
     codes_json = Stockit::CodeSync.index
     stockit_codes = JSON.parse(codes_json["codes"]) || {}
     stockit_codes.each do |code|
-      if active?(code["status"])
-        package_type = PackageType.find_by(stockit_id: code["id"])
-        if package_type
-          package_type.update_column(:allow_stock, true)
+      if active?(code["status"]) and package_type = get_package_type(code["id"])
+        if package_type.update_column(:allow_stock, true)
+          updated_record_count += 1
+        else
+          failed_record_count += 1
+          failed_package_type_ids << package_type.id
         end
       end
     end
+    log.info("TOTAL Record = #{stockit_codes.count}")
+    log.info("TOTAL UPDATED RECORD = #{updated_record_count}")
+    log.info("TOTAL FAILED UPDATES = #{failed_record_count}")
+    log.info("LIST OF FAILED RECORDS = #{failed_package_type_ids}")
+  end
+
+  def get_package_type(id)
+    PackageType.find_by(stockit_id: id)
   end
 
   def active?(status)

--- a/spec/models/package_type_spec.rb
+++ b/spec/models/package_type_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe PackageType, type: :model do
     it { is_expected.to have_db_column(:other_terms_en).of_type(:string) }
     it { is_expected.to have_db_column(:other_terms_zh_tw).of_type(:string) }
     it { is_expected.to have_db_column(:allow_pieces).of_type(:boolean) }
+    it { is_expected.to have_db_column(:allow_stock).of_type(:boolean) }
   end
 
   describe 'Associations' do
@@ -19,8 +20,8 @@ RSpec.describe PackageType, type: :model do
 
   describe 'scope' do
     describe "visible" do
-      it "returns records with visible_in_selects true value" do
-        expect(PackageType.visible.to_sql).to include("WHERE \"package_types\".\"visible_in_selects\" = 't'")
+      it "returns records with allow_stock true value" do
+        expect(PackageType.visible.to_sql).to include("WHERE \"package_types\".\"allow_stock\" = 't'")
       end
     end
   end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2781

### What does this PR do?

FEATURE: Sync StockIt's `codes.status` field with a new field in GoodCity `package_types.allow_stock`
Also added rake task to update `package_types.allow_stock` with Stockit `codes.status`.

### Impacted Areas
PackageType selection during in stock app will have types of `allow_stock` True.

### Linked PR's:
https://bitbucket.org/crfdevs/stockit/pull-requests/56/gcw-2781-add-sync-status-column-to/diff

Please review this PR.