### PR TITLE
Cache clear: packages_categories

### DIFF
--- a/app/models/package_categories_package_type.rb
+++ b/app/models/package_categories_package_type.rb
@@ -1,7 +1,7 @@
 class PackageCategoriesPackageType < ActiveRecord::Base
   include RollbarSpecification
-  belongs_to :package_type
-  belongs_to :package_category
+  belongs_to :package_type, touch: true
+  belongs_to :package_category, touch: true
 
   validates :package_type_id, uniqueness: { scope: :package_category_id }
 end


### PR DESCRIPTION
Touch on `package_categories_package_type` to clear the cache when the relationship to package_types changes