### PR TITLE
GCW-2812 add lookups for fixed values of some dropdowns

### DIFF
--- a/app/controllers/api/v1/lookups_controller.rb
+++ b/app/controllers/api/v1/lookups_controller.rb
@@ -4,7 +4,9 @@ module Api
       skip_authorization_check only: :index
 
       def index
-        render json: Lookup.all, each_serializer: Api::V1::LookupSerializer
+        @lookups = Lookup.all
+        @lookups = @lookups.where(name: params["name"]) if params["name"]
+        render json: @lookups, each_serializer: Api::V1::LookupSerializer
       end
     end
   end

--- a/app/controllers/api/v1/lookups_controller.rb
+++ b/app/controllers/api/v1/lookups_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class LookupsController < Api::V1::ApiController
+      skip_authorization_check only: :index
+
+      def index
+        render json: Lookup.all, each_serializer: Api::V1::LookupSerializer
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/lookups_controller.rb
+++ b/app/controllers/api/v1/lookups_controller.rb
@@ -4,9 +4,7 @@ module Api
       skip_authorization_check only: :index
 
       def index
-        @lookups = Lookup.all
-        @lookups = @lookups.where(name: params["name"]) if params["name"]
-        render json: @lookups, each_serializer: Api::V1::LookupSerializer
+        render json: Lookup.all, each_serializer: Api::V1::LookupSerializer
       end
     end
   end

--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -4,9 +4,16 @@ class Computer < ActiveRecord::Base
 
   belongs_to :country, required: false
   has_one :package, as: :detail, dependent: :destroy
-  after_commit :create_on_stockit, on: :create
-  after_update :update_on_stockit
   before_save :save_correct_country, if: :request_from_stockit?
   before_save :downcase_brand, if: :brand_changed?
   before_save :set_updated_by
+  before_save :map_drop_down_attributes, if: :request_from_stockit?
+  after_commit :create_on_stockit, on: :create
+  after_update :update_on_stockit
+
+  private
+
+  def map_drop_down_attributes
+    Lookup.find_by(name: "comp_test_status", value: comp_test_status).label_en if comp_test_status_changed?
+  end
 end

--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -14,6 +14,6 @@ class Computer < ActiveRecord::Base
   private
 
   def map_drop_down_attributes
-    Lookup.find_by(name: "comp_test_status", value: comp_test_status).label_en if comp_test_status_changed?
+    self.comp_test_status = Lookup.find_by(name: "comp_test_status", value: comp_test_status)&.label_en if comp_test_status_changed?
   end
 end

--- a/app/models/computer_accessory.rb
+++ b/app/models/computer_accessory.rb
@@ -4,9 +4,16 @@ class ComputerAccessory < ActiveRecord::Base
 
   belongs_to :country, required: false
   has_one :package, as: :detail, dependent: :destroy
-  after_commit :create_on_stockit, on: :create
-  after_update :update_on_stockit
   before_save :downcase_brand, if: :brand_changed?
   before_save :save_correct_country, if: :request_from_stockit?
   before_save :set_updated_by
+  before_save :map_drop_down_attributes, if: :request_from_stockit?
+  after_commit :create_on_stockit, on: :create
+  after_update :update_on_stockit
+
+  private
+
+  def map_drop_down_attributes
+    Lookup.find_by(name: "comp_test_status", value: comp_test_status).label_en if comp_test_status_changed?
+  end
 end

--- a/app/models/computer_accessory.rb
+++ b/app/models/computer_accessory.rb
@@ -14,6 +14,6 @@ class ComputerAccessory < ActiveRecord::Base
   private
 
   def map_drop_down_attributes
-    Lookup.find_by(name: "comp_test_status", value: comp_test_status).label_en if comp_test_status_changed?
+    self.comp_test_status = Lookup.find_by(name: "comp_test_status", value: comp_test_status).label_en if comp_test_status_changed?
   end
 end

--- a/app/models/concerns/subform_utilities.rb
+++ b/app/models/concerns/subform_utilities.rb
@@ -12,11 +12,15 @@ module SubformUtilities
   end
 
   def create_on_stockit
+    return if request_from_stockit?
+
     response = Stockit::ItemDetailSync.create(self)
     add_stockit_id(response)
   end
 
   def update_on_stockit
+    return if request_from_stockit?
+
     response = Stockit::ItemDetailSync.update(self)
     add_stockit_id(response)
   end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Country < ActiveRecord::Base
   include RollbarSpecification
   translates :name

