### PR TITLE
GCW-2881 inventory number already exists fix

### DIFF
--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -11,12 +11,4 @@ class Computer < ActiveRecord::Base
   after_commit :create_on_stockit, on: :create, unless: :request_from_stockit?
   after_update :update_on_stockit, unless: :request_from_stockit?
   validates :mar_os_serial_num, :mar_ms_office_serial_num, length: { is: 14 }, allow_nil: true, allow_blank: true
-  validate :validate_fields
-
-  private
-
-  def validate_fields
-    errors.add(:os_serial_num, "'Mar OS serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? && !mar_os_serial_num.blank?
-    errors.add(:os_serial_num, "'Mar Office serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? && !mar_ms_office_serial_num.blank?
-  end
 end

--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -16,7 +16,7 @@ class Computer < ActiveRecord::Base
   private
 
   def validate_fields
-    errors.add(:os_serial_num, "'Mar OS serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? and !mar_os_serial_num.blank?
-    errors.add(:os_serial_num, "'Mar Office serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? and !mar_ms_office_serial_num.blank?
+    errors.add(:os_serial_num, "'Mar OS serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? && !mar_os_serial_num.blank?
+    errors.add(:os_serial_num, "'Mar Office serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? && !mar_ms_office_serial_num.blank?
   end
 end

--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -10,5 +10,13 @@ class Computer < ActiveRecord::Base
   before_save :set_updated_by
   after_commit :create_on_stockit, on: :create, unless: :request_from_stockit?
   after_update :update_on_stockit, unless: :request_from_stockit?
-  validates :mar_os_serial_num, :mar_ms_office_serial_num, length: { minimum: 14 }, allow_nil: true, allow_blank: true
+  validates :mar_os_serial_num, :mar_ms_office_serial_num, length: { is: 14 }, allow_nil: true, allow_blank: true
+  validate :validate_fields
+
+  private
+
+  def validate_fields
+    errors.add(:os_serial_num, "'Mar OS serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? and !mar_os_serial_num.blank?
+    errors.add(:os_serial_num, "'Mar Office serial #' cannot be used if 'OS Serial #' is blank.") if os_serial_num.blank? and !mar_ms_office_serial_num.blank?
+  end
 end

--- a/app/models/concerns/subform_utilities.rb
+++ b/app/models/concerns/subform_utilities.rb
@@ -18,7 +18,6 @@ module SubformUtilities
 
   def create_on_stockit
     return if request_from_stockit?
-
     response = Stockit::ItemDetailSync.create(self)
     add_stockit_id(response)
   end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -318,7 +318,8 @@ class Package < ActiveRecord::Base
   end
 
   def add_to_stockit
-    return unless detail && detail.valid?
+    return if detail.present? && !detail.valid?
+
     response = Stockit::ItemSync.create(self)
     if response && (errors = response["errors"]).present?
       errors.each { |key, value| self.errors.add(key, value) }

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -318,6 +318,7 @@ class Package < ActiveRecord::Base
   end
 
   def add_to_stockit
+    return unless detail && detail.valid?
     response = Stockit::ItemSync.create(self)
     if response && (errors = response["errors"]).present?
       errors.each { |key, value| self.errors.add(key, value) }

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Package, type: :model do
       expect(Stockit::ItemSync).to_not receive(:create)
       package.save
       package.add_to_stockit
-      expect(package.errors).to include(:"detail.mar_os_serial_num", :"detail.os_serial_num")
+      expect(package.errors).to include(:"detail.mar_os_serial_num")
     end
   end
 

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -101,6 +101,16 @@ RSpec.describe Package, type: :model do
       package.add_to_stockit
       expect(package.stockit_id).to be_nil
     end
+
+    it "should not allow to send sync request to stockit if the detail is invalid" do
+      detail = build :computer, {os_serial_num: nil, mar_os_serial_num: "xyz"}
+      package = build :package, :received
+      package.detail = detail
+      expect(Stockit::ItemSync).to_not receive(:create)
+      package.save
+      package.add_to_stockit
+      expect(package.errors).to include(:"detail.mar_os_serial_num", :"detail.os_serial_num")
+    end
   end
 
   describe "remove_from_stockit" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2881

### What does this PR do?

BUG: If there is any issue in the item form, or subform, it throws an error on API side which prevents it from creating bad data. But, however, item was getting created on stockit side as there was no check for this kind of behavior what so ever. After fixing the data and resubmitting, it used to throw remove node error which has been fixed in this PR https://github.com/crossroads/stock.goodcity/pull/556 .

Along with that, it also fixes some code, and make it better to understand now. 

### Impacted Areas

Item Creation on stock app. Stockit Item sync.

### Linked PR's:

https://github.com/crossroads/stock.goodcity/pull/556
https://bitbucket.org/crfdevs/stockit/pull-requests/69/remove-unwanted-validations/diff