### PR TITLE
Gcw 2858 remove dispatched location

### DIFF
--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -59,14 +59,14 @@ class OrdersPackage < ActiveRecord::Base
       orders_package.updated_by =  User.current_user
     end
 
-    after_transition on: :dispatch, do: :assign_dispatched_location
+    after_transition on: :dispatch, do: :delete_packages_locations
   end
 
-  def assign_dispatched_location
+  # Once a package is dispatched, remove the location entry
+  def delete_packages_locations
     if package.singleton_package?
-      package.destroy_stale_packages_locations(quantity)
+      package.packages_locations.destroy_all
     end
-    package.assign_or_update_dispatched_location(id, quantity)
   end
 
   def undispatch_orders_package

--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -116,7 +116,7 @@ class OrdersPackage < ActiveRecord::Base
   def update_quantity_based_on_dispatch_state(total_quantity)
     location_id = Location.dispatch_location.id
     package.destroy_other_locations(location_id) if total_quantity == package.received_quantity
-    package.update_location_quantity(total_quantity, location_id)
+    package.packages_locations.where(location_id: location_id).destroy_all # No longer record Dispatched location
   end
 
   def dispatch_orders_package

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -134,45 +134,8 @@ class Package < ActiveRecord::Base
     end
   end
 
-  def assign_or_update_dispatched_location(orders_package_id, quantity)
-    if dispatch_from_stockit?
-      create_or_update_location_for_dispatch_from_stockit(dispatched_location, orders_package_id, quantity)
-    else
-      create_dispatched_packages_location_from_gc(dispatched_location, orders_package_id, quantity)
-    end
-  end
-
   def dispatched_location
     Location.dispatch_location
-  end
-
-  def destroy_stale_packages_locations(new_quantity)
-    if (singleton_package? || total_quantity_move_without_dispatch_location?(new_quantity))
-      delete_associated_packages_locations
-    end
-  end
-
-  def total_quantity_move_without_dispatch_location?(new_quantity)
-    packages_location_quantity_equal_to_received_quantity?(new_quantity) && !(locations.include?(dispatched_location))
-  end
-
-  def packages_location_quantity_equal_to_received_quantity?(new_quantity)
-    received_quantity == packages_locations.pluck(:quantity).sum && new_quantity == received_quantity
-  end
-
-  def create_dispatched_packages_location_from_gc(dispatched_location, orders_package_id, quantity)
-    unless locations.include?(dispatched_location)
-      create_associated_packages_location(dispatched_location.id, quantity, orders_package_id)
-    end
-  end
-
-  def create_or_update_location_for_dispatch_from_stockit(dispatched_location, orders_package_id, quantity)
-    destroy_stale_packages_locations(quantity)
-    if (dispatched_packages_location = find_packages_location_with_location_id(dispatched_location.id))
-      dispatched_packages_location.update_referenced_orders_package(orders_package_id)
-    else
-      create_associated_packages_location(dispatched_location.id, quantity, orders_package_id)
-    end
   end
 
   def create_associated_packages_location(location_id, quantity, reference_to_orders_package = nil)
@@ -321,14 +284,6 @@ class Package < ActiveRecord::Base
       errors.each { |key, value| self.errors.add(key, value) }
     elsif response && (item_id = response["item_id"]).present?
       self.stockit_id = item_id
-    end
-  end
-
-  def stockit_location_id
-    if packages_locations.count > 1
-      Location.multiple_location.try(:stockit_id)
-    else
-      packages_locations.first.try(:location).try(:stockit_id) || Location.find_by(id: location_id).try(:stockit_id)
     end
   end
 

--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -140,7 +140,7 @@ module Stockit
     # GoodCity doesn't keep location records for dispatched packages
     #   but Stockit likes to put them in the Dispatched location
     def stockit_location_id
-      if package.stockit_sent_on.present?
+      if package.stockit_sent_on.present? or package.orders_packages.where(state: 'dispatched').any?
         Location.dispatch_location.stockit_id
       elsif package.packages_locations.count > 1
         Location.multiple_location.try(:stockit_id)

--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -140,7 +140,7 @@ module Stockit
     # GoodCity doesn't keep location records for dispatched packages
     #   but Stockit likes to put them in the Dispatched location
     def stockit_location_id
-      if package.sent_on.present?
+      if package.stockit_sent_on.present?
         Location.dispatch_location.stockit_id
       elsif package.packages_locations.count > 1
         Location.multiple_location.try(:stockit_id)

--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -145,7 +145,7 @@ module Stockit
       elsif package.packages_locations.count > 1
         Location.multiple_location.try(:stockit_id)
       else
-        package.packages_locations.first.try(:location).try(:stockit_id) || Location.find_by(id: package.location_id).try(:stockit_id)
+        package.locations.first.try(:stockit_id) || Location.find_by(id: package.location_id).try(:stockit_id)
       end
     end
 

