### PR TITLE
GCW-2890 rake for importing data for package detail from stockit

### DIFF
--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -2,6 +2,8 @@ class Computer < ActiveRecord::Base
   include SubformUtilities
   has_paper_trail class_name: 'Version'
 
+  validates :mar_os_serial_num, :mar_ms_office_serial_num, length: { is: 14 }, allow_nil: true, allow_blank: true
+
   belongs_to :comp_test_status, class_name: 'Lookup', required: false
   belongs_to :country, required: false
   has_one :package, as: :detail
@@ -11,5 +13,4 @@ class Computer < ActiveRecord::Base
   before_save :set_updated_by
   after_commit :create_on_stockit, on: :create, unless: :request_from_stockit?
   after_update :update_on_stockit, unless: :request_from_stockit?
-  validates :mar_os_serial_num, :mar_ms_office_serial_num, length: { is: 14 }, allow_nil: true, allow_blank: true
 end

--- a/app/models/concerns/subform_utilities.rb
+++ b/app/models/concerns/subform_utilities.rb
@@ -18,6 +18,7 @@ module SubformUtilities
 
   def create_on_stockit
     return if request_from_stockit?
+
     response = Stockit::ItemDetailSync.create(self)
     add_stockit_id(response)
   end

--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -40,8 +40,8 @@ module Stockit
       end
 
       # temporary method, to be removed after data import
-      def index_with_detail(package, offset, per_page)
-        new(package, offset, per_page).index_with_detail
+      def index_with_detail(offset, per_page, table_name)
+        new(nil, offset, per_page).index_with_detail(table_name)
       end
 
       def dispatch(package)
@@ -55,9 +55,9 @@ module Stockit
     end
 
     # temporary method, to be removed after data import
-    def index_with_detail
+    def index_with_detail(table_name)
       url = url_for("/api/v1/items_with_detail")
-      get(url, { offset: offset, per_page: per_page })
+      get(url, { offset: offset, per_page: per_page, table_name: table_name})
     end
 
     def create

--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -57,7 +57,8 @@ module Stockit
     # temporary method, to be removed after data import
     def index_with_detail(table_name)
       url = url_for("/api/v1/items_with_detail")
-      get(url, { offset: offset, per_page: per_page, table_name: table_name})
+      options = { offset: offset, per_page: per_page, table_name: table_name }
+      get(url, options)
     end
 
     def create

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -1,6 +1,6 @@
 module Goodcity
   class DetailFactory
-    PERMITTED_DETAIL_TYPES = %w[Computer Electrical ComputerAccessory].freeze
+    PERMITTED_DETAIL_TYPES = %w[computer electrical computer_accessory].freeze
     FIXED_DETAIL_ATTRIBUTES = %w[comp_test_status test_status frequency voltage].freeze
 
     attr_accessor :item, :package, :stockit_detail_id
@@ -12,7 +12,7 @@ module Goodcity
     end
 
     def run
-      package && import_and_save_detail? && package_updated?
+      import_and_save_detail? && !detail_present? && package_updated?
     end
 
     private
@@ -25,12 +25,16 @@ module Goodcity
       item["id"] && item["detail_type"] && stockit_detail_id
     end
 
+    def detail_present?
+      package.detail.present?
+    end
+
     def detail_type
       item["detail_type"] || package&.package_type&.subform&.titleize
     end
 
     def detail_id
-      return unless PERMITTED_DETAIL_TYPES.include?(item["detail_type"])
+      return unless PERMITTED_DETAIL_TYPES.include?(item["detail_type"].underscore)
       create_detail_record&.id
     end
 

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -28,15 +28,13 @@ module Goodcity
     private
 
     def create_detail_and_update_package
+      return false if package.detail.present? # check if records is present on GC
+
       package && package.update_columns(detail_id: create_detail, detail_type: detail_type)
     end
 
     def detail_present_on_stockit?
       stockit_item_hash["id"] && stockit_item_hash["detail_type"] && stockit_detail_id
-    end
-
-    def detail_present?
-      package.detail.present?
     end
 
     def detail_type

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -1,6 +1,6 @@
 module Goodcity
   class DetailFactory
-    PERMITTED_DETAIL_TYPES = %w[computer electrical computer_accessory].freeze
+    PERMITTED_DETAIL_TYPES = %w[Computer Electrical ComputerAccessory].freeze
     FIXED_DETAIL_ATTRIBUTES = %w[comp_test_status test_status frequency voltage].freeze
 
     attr_accessor :item, :package
@@ -11,11 +11,12 @@ module Goodcity
     end
 
     def run
-      if import_and_save_detail? && update_package_detail?
+      if package && import_and_save_detail? && update_package_detail?
         package&.update_columns(
           detail_id: detail_id,
           detail_type: detail_type,
         )
+        print "."
       end
     end
 
@@ -30,7 +31,7 @@ module Goodcity
     end
 
     def detail_type
-      item["detail_type"] || package&.package_type&.subform
+      item["detail_type"] || package&.package_type&.subform.titleize
     end
 
     def detail_id
@@ -40,11 +41,11 @@ module Goodcity
 
     def create_detail_record
       case detail_type
-      when "computer"
+      when "Computer"
         Computer.create(computer_attributes)
-      when "electrical"
+      when "Electrical"
         Electrical.create(electrical_attributes)
