### PR TITLE
Include orders_packages in orders#show

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -55,15 +55,17 @@ module Api
       api :GET, '/v1/designations/1', "Get a order"
       def show
         root = is_browse_app? ? "order" : "designation"
-        render json: @order,
-          serializer: serializer,
+        render json: serializer.new(@order,
           root: root,
           exclude_code_details: true,
           include_packages: bool_param(:include_packages, true),
           include_order: false,
           include_territory: true,
           include_images: true,
+          include_allowed_actions: true,
+          include_orders_packages: true,
           exclude_stockit_set_item: true
+        )
       end
 
       def transition

--- a/app/serializers/api/v1/order_serializer.rb
+++ b/app/serializers/api/v1/order_serializer.rb
@@ -44,7 +44,9 @@ module Api::V1
     end
 
     def include_orders_packages?
-      !@options[:include_packages] && !@options[:include_order]
+      @options[:include_orders_packages] || (
+        !@options[:include_packages] && !@options[:include_order]
+      )
     end
 
     alias_method :include_stockit_contact?, :include_non_browse_details?


### PR DESCRIPTION
### Ticket Link: 

GCW-2779

### What does this PR do?

- OrdersPackages were missing when doing `GET /orders/:id` because of weird Serializer logic. 
I added an explicit argument that defaults to false
- Including the orders_packages 'allowed actions'
