### PR TITLE
fix twilio sms

### DIFF
--- a/app/jobs/twilio_job.rb
+++ b/app/jobs/twilio_job.rb
@@ -6,7 +6,7 @@ class TwilioJob < ActiveJob::Base
     if options[:to].present?
       twilio_conf = Rails.application.secrets.twilio
       client = Twilio::REST::Client.new(twilio_conf['account_sid'], twilio_conf['auth_token'])
-      client.account.messages.create({ from: twilio_conf['phone_number'] }.merge(options))
+      client.messages.create({ from: twilio_conf['phone_number'] }.merge(options))
     end
   end
 end

--- a/spec/jobs/twilio_job_spec.rb
+++ b/spec/jobs/twilio_job_spec.rb
@@ -10,7 +10,7 @@ describe TwilioJob, :type => :job do
   end
 
   it "should call twilio with options" do
-    expect(twilio_client).to receive_message_chain(:account, :messages, :create).with(options)
+    expect(twilio_client).to receive_message_chain(:messages, :create).with(options)
     TwilioJob.new.perform(options)
   end
 


### PR DESCRIPTION
 Hi Team,

This PR fixes rollbar issue: https://rollbar.com/crossroads_it/api.goodcity/items/706/

As we have upgrade Twilio gem, the messages method does not work with the account and it has been moved to the client. 

Please refer doc: https://github.com/twilio/twilio-ruby

I have tested this fix from the console.

Please review.

Thanks.