-      when "computer_accessory"
+      when "Computer_accessory"
         ComputerAccessory.create(computer_accessory_attributes)
       end
     end
@@ -79,10 +80,10 @@ module Goodcity
     end
 
     def lookup_hash
-      FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |item, hash|
-        if (key = detail_params[item].presence)
-          name = "electrical_#{item}" unless (item == "comp_test_status")
-          hash["#{item}_id"] = Lookup.find_by(name: name, key: key)&.id
+      FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |attr, hash|
+        if (key = item[attr].presence)
+          name = "electrical_#{attr}" unless (attr == "comp_test_status")
+          hash["#{attr}_id"] = Lookup.find_by(name: name, key: key)&.id
         end
       end
     end

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -47,10 +47,18 @@ module Goodcity
     end
 
     def create_detail_record
-      GoodcitySync.request_from_stockit = detail_present_on_stockit?
-      detail_type_class = detail_type.classify.constantize
-      detail_params = package_detail_attributes(PACKAGE_DETAIL_ATTRIBUTES["#{detail_type.underscore}".to_sym])
-      detail_type_class.where(stockit_id: stockit_detail_id).first_or_create(detail_params)
+      klass = detail_type.classify.constantize
+      # create detail record with data
+      if detail_present_on_stockit?
+        GoodcitySync.request_from_stockit = true
+        klass.where(stockit_id: stockit_detail_id).first_or_create(
+          package_detail_attributes(PACKAGE_DETAIL_ATTRIBUTES["#{detail_type.underscore}".to_sym])
+        )
+      else
+        # create empty detail record
+        GoodcitySync.request_from_stockit = false
+        klass.create({})
+      end
     end
 
     def package_detail_attributes(attributes)

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -11,7 +11,7 @@ module Goodcity
     end
 
     def run
-      if package && import_and_save_detail? && update_package_detail?
+      if package && import_and_save_detail?
         package&.update_columns(
           detail_id: detail_id,
           detail_type: detail_type,
@@ -26,10 +26,6 @@ module Goodcity
       item["id"] && item["detail_type"] && item["detail_id"]
     end
 
-    def update_package_detail?
-      detail_id && detail_type
-    end
-
     def detail_type
       item["detail_type"] || package&.package_type&.subform.titleize
     end
@@ -40,13 +36,14 @@ module Goodcity
     end
 
     def create_detail_record
+      GoodcitySync.request_from_stockit = true
       case detail_type
       when "Computer"
-        Computer.create(computer_attributes)
+        Computer.where(stockit_id: item["detail_id"]).first_or_create(computer_attributes)
       when "Electrical"
-        Electrical.create(electrical_attributes)
+        Electrical.where(stockit_id: item["detail_id"]).first_or_create(electrical_attributes)
       when "Computer_accessory"
-        ComputerAccessory.create(computer_accessory_attributes)
+        ComputerAccessory.where(stockit_id: item["detail_id"]).first_or_create(computer_accessory_attributes)
       end
     end
 
@@ -58,6 +55,7 @@ module Goodcity
         size sound usb video wireless].each do |attr|
         attr_hash.merge({ "#{attr}": item["#{attr}"] })
       end
+      attr_hash["stockit_id"] = item["detail_id"]
       attr_hash.merge(lookup_hash)
     end
 
@@ -67,6 +65,7 @@ module Goodcity
         system_or_region].each do |attr|
         attr_hash.merge({ "#{attr}": item["#{attr}"] })
       end
+      attr_hash["stockit_id"] = item["detail_id"]
       attr_hash.merge(lookup_hash)
     end
 
@@ -76,6 +75,7 @@ module Goodcity
         model serial_num size].each do |attr|
         attr_hash.merge({ "#{attr}": item["#{attr}"] })
       end
+      attr_hash["stockit_id"] = item["detail_id"]
       attr_hash.merge(lookup_hash)
     end
 

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -1,0 +1,90 @@
+module Goodcity
+  class DetailFactory
+    PERMITTED_DETAIL_TYPES = %w[computer electrical computer_accessory].freeze
+    FIXED_DETAIL_ATTRIBUTES = %w[comp_test_status test_status frequency voltage].freeze
+
+    attr_accessor :item, :package
+
+    def initialize(item, package)
+      @item = item
+      @package = package
+    end
+
+    def run
+      if import_and_save_detail? && update_package_detail?
+        package&.update_columns(
+          detail_id: detail_id,
+          detail_type: detail_type,
+        )
+      end
+    end
+
+    private
+
+    def import_and_save_detail?
+      item["id"] && item["detail_type"] && item["detail_id"]
+    end
+
+    def update_package_detail?
+      detail_id && detail_type
+    end
+
+    def detail_type
+      item["detail_type"] || package&.package_type&.subform
+    end
+
+    def detail_id
+      return unless PERMITTED_DETAIL_TYPES.include?(item["detail_type"])
+      create_detail_record&.id
+    end
+
+    def create_detail_record
+      case detail_type
+      when "computer"
+        Computer.create(computer_attributes)
+      when "electrical"
+        Electrical.create(electrical_attributes)
+      when "computer_accessory"
+        ComputerAccessory.create(computer_accessory_attributes)
+      end
+    end
+
+    def computer_attributes
+      attr_hash = {}
+      %w[brand comp_voltage country_id cpu hdd
+        lan mar_ms_office_serial_num mar_os_serial_num model
+        ms_office_serial_num optical os os_serial_num ram serial_num
+        size sound usb video wireless].each do |attr|
+        attr_hash.merge({ "#{attr}": item["#{attr}"] })
+      end
+      attr_hash.merge(lookup_hash)
+    end
+
+    def electrical_attributes
+      attr_hash = {}
+      %w[brand country_id model power serial_number standard
+        system_or_region].each do |attr|
+        attr_hash.merge({ "#{attr}": item["#{attr}"] })
+      end
+      attr_hash.merge(lookup_hash)
+    end
+
+    def computer_accessory_attributes
+      attr_hash = {}
+      %w[brand comp_voltage country_id interface
+        model serial_num size].each do |attr|
+        attr_hash.merge({ "#{attr}": item["#{attr}"] })
+      end
+      attr_hash.merge(lookup_hash)
+    end
+
+    def lookup_hash
+      FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |item, hash|
+        if (key = detail_params[item].presence)
+          name = "electrical_#{item}" unless (item == "comp_test_status")
+          hash["#{item}_id"] = Lookup.find_by(name: name, key: key)&.id
+        end
+      end
+    end
+  end
+end

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -26,7 +26,7 @@ module Goodcity
     end
 
     def detail_type