--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -117,7 +117,7 @@ module Stockit
         condition: PackageConditionMapper.to_stockit(@package.donor_condition_name),
         grade: package.grade,
         description: package.notes,
-        location_id: package.stockit_location_id,
+        location_id: stockit_location_id,
         id: package.stockit_id,
         pieces: package.pieces,
         # designation_id: package.singleton_package? ? package.stockit_order_id : nil,
@@ -136,5 +136,18 @@ module Stockit
         description: package.notes
       }
     end
+
+    # GoodCity doesn't keep location records for dispatched packages
+    #   but Stockit likes to put them in the Dispatched location
+    def stockit_location_id
+      if package.sent_on.present?
+        Location.dispatch_location.stockit_id
+      elsif package.packages_locations.count > 1
+        Location.multiple_location.try(:stockit_id)
+      else
+        package.packages_locations.first.try(:location).try(:stockit_id) || Location.find_by(id: package.location_id).try(:stockit_id)
+      end
+    end
+
   end
 end

--- a/app/services/stockit/orders_package_sync.rb
+++ b/app/services/stockit/orders_package_sync.rb
@@ -92,7 +92,7 @@ module Stockit
 
     # GoodCity doesn't keep location records for dispatched packages
     def stockit_location_id
-      if package.stockit_sent_on.present?
+      if package.stockit_sent_on.present? or package.orders_packages.where(state: 'dispatched').any?
         Location.dispatch_location.stockit_id
       elsif package.packages_locations.count > 1
         Location.multiple_location.try(:stockit_id)

--- a/app/services/stockit/orders_package_sync.rb
+++ b/app/services/stockit/orders_package_sync.rb
@@ -71,7 +71,7 @@ module Stockit
         condition: PackageConditionMapper.to_stockit(@package.donor_condition_name),
         grade: package.grade,
         description: package.notes,
-        location_id: package.stockit_location_id,
+        location_id: stockit_location_id,
         id: package.stockit_id,
         designation_id: @orders_package.order.try(:stockit_id),
         designated_on: @orders_package.created_at,
@@ -89,5 +89,17 @@ module Stockit
         description: package.notes
       }
     end
+
+    # GoodCity doesn't keep location records for dispatched packages
+    def stockit_location_id
+      if package.sent_on.present?
+        Location.dispatch_location.stockit_id
+      elsif package.packages_locations.count > 1
+        Location.multiple_location.try(:stockit_id)
+      else
+        package.packages_locations.first.try(:location).try(:stockit_id) || Location.find_by(id: package.location_id).try(:stockit_id)
+      end
+    end
+
   end
 end

--- a/app/services/stockit/orders_package_sync.rb
+++ b/app/services/stockit/orders_package_sync.rb
@@ -92,7 +92,7 @@ module Stockit
 
     # GoodCity doesn't keep location records for dispatched packages
     def stockit_location_id
-      if package.sent_on.present?
+      if package.stockit_sent_on.present?
         Location.dispatch_location.stockit_id
       elsif package.packages_locations.count > 1
         Location.multiple_location.try(:stockit_id)

--- a/lib/goodcity/cleanup.rb
+++ b/lib/goodcity/cleanup.rb
@@ -1,0 +1,25 @@
+module Goodcity
+  module Cleanup
+    module_function
+
+    def delete_dispatched_packages_locations
+      location_id = Location.dispatch_location.id
+      PackagesLocation
+        .joins("LEFT OUTER JOIN packages ON packages_locations.package_id = packages.id")
+        .where(location_id: location_id)
+        .where(
+          <<-SQL
+            packages.stockit_sent_on IS NOT NULL
+              OR
+            EXISTS(
+              SELECT 1 FROM orders_packages WHERE (
+                orders_packages.state = 'dispatched' AND
+                orders_packages.package_id = packages_locations.package_id
+              )
+            )
+          SQL
+        )
+        .delete_all
+    end
+  end
+end

--- a/lib/tasks/goodcity/packages_locations/delete_dispatched_locations.rake
+++ b/lib/tasks/goodcity/packages_locations/delete_dispatched_locations.rake
@@ -1,0 +1,12 @@
+namespace :goodcity do
+  namespace :packages_locations do
+
+    desc "Delete dispatched packages_locations"
+    task delete_dispatched_locations: :environment do
+      # Use delete instead of destroy so we don't fire push updates
+      location_id = Location.dispatch_location.id
+      PackagesLocation.where(location_id: location_id).delete_all
+    end
+
+  end
+end

--- a/lib/tasks/goodcity/packages_locations/delete_dispatched_locations.rake
+++ b/lib/tasks/goodcity/packages_locations/delete_dispatched_locations.rake
@@ -1,11 +1,11 @@
+require 'goodcity/cleanup'
+
 namespace :goodcity do
   namespace :packages_locations do
 
     desc "Delete dispatched packages_locations"
     task delete_dispatched_locations: :environment do