--- a/app/models/electrical.rb
+++ b/app/models/electrical.rb
@@ -8,6 +8,16 @@ class Electrical < ActiveRecord::Base
   before_save :downcase_brand, if: :brand_changed?
   before_save :save_correct_country, if: :request_from_stockit?
   before_save :set_updated_by
+  before_save :map_drop_down_attributes, if: :request_from_stockit?
   after_commit :create_on_stockit, on: :create
   after_update :update_on_stockit
+
+  private
+
+  def map_drop_down_attributes
+    ['frequency', 'voltage', 'test_status'].each do |attr|
+      attr_value = Lookup.find_by(name: "electrical_#{attr}", value: send(attr))&.label_en
+      self.send("#{attr}=", attr_value)
+    end
+  end
 end

--- a/app/models/lookup.rb
+++ b/app/models/lookup.rb
@@ -1,0 +1,2 @@
+class Lookup < ActiveRecord::Base
+end

--- a/app/serializers/api/v1/lookup_serializer.rb
+++ b/app/serializers/api/v1/lookup_serializer.rb
@@ -1,0 +1,6 @@
+module Api::V1
+  class LookupSerializer < ApplicationSerializer
+    embed :ids, include: true
+    attributes :id, :name, :value, :label_en, :label_zh_tw
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       resources :computers
       resources :computer_accessories
       resources :electricals
+      resources :lookups, only: :index
 
       resources :items, except: [:index] do
         get :messages, on: :member

--- a/db/lookup.yml
+++ b/db/lookup.yml
@@ -1,0 +1,96 @@
+---
+-
+  name: "comp_test_status"
+  value: "A"
+  label_en: "Active"
+  label_zh_tw: "Active"
+-
+  name: "comp_test_status"
+  value: "F"
+  label_en: "Failure"
+  label_zh_tw: "Failure"
+-
+  name: "comp_test_status"
+  value: "O"
+  label_en: "Obsolete"
+  label_zh_tw: "Obsolete"
+-
+  name: "comp_test_status"
+  value: "R"
+  label_en: "Reserved"
+  label_zh_tw: "Reserved"
+-
+  name: "comp_test_status"
+  value: "S"
+  label_en: "Spare"
+  label_zh_tw: "Spare"
+-
+  name: "electrical_test_status"
+  value: "T"
+  label_en: "Tested (DO NOT USE)"
+  label_zh_tw: "Tested (DO NOT USE)"
+-
+  name: "electrical_test_status"
+  value: "U"
+  label_en: "Untested (DO NOT USE)"
+  label_zh_tw: "Untested (DO NOT USE)"
+-
+  name: "electrical_test_status"
+  value: "M"
+  label_en: "Maintenance (DO NOT USE)"
+  label_zh_tw: "Maintenance (DO NOT USE)"
+-
+  name: "electrical_frequency"
+  value: "0"
+  label_en: "N/A"
+  label_zh_tw: "N/A"
+-
+  name: "electrical_frequency"
+  value: "1"
+  label_en: "50"
+  label_zh_tw: "50"
+-
+  name: "electrical_frequency"
+  value: "2"
+  label_en: "60"
+  label_zh_tw: "60"
+-
+  name: "electrical_frequency"
+  value: "3"
+  label_en: "50/60 (Multi)"
+  label_zh_tw: "50/60 (Multi)"
+-
+  name: "electrical_frequency"
+  value: "4"
+  label_en: "Other"
+  label_zh_tw: "Other"
+-
+  name: "electrical_voltage"
+  value: "0"
+  label_en: "N/A"
+  label_zh_tw: "N/A"
+-
+  name: "electrical_voltage"
+  value: "1"
+  label_en: "120V ~ (100-200V)"
+  label_zh_tw: "120V ~ (100-200V)"
+-
+  name: "electrical_voltage"
+  value: "2"
+  label_en: "240V ~ (200-300V)"
+  label_zh_tw: "240V ~ (200-300V)"
+-
+  name: "electrical_voltage"
+  value: "3"
+  label_en: "> 300V"
+  label_zh_tw: "> 300V"
+-
+  name: "electrical_voltage"
+  value: "4"
+  label_en: "Multi"
+  label_zh_tw: "Multi"
+-
+  name: "electrical_voltage"
+  value: "5"
+  label_en: "Other"
+  label_zh_tw: "Other"