-      item["detail_type"] || package&.package_type&.subform.titleize
+      item["detail_type"] || package&.package_type&.subform&.titleize
     end
 
     def detail_id
@@ -37,16 +37,18 @@ module Goodcity
     def create_detail_record
       GoodcitySync.request_from_stockit = true
       detail_type.classify.constantize.where(stockit_id: stockit_detail_id)
-      .first_or_create(send "#{detail_type.underscore}_attributes".to_sym)
+                 .first_or_create(send("#{detail_type.underscore}_attributes".to_sym))
     end
 
     def computer_attributes
       attr_hash = {}
-      %w[brand comp_voltage country_id cpu hdd
+      %w[
+        brand comp_voltage country_id cpu hdd
         lan mar_ms_office_serial_num mar_os_serial_num model
         ms_office_serial_num optical os os_serial_num ram serial_num
-        size sound usb video wireless].each do |attr|
-        attr_hash.merge({ "#{attr}": item["#{attr}"] })
+        size sound usb video wireless
+      ].each do |attr|
+        attr_hash.merge({ "#{attr}": item[attr.to_s] })
       end
       attr_hash["stockit_id"] = stockit_detail_id
       attr_hash.merge(lookup_hash)
@@ -54,9 +56,11 @@ module Goodcity
 
     def electrical_attributes
       attr_hash = {}
-      %w[brand country_id model power serial_number standard
-        system_or_region].each do |attr|
-        attr_hash.merge({ "#{attr}": item["#{attr}"] })
+      %w[
+        brand country_id model power serial_number standard
+        system_or_region
+      ].each do |attr|
+        attr_hash.merge({ "#{attr}": item[attr.to_s] })
       end
       attr_hash["stockit_id"] = stockit_detail_id
       attr_hash.merge(lookup_hash)
@@ -64,9 +68,11 @@ module Goodcity
 
     def computer_accessory_attributes
       attr_hash = {}
-      %w[brand comp_voltage country_id interface
-        model serial_num size].each do |attr|
-        attr_hash.merge({ "#{attr}": item["#{attr}"] })
+      %w[
+        brand comp_voltage country_id interface
+        model serial_num size
+      ].each do |attr|
+        attr_hash.merge({ "#{attr}": item[attr.to_s] })
       end
       attr_hash["stockit_id"] = stockit_detail_id
       attr_hash.merge(lookup_hash)
@@ -74,7 +80,7 @@ module Goodcity
 
     def lookup_hash
       FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |attr, hash|
-        if (key = item[attr].presence)
+        if key = item[attr].presence
           name = "electrical_#{attr}" unless (attr == "comp_test_status")
           hash["#{attr}_id"] = Lookup.find_by(name: name, key: key)&.id
         end

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -22,6 +22,7 @@ module Goodcity
     end
 
     def run
+      debugger
       create_detail_and_update_package
     end
 
@@ -29,7 +30,7 @@ module Goodcity
 
     def create_detail_and_update_package
       return false if package.detail.present? # check if records is present on GC
-
+      debugger
       package && package.update_columns(detail_id: create_detail, detail_type: detail_type)
     end
 
@@ -42,6 +43,7 @@ module Goodcity
     end
 
     def create_detail
+      debugger
       return unless PERMITTED_DETAIL_TYPES.include?(detail_type.underscore)
       create_detail_record.id
     end

--- a/lib/goodcity/detail_factory.rb
+++ b/lib/goodcity/detail_factory.rb
@@ -2,7 +2,7 @@ module Goodcity
   class DetailFactory
     PERMITTED_DETAIL_TYPES = %w[computer electrical computer_accessory].freeze
     FIXED_DETAIL_ATTRIBUTES = %w[comp_test_status test_status frequency voltage].freeze