-      # Use delete instead of destroy so we don't fire push updates
-      location_id = Location.dispatch_location.id
-      PackagesLocation.where(location_id: location_id).delete_all
+      Goodcity::Cleanup.delete_dispatched_packages_locations
     end
 
   end

--- a/spec/lib/goodcity/cleanup_spec.rb
+++ b/spec/lib/goodcity/cleanup_spec.rb
@@ -1,0 +1,49 @@
+require 'goodcity/cleanup'
+require 'rails_helper'
+
+context Goodcity::Cleanup do
+  let(:dispatch_location) { create(:location, :dispatched) }
+
+  subject { described_class.new }
+
+  describe "Cleaning up dispatched packages_locations" do
+    let(:packages_location) { create(:packages_location, location: dispatch_location, package: package) }
+    let(:record_id) { packages_location.id }
+
+    def run_cleanup
+      Goodcity::Cleanup.delete_dispatched_packages_locations
+    end
+
+    context "when the package has a dispatched orders_packages" do
+      let(:package) { create(:package) }
+
+      before { create(:orders_package, :with_state_dispatched, package: package) }
+
+      it "deletes the record" do
+        expect { run_cleanup }.to change {
+          PackagesLocation.find_by(id: record_id)
+        }.from(packages_location).to(nil)
+      end
+    end
+
+    context "when stockit_sent_on is set on the package" do
+      let(:package) { create(:package, stockit_sent_on: Time.now) }
+
+      it "deletes the record" do
+        expect { run_cleanup }.to change {
+          PackagesLocation.find_by(id: record_id)
+        }.from(packages_location).to(nil)
+      end
+    end
+
+    context "when the package isn't dispatched" do
+      let(:package) { create(:package) }
+
+      it "doesn't deletes the record" do
+        expect { run_cleanup }.not_to change {
+          PackagesLocation.find_by(id: record_id)
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/goodcity/health_checks/orders_packages_order_id_nil_check_spec.rb
+++ b/spec/lib/goodcity/health_checks/orders_packages_order_id_nil_check_spec.rb
@@ -4,23 +4,18 @@ require 'goodcity/health_checks/orders_packages_order_id_check'
 context Goodcity::HealthChecks::OrdersPackagesOrderIdCheck do
 
   subject { described_class.new }
+  let!(:orders_package) { create(:orders_package) }
 
   it { expect(subject.desc).to eql("OrdersPackages should contain an order_id reference.") }
 
   it "passes" do
-    WebMock.disable!
-    order = create :order
-    package = create :package, :received
-    create :orders_package, order: order, package: package
     subject.run
     expect(subject.passed?).to eql(true)
-    WebMock.enable!
   end
 
-  # it "fails" do
-  #   orders_package = build :orders_package, order_id: nil
-  #   expect(orders_package.valid?).to eql(false)
-  #   expect(orders_package.errors.messages).to eql({:order=>["can't be blank"]})
-  # end
+  it "fails" do
+    orders_package.update_column(:order_id, nil)
+    expect(subject.passed?).to eql(false)
+  end
 
 end

--- a/spec/models/orders_package_spec.rb
+++ b/spec/models/orders_package_spec.rb
@@ -115,11 +115,11 @@ RSpec.describe OrdersPackage, type: :model do
     let!(:orders_package) { create :orders_package, state: 'designated', quantity: 1 }
     let!(:dispatched_location) { create :location,  building: "Dispatched" }
 
-    # it "sets today's date for sent_on column" do
-    #   todays_date = Date.today
-    #   orders_package.dispatch_orders_package
-    #   expect(orders_package.reload.sent_on.to_date).to eq todays_date
-    # end
+    it "sets today's date for sent_on column" do
+      todays_date = Date.today
+      orders_package.dispatch_orders_package
+      expect(orders_package.reload.sent_on.to_date).to eq todays_date
+    end
 
     it 'updates state to dispatched' do
       expect{
@@ -127,10 +127,6 @@ RSpec.describe OrdersPackage, type: :model do
         }.to change(orders_package, :state).to eq 'dispatched'
     end
 
-    it 'adds dispatched location for associate package' do
-      orders_package.dispatch_orders_package
-      expect(orders_package.package.reload.locations).to include(dispatched_location)
-    end
   end
 
   describe '.update_orders_package_state' do

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -520,26 +520,6 @@ RSpec.describe Package, type: :model do
     end
   end
 
-  describe '#create_or_update_location_for_dispatch_from_stockit' do
-    let(:package) { create :package }
-    let(:order) { create :order }
-    let(:orders_package) { create :orders_package, state: 'dispatched', package: package, order: order }
-    let(:dispatched_location) { create :location, :dispatched }
-
-    it 'updates orders_package_id against packages_location record if dispatched' do
-      packages_location = create :packages_location, package: package, location: dispatched_location
-      package.create_or_update_location_for_dispatch_from_stockit(dispatched_location, orders_package.id, orders_package.quantity)
-      expect(packages_location.reload.reference_to_orders_package).to eq orders_package.id
-    end
-
-    it 'creates new packages_location record with orders_package_id if packages_location record do not exist and package dispatched' do
-      expect{
-        package.create_or_update_location_for_dispatch_from_stockit(dispatched_location, orders_package.id, orders_package.quantity)
-      }.to change(PackagesLocation, :count).by(1)
-      expect(package.reload.packages_locations.first.reference_to_orders_package).to eq orders_package.id
-    end
-  end
-
   describe '#create_or_update_orders_package_for_nested_designation_ and_dispatch_from_Stockit' do
     let(:order) { create :order }
     it 'creates new orders_package record for the package and recalculates quantity' do
@@ -550,31 +530,6 @@ RSpec.describe Package, type: :model do
       expect(package.quantity).to eq 0
       orders_package = package.reload.orders_packages.first
       expect(orders_package.quantity).to eq(package.received_quantity)
-    end
-  end
-
-  describe '#create_dispatched_packages_location_from_gc' do
-    let(:dispatched_location) { create :location, :dispatched }
-    let(:order) { create :order }
-    let(:orders_package) { create :orders_package, state: 'dispatched', package: package, order: order }
-    let(:dispatched_location) { create :location, :dispatched }
-
-    it 'creates dispatched packages location record against package if do not exist' do
-      expect{
-        package.create_dispatched_packages_location_from_gc(dispatched_location, orders_package.id, 1)
-      }.to change(PackagesLocation, :count).by(1)
-      first_location = package.reload.packages_locations.first
-      expect(first_location.location).to eq dispatched_location
-      expect(first_location.reference_to_orders_package).to eq orders_package.id
-      expect(first_location.quantity).to eq 1
-    end
-
-    it 'do not creates dispatched packages_location record if already exists' do
-      packages_location = create :packages_location, package: package, location: dispatched_location,
-        reference_to_orders_package: orders_package.id
-      expect{
-        package.create_dispatched_packages_location_from_gc(dispatched_location, orders_package.id, 1)
-      }.to change(PackagesLocation, :count).by(0)
     end
   end
 

--- a/spec/services/stockit/item_sync_spec.rb
+++ b/spec/services/stockit/item_sync_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Stockit::ItemSync do
-  let(:package)  { create :package, :stockit_package, :with_item , quantity:1, received_quantity: 1}
+  let(:package)  { create(:package, :stockit_package, :with_item , quantity:1, received_quantity: 1) }
   let(:inventory_number) { package.inventory_number }
   let(:stockit_inventory_number) { "X#{inventory_number}" }
   let(:stockit)  { described_class.new(package) }
@@ -107,4 +107,29 @@ describe Stockit::ItemSync do
     end
 
   end
+
+  context "stockit_location_id" do
+    context "dispatched package" do
+      let!(:dispatched_location) { create(:location, :dispatched) }
+      context "when stockit_sent_on is set" do
+        let(:package)  { create(:package, stockit_sent_on: Date.today) }
+        it "should return dispatched_location" do
+          expect(stockit.send(:stockit_location_id)).to eql(dispatched_location.stockit_id)
+        end
+      end
+      context "when orders_package state is dispatched" do
+        let(:package)  { create(:orders_package, :with_state_dispatched).package }
+        it "should return dispatched_location" do
+          expect(stockit.send(:stockit_location_id)).to eql(dispatched_location.stockit_id)
+        end
+      end
+    end
+    context "in-stock package" do
+      let(:package)  { create(:package, :package_with_locations, :with_item , quantity: 1, received_quantity: 1) }
+      it "should return the package location" do
+        expect(stockit.send(:stockit_location_id)).to eql(package.locations.first.stockit_id)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
### Ticket Link: 

GCW-2858

### What does this PR do?

FEATURE: Dispatched packages should no longer be in the Dispatched location

This is a fundamental change in the way we handle dispatched packages. We will no longer store them in the location 'Dispatched'. This smooths the way for the packages_inventories migration.

Note: once deployed, we will run a rake task to remove all packages_locations records that are in the 'Dispatched' location.

`rake goodcity:packages_locations:delete_dispatched_locations`

### Impacted Areas

* Package dispatch
* Packages Locations
* Stockit sync

There is also a separate PR for Stockit sync that ensures it tells GoodCity that the location is nil if the package is dispatched.

### Any Open question(s) or challenge(s):

* What happens to the app UI when packages are no longer in the 'Dispatched' location? Do they understand that packages with `stockit_sent_on` set and/or `orders_packages.where(state: 'dispatched')` are dispatched?