--- a/db/migrate/20191030081621_create_lookups.rb
+++ b/db/migrate/20191030081621_create_lookups.rb
@@ -1,0 +1,16 @@
+class CreateLookups < ActiveRecord::Migration
+  def change
+    create_table :lookups do |t|
+      t.string :name
+      t.string :value
+      t.string :label_en
+      t.string :label_zh_tw
+
+      t.timestamps null: false
+    end
+
+    add_index :lookups, :name
+    add_index :lookups, [:name, :label_en]
+    add_index :lookups, [:name, :label_zh_tw]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190925110227) do
+ActiveRecord::Schema.define(version: 20191030081621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -347,6 +347,19 @@ ActiveRecord::Schema.define(version: 20190925110227) do
   add_index "locations", ["area"], name: "index_locations_on_area", using: :gin
   add_index "locations", ["building"], name: "index_locations_on_building", using: :gin
   add_index "locations", ["stockit_id"], name: "index_locations_on_stockit_id", using: :btree
+
+  create_table "lookups", force: :cascade do |t|
+    t.string   "name"
+    t.string   "value"
+    t.string   "label_en"
+    t.string   "label_zh_tw"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "lookups", ["name", "label_en"], name: "index_lookups_on_name_and_label_en", using: :btree
+  add_index "lookups", ["name", "label_zh_tw"], name: "index_lookups_on_name_and_label_zh_tw", using: :btree
+  add_index "lookups", ["name"], name: "index_lookups_on_name", using: :btree
 
   create_table "messages", force: :cascade do |t|
     t.text     "body"

--- a/lib/tasks/create_lookups.rake
+++ b/lib/tasks/create_lookups.rake
@@ -1,0 +1,10 @@
+namespace :goodcity do
+  # rake goodcity:create_lookups
+  desc "Add dummy package detail data"
+  task create_lookups: :environment do
+    lookups = YAML.load_file("#{Rails.root}/db/lookup.yml")
+    lookups.each do |lookup|
+      Lookup.where(name: lookup["name"], value: lookup["label_en"]).first_or_create(lookup)
+    end
+  end
+end

--- a/spec/controllers/api/v1/lookups_controller_spec.rb
+++ b/spec/controllers/api/v1/lookups_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::LookupsController, type: :controller do
+  let(:user) { create(:user_with_token, :with_can_manage_package_detail_permission, role_name: "Order Fulfilment") }
+
+  before do
+    generate_and_set_token(user)
+    10.times.each do |n|
+      create(:lookup, name: "lookup_#{n}")
+    end
+    5.times.each do |n|
+      create(:lookup, name: "lookup_11")
+    end
+  end
+  describe "GET lookups" do
+    it "returns 200", :show_in_doc do
+      get :index
+      expect(response.status).to eq(200)
+    end
+
+    it "return serialized lookups" do
+      get :index
+      body = JSON.parse(response.body)
+      expect(body["lookups"].length).to eq(Lookup.count)
+    end
+
+    it "returns filtered serialized lookups" do
+      get :index, name:"lookup_11"
+      body = JSON.parse(response.body)
+      expect(body["lookups"].length).to eq(5)
+    end
+  end
+end

--- a/spec/factories/lookups.rb
+++ b/spec/factories/lookups.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :lookup do
+    name "MyString"
+    value "MyString"
+    label_en "MyString"
+    label_zh_tw "MyString"
+  end
+end

--- a/spec/models/lookup_spec.rb
+++ b/spec/models/lookup_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Lookup, type: :model do
+
+  describe 'Database columns' do
+    it{ is_expected.to have_db_column(:name).of_type(:string)}
+    it{ is_expected.to have_db_column(:value).of_type(:string)}
+    it{ is_expected.to have_db_column(:label_en).of_type(:string)}
+    it{ is_expected.to have_db_column(:label_zh_tw).of_type(:string)}
+  end
+end

--- a/spec/serializers/api/v1/lookup_serializer_spec.rb
+++ b/spec/serializers/api/v1/lookup_serializer_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+context Api::V1::LookupSerializer do
+  let(:lookup) { build(:lookup) }
+  let(:serializer) { Api::V1::LookupSerializer.new(lookup).as_json }
+  let(:json) { JSON.parse(serializer.to_json) }
+
+  it "creates JSON" do
+    lookup.attributes.except("id").keys.each do |key|
+      expect(json["lookup"]["#{key}"]).to eq(lookup.send("#{key}".to_sym))
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

Adds Lookups table for fixed attributes. eg, electrical frequency, electrical voltage, test_status etc.

LINKED TO PARENT BRANCH, 
i.e. `GCW-2812-support-additional-fields`