-    REJECT_ATTRIBUTES=%w[detail_type detail_id package_id]
+    REJECT_ATTRIBUTES= %w[detail_type detail_id package_id].freeze
     PACKAGE_DETAIL_ATTRIBUTES = {
       computer_accessory: %w[brand comp_voltage country_id interface
         model serial_num size].freeze,
@@ -64,7 +64,7 @@ module Goodcity
 
     def lookup_hash
       FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |attr, hash|
-        if key = stockit_item_hash[attr].presence
+        if (key = stockit_item_hash[attr].presence)
           name = "electrical_#{attr}" unless (attr == "comp_test_status")
           hash["#{attr}_id"] = Lookup.find_by(name: name, key: key)&.id
         end

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -6,23 +6,31 @@ namespace :stockit do
   desc 'Import data from stockit for item detail and save it in package'
   task add_stockit_items_detail_to_packages: :environment do
     log = Goodcity::RakeLogger.new("add_stockit_items_detail_to_packages")
-    offset = 0
-    per_page = 1000
-
-    loop do
-      items_json = Stockit::ItemSync.new(nil, offset, per_page).index_with_detail
-      offset += per_page
-      stockit_items = JSON.parse(items_json["items"])
-      break if stockit_items.blank?
-
-      stockit_items.each do |item|
-        package = Package.find_by(stockit_id: item["id"]) if item["id"]
-        begin
-          Goodcity::DetailFactory.new(item, package).run
-        rescue => exception
-          log.error "(#{exception.message})"
+    count = 0
+    ["electricals", "computers", "computer_accessories"].each do |table_name|
+      offset = 0
+      per_page = 10000000
+      loop do
+        items_json = Stockit::ItemSync.index_with_detail(offset, per_page, table_name)
+        offset += per_page
+        stockit_items = JSON.parse(items_json["items"])
+        break if stockit_items.blank?
+        stockit_items.each do |item|
+          item_id = item["package_id"].presence
+          package = Package.find_by(stockit_id: item["package_id"]) if item_id
+          begin
+            is_package_updated = Goodcity::DetailFactory.new(item, package).run
+          rescue => exception
+            log.error("package: #{package.id}, stockit_item: #{item_id} #{exception.message}")
+          end
+          if is_package_updated
+            print "."
+            count += 1
+          end
         end
       end
     end
+    puts "\n#{count} packages updated with new details from stockit"
+    log.info("#{count} packages updated with new details from stockit")
   end
 end

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -15,17 +15,16 @@ namespace :stockit do
         offset += per_page
         stockit_items = JSON.parse(items_json["items"])
         break if stockit_items.blank?
-        stockit_items.each do |item|
-          item_id = item["package_id"].presence
-          package = Package.find_by(stockit_id: item["package_id"]) if item_id
-          begin
-            is_package_updated = Goodcity::DetailFactory.new(item, package).run
-          rescue StandardError => exception
-            log.error("package: #{package.id}, stockit_item: #{item_id} #{exception.message}")
-          end
-          if is_package_updated
-            print "."
-            count += 1
+        stockit_items.each do |stockit_item|
+          stockit_item_id = stockit_item["package_id"].presence
+          package = Package.find_by(stockit_id: stockit_item["package_id"])
+          if package
+            begin
+              package_updated = Goodcity::DetailFactory.new(stockit_item, package).run
+            rescue StandardError => exception
+              log.error("package: #{package.id}, stockit_item: #{stockit_item_id} #{exception.message}")
+            end
+            print "."; count += 1 if package_updated
           end
         end
       end

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -24,11 +24,7 @@ namespace :stockit do
             rescue StandardError => exception
               log.error("package: #{package.id}, stockit_item: #{stockit_item_id} #{exception.message}")
             end
-
-            if package_updated
-              count += 1
-              print "."
-            end
+            count += 1 and print "." if package_updated
           end
         end
       end

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -1,0 +1,120 @@
+PERMITTED_DETAIL_TYPES = %w[computer electrical computer_accessory].freeze
+FIXED_DETAIL_ATTRIBUTES = %w[comp_test_status test_status frequency voltage].freeze
+
+#import data from stockit for item detail and save it in package.
+namespace :stockit do
+  desc 'Load all item detail records from Stockit'
+  task add_stockit_item_details_to_packages: :environment do
+    offset = 0
+    per_page = 1000
+
+    loop do
+      items_json = Stockit::ItemSync.new(nil, offset, per_page).index_with_detail
+      offset += per_page
+      stockit_items = JSON.parse(items_json["items"])
+      bar = RakeProgressbar.new(stockit_items.size)
+      break if stockit_items.blank?
+
+      stockit_items.each do |item|
+        bar.inc
+        package = Package.find_by(stockit_id: item["id"]) if item["id"]
+        TaskMethods.new(item, package).run
+      end
+    end
+    bar.finished
+  end
+end
+
+class TaskMethods
+  attr_accessor :item, :package
+
+  def initialize(item, package)
+    @item = item
+    @package = package
+  end
+
+  def run
+    if package && import_and_save_detail? && update_package_detail?
+      package&.update_columns(
+        detail_id: detail_id,
+        detail_type: detail_type,
+      )
+    end
+  end
+
+  def import_and_save_detail?
+    item["id"] && item["detail_type"] && item["detail_id"]
+  end
+
+  def create_new_record?
+    item["detail_id"].nil? || item["detail_id"].blank?
+  end
+
+  def create_detail_with_attributes
+    case detail_type
+    when "computer"
+      Computer.create(computer_attributes)
+    when "electrical"
+      Electrical.create(electrical_attributes)
+    when "computer_accessory"
+      ComputerAccessory.create(computer_accessory_attributes)
+    end
+  end
+
+  def create_empty_record
+    detail_type.classify&.constantize.create unless detail_type.blank?
+  end
+
+  def detail_type
+    item["detail_type"] || package.package_type&.subform
+  end
+
+  def detail_id
+    return unless PERMITTED_DETAIL_TYPES.include?(item["detail_type"])
+
+    create_new_record? ? create_empty_record&.id : create_detail_with_attributes&.id
+  end
+
+  def computer_attributes
+    attr_hash = {}
+    %w[brand comp_voltage country_id cpu hdd
+      lan mar_ms_office_serial_num mar_os_serial_num model
+      ms_office_serial_num optical os os_serial_num ram serial_num
+      size sound usb video wireless].each do |attr|
+      attr_hash.merge({ "#{attr}": item["#{attr}"] })
+    end
+    attr_hash.merge(lookup_hash)
+  end
+
+  def electrical_attributes
+    attr_hash = {}
+    %w[brand country_id model power serial_number standard
+      system_or_region].each do |attr|
+      attr_hash.merge({ "#{attr}": item["#{attr}"] })
+    end
+    attr_hash.merge(lookup_hash)
+  end
+
+  def computer_accessory_attributes
+    attr_hash = {}
+    %w[brand comp_voltage country_id interface
+      model serial_num size].each do |attr|
+      attr_hash.merge({ "#{attr}": item["#{attr}"] })
+    end
+    attr_hash.merge(lookup_hash)
+  end
+
+  def lookup_hash
+    FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |item, hash|
+      if (key = detail_params[item].presence)
+        name = "electrical_#{item}" unless (item == "comp_test_status")
+        hash["#{item}_id"] = Lookup.find_by(name: name, key: key)&.id
+      end
+    end
+  end
+
+  def update_package_detail?
+    detail_id && detail_type
+  end
+end
+

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -10,17 +10,12 @@ namespace :stockit do
       items_json = Stockit::ItemSync.new(nil, offset, per_page).index_with_detail
       offset += per_page
       stockit_items = JSON.parse(items_json["items"])
-      bar = RakeProgressbar.new(stockit_items.size)
       break if stockit_items.blank?
 
       stockit_items.each do |item|
-        bar.inc
         package = Package.find_by(stockit_id: item["id"]) if item["id"]
-        next unless package
-
         Goodcity::DetailFactory.new(item, package).run
       end
     end
-    bar.finished
   end
 end

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -1,8 +1,11 @@
 #rake stockit:add_stockit_items_detail_to_packages
 require "goodcity/detail_factory"
+require "goodcity/rake_logger"
+
 namespace :stockit do
   desc 'Import data from stockit for item detail and save it in package'
   task add_stockit_items_detail_to_packages: :environment do
+    log = Goodcity::RakeLogger.new("add_stockit_items_detail_to_packages")
     offset = 0
     per_page = 1000
 
@@ -14,7 +17,11 @@ namespace :stockit do
 
       stockit_items.each do |item|
         package = Package.find_by(stockit_id: item["id"]) if item["id"]
-        Goodcity::DetailFactory.new(item, package).run
+        begin
+          Goodcity::DetailFactory.new(item, package).run
+        rescue => exception
+          log.error "(#{exception.message})"
+        end
       end
     end
   end

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -1,10 +1,8 @@
-PERMITTED_DETAIL_TYPES = %w[computer electrical computer_accessory].freeze
-FIXED_DETAIL_ATTRIBUTES = %w[comp_test_status test_status frequency voltage].freeze
-
-#import data from stockit for item detail and save it in package.
+#rake stockit:add_stockit_items_detail_to_packages
+require "goodcity/detail_factory"
 namespace :stockit do
-  desc 'Load all item detail records from Stockit'
-  task add_stockit_item_details_to_packages: :environment do
+  desc 'Import data from stockit for item detail and save it in package'
+  task add_stockit_items_detail_to_packages: :environment do
     offset = 0
     per_page = 1000
 
@@ -18,103 +16,11 @@ namespace :stockit do
       stockit_items.each do |item|
         bar.inc
         package = Package.find_by(stockit_id: item["id"]) if item["id"]
-        TaskMethods.new(item, package).run
+        next unless package
+
+        Goodcity::DetailFactory.new(item, package).run
       end
     end
     bar.finished
   end
 end
-
-class TaskMethods
-  attr_accessor :item, :package
-
-  def initialize(item, package)
-    @item = item
-    @package = package
-  end
-
-  def run
-    if package && import_and_save_detail? && update_package_detail?
-      package&.update_columns(
-        detail_id: detail_id,
-        detail_type: detail_type,
-      )
-    end
-  end
-
-  def import_and_save_detail?
-    item["id"] && item["detail_type"] && item["detail_id"]
-  end
-
-  def create_new_record?
-    item["detail_id"].nil? || item["detail_id"].blank?
-  end
-
-  def create_detail_with_attributes
-    case detail_type
-    when "computer"
-      Computer.create(computer_attributes)
-    when "electrical"
-      Electrical.create(electrical_attributes)
-    when "computer_accessory"
-      ComputerAccessory.create(computer_accessory_attributes)
-    end
-  end
-
-  def create_empty_record
-    detail_type.classify&.constantize.create unless detail_type.blank?
-  end
-
-  def detail_type
-    item["detail_type"] || package.package_type&.subform
-  end
-
-  def detail_id
-    return unless PERMITTED_DETAIL_TYPES.include?(item["detail_type"])
-
-    create_new_record? ? create_empty_record&.id : create_detail_with_attributes&.id
-  end
-
-  def computer_attributes
-    attr_hash = {}
-    %w[brand comp_voltage country_id cpu hdd
-      lan mar_ms_office_serial_num mar_os_serial_num model
-      ms_office_serial_num optical os os_serial_num ram serial_num
-      size sound usb video wireless].each do |attr|
-      attr_hash.merge({ "#{attr}": item["#{attr}"] })
-    end
-    attr_hash.merge(lookup_hash)
-  end
-
-  def electrical_attributes
-    attr_hash = {}
-    %w[brand country_id model power serial_number standard
-      system_or_region].each do |attr|
-      attr_hash.merge({ "#{attr}": item["#{attr}"] })
-    end
-    attr_hash.merge(lookup_hash)
-  end
-
-  def computer_accessory_attributes
-    attr_hash = {}
-    %w[brand comp_voltage country_id interface
-      model serial_num size].each do |attr|
-      attr_hash.merge({ "#{attr}": item["#{attr}"] })
-    end
-    attr_hash.merge(lookup_hash)
-  end
-
-  def lookup_hash
-    FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |item, hash|
-      if (key = detail_params[item].presence)
-        name = "electrical_#{item}" unless (item == "comp_test_status")
-        hash["#{item}_id"] = Lookup.find_by(name: name, key: key)&.id
-      end
-    end
-  end
-
-  def update_package_detail?
-    detail_id && detail_type
-  end
-end
-

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -1,4 +1,4 @@
-#rake stockit:add_stockit_items_detail_to_packages
+# rake stockit:add_stockit_items_detail_to_packages
 require "goodcity/detail_factory"
 require "goodcity/rake_logger"
 
@@ -7,9 +7,9 @@ namespace :stockit do
   task add_stockit_items_detail_to_packages: :environment do
     log = Goodcity::RakeLogger.new("add_stockit_items_detail_to_packages")
     count = 0
-    ["electricals", "computers", "computer_accessories"].each do |table_name|
+    %w[electricals computers computer_accessories].each do |table_name|
       offset = 0
-      per_page = 10000000
+      per_page = 1000
       loop do
         items_json = Stockit::ItemSync.index_with_detail(offset, per_page, table_name)
         offset += per_page
@@ -20,7 +20,7 @@ namespace :stockit do
           package = Package.find_by(stockit_id: item["package_id"]) if item_id
           begin
             is_package_updated = Goodcity::DetailFactory.new(item, package).run
-          rescue => exception
+          rescue StandardError => exception
             log.error("package: #{package.id}, stockit_item: #{item_id} #{exception.message}")
           end
           if is_package_updated

--- a/lib/tasks/stockit_item_detail_import.rake
+++ b/lib/tasks/stockit_item_detail_import.rake
@@ -24,7 +24,11 @@ namespace :stockit do
             rescue StandardError => exception
               log.error("package: #{package.id}, stockit_item: #{stockit_item_id} #{exception.message}")
             end
-            print "."; count += 1 if package_updated
+
+            if package_updated
+              count += 1
+              print "."
+            end
           end
         end
       end

--- a/spec/lib/goodcity/detail_factory_spec.rb
+++ b/spec/lib/goodcity/detail_factory_spec.rb
@@ -2,13 +2,52 @@ require "rails_helper"
 require "goodcity/detail_factory"
 
 describe Goodcity::DetailFactory do
-  let(:item_params) {  }
-  let(:pacakge) {}
-  let(:detail_factory) { described_class.new(item_params, package) }
+  PACKAGE_DETAIL_TYPES = {
+    computer: {
+      "stockit_id": "1231",
+      "brand": "Asus",
+      "cpu": "1GhZ",
+      "model": "GCW123SAD123",
+      "sound": "Dolby Digital",
+      "usb": "test123",
+      "serial_num": "serial number"
+    },
+    electrical: {
+      "stockit_id": "1230",
+      "brand": "Asus",
+      "model": "GCW123SAD123",
+      "serial_num": "serial number",
+      "power": "power"
+    },
+    computer_accessory: {
+      "stockit_id": "1232",
+      "brand": "Asus",
+      "model": "GCW123SAD123",
+      "serial_num": "serial number",
+    }
+  }
 
-  before do
-    stub_request(:get, /goodcitystorage.blob.core.windows.net/).
-      with(headers: { "Accept" => "*/*", "User-Agent" => "Ruby" }).
-      to_return(status: 200, body: file, headers: {}).response.body
+  def stock_item_hash_for(detail_type)
+    PACKAGE_DETAIL_TYPES[detail_type.to_sym].merge({"detail_type": detail_type})
+  end
+
+  describe "run" do
+    it "creates a blank detail record and assigns it to package" do
+      ["electrical", "computer", "computer_accessory"].each_with_index do |detail_type, index|
+        package = create(:package, :with_inventory_number, stockit_id: "123#{index}")
+        detail_factory = described_class.new(stock_item_hash_for(detail_type), package)
+        detail_factory.run
+        expect(@package.detail.present?).to eq(true)
+      end
+    end
+
+    it "creates a record with data and assigns it to package" do
+      ["electrical", "computer", "computer_accessory"].each_with_index do |detail_type, index|
+        package = create(:package, :with_inventory_number, stockit_id: "223#{index}")
+        detail_factory = described_class.new({}, package)
+        detail_factory.run
+        expect(@package.detail.present?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/lib/goodcity/detail_factory_spec.rb
+++ b/spec/lib/goodcity/detail_factory_spec.rb
@@ -5,48 +5,91 @@ describe Goodcity::DetailFactory do
   PACKAGE_DETAIL_TYPES = {
     computer: {
       "stockit_id": "1231",
-      "brand": "Asus",
+      "brand": "asus",
       "cpu": "1GhZ",
+      "detail_id": "1234",
       "model": "GCW123SAD123",
       "sound": "Dolby Digital",
       "usb": "test123",
-      "serial_num": "serial number"
+      "serial_num": "serialNumber"
     },
     electrical: {
       "stockit_id": "1230",
-      "brand": "Asus",
-      "model": "GCW123SAD123",
-      "serial_num": "serial number",
-      "power": "power"
+      "brand": "havells",
+      "detail_id": "1239",
+      "model": "GCW123SAD1234",
+      "serial_num": "serialNumber",
+      "power": "power",
     },
     computer_accessory: {
       "stockit_id": "1232",
-      "brand": "Asus",
-      "model": "GCW123SAD123",
-      "serial_num": "serial number",
+      "brand": "dell",
+      "model": "GCW123SAD1235",
+      "detail_id": "12431",
+      "serial_num": "serialNumber"
     }
   }
 
-  def stock_item_hash_for(detail_type)
-    PACKAGE_DETAIL_TYPES[detail_type.to_sym].merge({"detail_type": detail_type})
+  def stock_item_hash_for(detail_type, pkg_id)
+    PACKAGE_DETAIL_TYPES[detail_type.to_sym].merge({"detail_type": detail_type, "package_id": pkg_id})
   end
 
-  describe "run" do
-    it "creates a blank detail record and assigns it to package" do
-      ["electrical", "computer", "computer_accessory"].each_with_index do |detail_type, index|
-        package = create(:package, :with_inventory_number, stockit_id: "123#{index}")
-        detail_factory = described_class.new(stock_item_hash_for(detail_type), package)
+  context "run" do
+    describe "creates a detail record with data and assigns it to package" do
+      it "creates computer" do
+        package = create(:package, :with_inventory_number, stockit_id: "1231")
+        detail_factory = described_class.new(stock_item_hash_for("computer", package.id), package)
         detail_factory.run
-        expect(@package.detail.present?).to eq(true)
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq("GCW123SAD123")
+        expect(package.detail.brand).to eq("asus")
+      end
+
+      it "creates electrical" do
+        package = create(:package, :with_inventory_number, stockit_id: "1230")
+        detail_factory = described_class.new(stock_item_hash_for("electrical", package.id), package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq("GCW123SAD1234")
+        expect(package.detail.brand).to eq("havells")
+      end
+
+      it "creates computer_accessory" do
+        package = create(:package, :with_inventory_number, stockit_id: "1232")
+        detail_factory = described_class.new(stock_item_hash_for("computer_accessory", package.id), package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq("GCW123SAD1235")
+        expect(package.detail.brand).to eq("dell")
       end
     end
 
-    it "creates a record with data and assigns it to package" do
-      ["electrical", "computer", "computer_accessory"].each_with_index do |detail_type, index|
-        package = create(:package, :with_inventory_number, stockit_id: "223#{index}")
-        detail_factory = described_class.new({}, package)
+    describe "creates a blank detail record" do
+      it "with computer" do
+        package = create(:package, :with_inventory_number, stockit_id: 2221)
+        detail_factory = described_class.new({detail_type: "computer"}, package)
         detail_factory.run
-        expect(@package.detail.present?).to eq(true)
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq(nil)
+        expect(package.detail.brand).to eq(nil)
+      end
+
+      it "with electrical" do
+        package = create(:package, :with_inventory_number, stockit_id: 2220)
+        detail_factory = described_class.new({detail_type: "electrical"}, package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq(nil)
+        expect(package.detail.brand).to eq(nil)
+      end
+
+      it "with computer_accessory" do
+        package = create(:package, :with_inventory_number, stockit_id: 2223)
+        detail_factory = described_class.new({detail_type: "computer_accessory"}, package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq(nil)
+        expect(package.detail.brand).to eq(nil)
       end
     end
   end

--- a/spec/lib/goodcity/detail_factory_spec.rb
+++ b/spec/lib/goodcity/detail_factory_spec.rb
@@ -18,7 +18,7 @@ describe Goodcity::DetailFactory do
       "brand": "havells",
       "detail_id": "1239",
       "model": "GCW123SAD1234",
-      "serial_num": "serialNumber",
+      "serial_number": "serialNumber",
       "power": "power",
     },
     computer_accessory: {
@@ -43,6 +43,7 @@ describe Goodcity::DetailFactory do
         expect(package.detail.present?).to eq(true)
         expect(package.detail.model).to eq("GCW123SAD123")
         expect(package.detail.brand).to eq("asus")
+        expect(package.detail.serial_num).to eq("serialNumber")
       end
 
       it "creates electrical" do
@@ -52,6 +53,7 @@ describe Goodcity::DetailFactory do
         expect(package.detail.present?).to eq(true)
         expect(package.detail.model).to eq("GCW123SAD1234")
         expect(package.detail.brand).to eq("havells")
+        expect(package.detail.serial_number).to eq("serialNumber")
       end
 
       it "creates computer_accessory" do
@@ -61,6 +63,7 @@ describe Goodcity::DetailFactory do
         expect(package.detail.present?).to eq(true)
         expect(package.detail.model).to eq("GCW123SAD1235")
         expect(package.detail.brand).to eq("dell")
+        expect(package.detail.serial_num).to eq("serialNumber")
       end
     end
 
@@ -72,6 +75,7 @@ describe Goodcity::DetailFactory do
         expect(package.detail.present?).to eq(true)
         expect(package.detail.model).to eq(nil)
         expect(package.detail.brand).to eq(nil)
+        expect(package.detail.serial_num).to eq(nil)
       end
 
       it "with electrical" do
@@ -80,6 +84,7 @@ describe Goodcity::DetailFactory do
         detail_factory.run
         expect(package.detail.present?).to eq(true)
         expect(package.detail.model).to eq(nil)
+        expect(package.detail.serial_number).to eq(nil)
         expect(package.detail.brand).to eq(nil)
       end
 
@@ -89,6 +94,7 @@ describe Goodcity::DetailFactory do
         detail_factory.run
         expect(package.detail.present?).to eq(true)
         expect(package.detail.model).to eq(nil)
+        expect(package.detail.serial_num).to eq(nil)
         expect(package.detail.brand).to eq(nil)
       end
     end

--- a/spec/lib/goodcity/detail_factory_spec.rb
+++ b/spec/lib/goodcity/detail_factory_spec.rb
@@ -8,6 +8,7 @@ describe Goodcity::DetailFactory do
       "brand": "asus",
       "cpu": "1GhZ",
       "detail_id": "1234",
+      "id": "1234",
       "model": "GCW123SAD123",
       "sound": "Dolby Digital",
       "usb": "test123",
@@ -17,6 +18,7 @@ describe Goodcity::DetailFactory do
       "stockit_id": "1230",
       "brand": "havells",
       "detail_id": "1239",
+      "id": "1239",
       "model": "GCW123SAD1234",
       "serial_number": "serialNumber",
       "power": "power",
@@ -26,6 +28,7 @@ describe Goodcity::DetailFactory do
       "brand": "dell",
       "model": "GCW123SAD1235",
       "detail_id": "12431",
+      "id": "12431",
       "serial_num": "serialNumber"
     }
   }
@@ -96,6 +99,50 @@ describe Goodcity::DetailFactory do
         expect(package.detail.model).to eq(nil)
         expect(package.detail.serial_num).to eq(nil)
         expect(package.detail.brand).to eq(nil)
+      end
+    end
+
+    describe 'creates empty record on gc if not present on stockit' do
+      it "with computer" do
+        package_type = create(:package_type, subform: "computer")
+        package = create(:package, :with_inventory_number, stockit_id: 2221, package_type: package_type)
+        detail_factory = described_class.new({detail_type: "computer"}, package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq(nil)
+        expect(package.detail.brand).to eq(nil)
+        expect(package.detail.serial_num).to eq(nil)
+      end
+
+      it "with electrical" do
+        package_type = create(:package_type, subform: "electrical")
+        package = create(:package, :with_inventory_number, stockit_id: 2220, package_type: package_type)
+        detail_factory = described_class.new({}, package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq(nil)
+        expect(package.detail.serial_number).to eq(nil)
+        expect(package.detail.brand).to eq(nil)
+      end
+
+      it "with computer_accessory" do
+        package_type = create(:package_type, subform: "computer_accessory")
+        package = create(:package, :with_inventory_number, stockit_id: 2222, package_type: package_type)
+        detail_factory = described_class.new({}, package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(true)
+        expect(package.detail.model).to eq(nil)
+        expect(package.detail.serial_num).to eq(nil)
+        expect(package.detail.brand).to eq(nil)
+      end
+    end
+
+    describe "doesnot create detail if subform comes as medical" do
+      it "with computer" do
+        package = create(:package, :with_inventory_number, stockit_id: 2221)
+        detail_factory = described_class.new({detail_type: "medical"}, package)
+        detail_factory.run
+        expect(package.detail.present?).to eq(false)
       end
     end
   end

--- a/spec/lib/goodcity/detail_factory_spec.rb
+++ b/spec/lib/goodcity/detail_factory_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+require "goodcity/detail_factory"
+
+describe Goodcity::DetailFactory do
+  let(:item_params) {  }
+  let(:pacakge) {}
+  let(:detail_factory) { described_class.new(item_params, package) }
+
+  before do
+    stub_request(:get, /goodcitystorage.blob.core.windows.net/).
+      with(headers: { "Accept" => "*/*", "User-Agent" => "Ruby" }).
+      to_return(status: 200, body: file, headers: {}).response.body
+  end
+end


### PR DESCRIPTION
### What does this PR do?

This PR adds a rake task to manage previous data for packages. On stockit,
1. Fetch packages(items) from stockit
2. Check for details, if present, create a record for those details on GC
3. If not present, create a blank record on GC which will get synced to Stockit.

### Impacted Areas
Package detail data.

Stockit PR link https://bitbucket.org/crfdevs/stockit/pull-requests/72