### PR TITLE
fix comp test status sync issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'apipie-rails' , git: "https://github.com/Apipie/apipie-rails.git", branch: 
 gem "go_go_van_api", git: "git@github.com:crossroads/go_go_van_api.git", branch: 'master'
 gem 'by_star', git: "https://github.com/radar/by_star.git"
 gem 'nestful', git: "https://github.com/maccman/nestful.git"
-gem 'nokogiri'
+gem 'nokogiri', '>= 1.0.4'
 gem 'sidekiq'
 gem 'sidekiq-statistic'
 gem 'sinatra', require: nil # for sidekiq reporting console

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'ffaker'
 gem 'execjs'
 # shivani - changed from jwt 0.1.13 to 1.2.0
 gem 'jwt', '~> 1.2.0'
-gem 'rack-cors'
+gem 'rack-cors', '>= 1.0.4'
 gem 'rack-protection'
 gem 'state_machine'
 gem 'twilio-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     net-ssh (5.0.2)
     netrc (0.11.0)
     newrelic_rpm (5.2.0.345)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -494,7 +494,7 @@ DEPENDENCIES
   loofah (>= 2.3.1)
   nestful!
   newrelic_rpm
-  nokogiri
+  nokogiri (>= 1.0.4)
   oj
   paper_trail (~> 4.0.0.beta)
   paranoia (~> 2.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,8 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (1.6.11)
-    rack-cors (1.0.2)
+    rack-cors (1.0.6)
+      rack (>= 1.6.0)
     rack-protection (2.0.3)
       rack
     rack-test (0.6.3)
@@ -502,7 +503,7 @@ DEPENDENCIES
   postgres_ext (~> 2.4.0.beta.1)
   postgres_ext-serializers!
   puma
-  rack-cors
+  rack-cors (>= 1.0.4)
   rack-protection
   rack-timeout
   railroady

--- a/lib/classes/package_detail_builder.rb
+++ b/lib/classes/package_detail_builder.rb
@@ -15,7 +15,6 @@ class PackageDetailBuilder
   def build_or_update_record
     klass = detail_class if build_or_update_record?
     return unless klass
-
     detail_record = klass.find_by(stockit_id: detail_params["id"]) if stockit_id_present?
     if detail_record
       detail_record.assign_attributes(detail_attributes)
@@ -51,7 +50,7 @@ class PackageDetailBuilder
     FIXED_DETAIL_ATTRIBUTES.each_with_object({}) do |item, hash|
       if (key = detail_params[item].presence)
         name = "electrical_#{item}" unless item.eql?("comp_test_status")
-        hash["#{item}_id"] = Lookup.find_by(name: name, key: key)&.id
+        hash["#{item}_id"] = Lookup.find_by(name: name || item, key: key)&.id
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

FEATURE: Subform fields

BUG: Comp test status sync was failing due to one minor miss. 


NOTE: For the lookup_ids that we have stored in our database, we have `comp_test_status` for computers and computer_acessories. So while building the parameters, code was just building it for electrical params. Due to that, the computer test status was not getting syced.

It is now fixed and now will work smoothly. 