### PR TITLE
remove unwanted params which are causing issue in sync

### DIFF
--- a/app/services/stockit/item_sync.rb
+++ b/app/services/stockit/item_sync.rb
@@ -131,8 +131,6 @@ module Stockit
         location_id: package.stockit_location_id,
         id: package.stockit_id,
         pieces: package.pieces,
-        detail_id: package&.detail_id,
-        detail_type: package&.detail_type,
         # designation_id: package.singleton_package? ? package.stockit_order_id : nil,
         # designated_on: package.singleton_package? ? package.stockit_designated_on : nil
         designation_id: package.stockit_order_id,


### PR DESCRIPTION
### What does this PR do?
BUG: Specify bug 

If item is updated, (any attribute of item is updated). It sends a sync request, which sends detail_id of api to stockit and creates a bad entry. This PR fixes that.