### PR TITLE
Don't send notifications to all admins if there is no real donor.

### DIFF
--- a/app/models/concerns/message_subscription.rb
+++ b/app/models/concerns/message_subscription.rb
@@ -33,7 +33,7 @@ module MessageSubscription
     #  - If donor sends a message but no one else is listening, subscribe all reviewers.
     subscribe_all_staff = is_private ?
       is_first_message_for(klass, obj.id) :
-      [self.sender_id] == user_ids
+      ([self.sender_id] == user_ids) && (obj&.created_by_id != nil)
 
     user_ids += User.staff.pluck(:id) if subscribe_all_staff
 

--- a/app/models/concerns/message_subscription.rb
+++ b/app/models/concerns/message_subscription.rb
@@ -27,13 +27,15 @@ module MessageSubscription
     user_ids -= [User.system_user.try(:id), User.stockit_user.try(:id)]
     user_ids -= [obj.try(:created_by_id)] if self.is_private or obj.try('cancelled?')
 
-
-    # Cases where we subscribe every stafff member
+    # Cases where we subscribe every staff member
     #  - For private messages, subscribe all supervisors ONLY for the first message
     #  - If donor sends a message but no one else is listening, subscribe all reviewers.
-    subscribe_all_staff = is_private ?
-      is_first_message_for(klass, obj.id) :
-      ([self.sender_id] == user_ids) && (obj&.created_by_id != nil)
+    subscribe_all_staff =
+      if is_private
+        is_first_message_for(klass, obj.id)
+      else
+        obj&.created_by_id.present? && (user_ids == [self.sender_id])
+      end
 
     user_ids += User.staff.pluck(:id) if subscribe_all_staff
 

--- a/spec/models/concerns/message_subscription_spec.rb
+++ b/spec/models/concerns/message_subscription_spec.rb
@@ -57,6 +57,19 @@ context MessageSubscription do
       end
     end
 
+    context "should not subscribe all reviewers if there is no donor (an admin created the offer)" do
+      let!(:reviewer) { create :user, :reviewer }
+      let!(:reviewer2) { create :user, :reviewer }
+      let(:offer) { create :offer, created_by_id: nil }
+      let(:message) { create :message, sender: reviewer, offer: offer }
+      it do
+        expect(message.offer.reviewed_by_id).to eql(nil)
+        expect(message).to receive(:add_subscription).with('read', reviewer.id)
+        expect(message).to_not receive(:add_subscription).with('unread', reviewer2.id)
+        message.subscribe_users_to_message
+      end
+    end
+
     context "should not subscribe system users" do
       let(:sender) { create :user, :system }
       before(:each) { allow(message).to receive(:sender_id).and_return(sender.id) }


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2902

### What does this PR do?

BUG: For an offer that has been created by an admin (not a donor), when a reviewer subsequently reviews the item and closes the offer, notifications are sent to all supervisors because the system thinks nobody is listening.

The fix is to avoid sending notifications to all staff when there is no donor. This affects just the 'donor' channel and not the 'private' supervisors messaging channel.

### Impacted Areas

Offers -> Messages