### PR TITLE
Fuzzy organisation search

### DIFF
--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -42,7 +42,7 @@ module Api::V1
       if params['ids'].present?
         records = @organisations.where(id: params['ids']).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       else
-        records = @organisations.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
+        records = Organisation.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       end
       data = ActiveModel::ArraySerializer.new(records, each_serializer: serializer, root: "gc_organisations").as_json
       render json: { "meta": { total_pages: records.total_pages, "search": params["searchText"] } }.merge(data)

--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -42,7 +42,7 @@ module Api::V1
       if params['ids'].present?
         records = @organisations.where(id: params['ids']).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       else
-        records = Organisation.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
+        records = @organisations.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       end
       data = ActiveModel::ArraySerializer.new(records, each_serializer: serializer, root: "gc_organisations").as_json
       render json: { "meta": { total_pages: records.total_pages, "search": params["searchText"] } }.merge(data)

--- a/app/models/concerns/fuzzy_search.rb
+++ b/app/models/concerns/fuzzy_search.rb
@@ -30,19 +30,17 @@ module FuzzySearch
     #     SIMILARITY(name_zh_tw, 'steve') DESC
     #
     def search(search_text)
-      sanitized_text = sanitize(search_text)
-      similarities = self.search_props.map { |f| "SIMILARITY(#{f}, #{sanitized_text})" }
+      similarities = search_props.map { |f| "SIMILARITY(#{f}, #{sanitize(search_text)})" }
 
       fields = similarities + ["#{table_name}.*"]
       conditions = similarities.map { |s| "#{s} > #{similarity_threshold}" }
-      ordering = similarities.map { |q| "#{q} DESC" }
+      ordering = similarities.map { |s| "#{s} DESC" }
 
       select(fields.join(','))
         .where(conditions.join(' OR '))
         .order(ordering.join(','))
         .distinct
     end
-
 
     #
     # Configuration of fuzzy search
@@ -65,8 +63,7 @@ module FuzzySearch
 
     def search_props
       return @search_props unless @search_props.blank?
-      self.columns.select{ |c| c.type == :string }.map(&:name)
+      columns.select { |c| c.type == :string }.map(&:name)
     end
   end
 end
-

--- a/app/models/concerns/fuzzy_search.rb
+++ b/app/models/concerns/fuzzy_search.rb
@@ -1,0 +1,72 @@
+module FuzzySearch
+  extend ActiveSupport::Concern
+
+  class_methods do
+    attr_reader :search_joins
+
+    ##
+    # Fuzzy search entry point
+    #
+    # @todo \
+    #   - Support join table properties (needed for other models)\
+    #   - Potential speed improvements (trigram indexes, using <-> operators)\
+    #   - Assess whether order_by has priority issues
+    #
+    # @param [string] search_text the text to search for
+    # @return [ActiveRecord::Relation]
+    #
+    # Current SQL looks something like this:
+    #
+    #  SELECT DISTINCT
+    #     SIMILARITY(name_en, 'steve'),
+    #     SIMILARITY(name_zh_tw, 'steve'),
+    #     organisations.*
+    #  FROM organisations
+    #  WHERE
+    #     SIMILARITY(name_en, 'steve') > 0.1 OR
+    #     SIMILARITY(name_zh_tw, 'steve') > 0.1
+    #  ORDER BY
+    #     SIMILARITY(name_en, 'steve') DESC,
+    #     SIMILARITY(name_zh_tw, 'steve') DESC
+    #
+    def search(search_text)
+      sanitized_text = sanitize(search_text)
+      similarities = self.search_props.map { |f| "SIMILARITY(#{f}, #{sanitized_text})" }
+
+      fields = similarities + ["#{table_name}.*"]
+      conditions = similarities.map { |s| "#{s} > #{similarity_threshold}" }
+      ordering = similarities.map { |q| "#{q} DESC" }
+
+      select(fields.join(','))
+        .where(conditions.join(' OR '))
+        .order(ordering.join(','))
+        .distinct
+    end
+
+
+    #
+    # Configuration of fuzzy search
+    #
+    # @param [string[]] props array of columns to search against
+    # @param [float] tolerance the tolerance of the search between 0 and 1 \
+    #     1 requires a perfect match and 0 lets any similarity through
+    #
+    # @return [<Type>] <description>
+    #
+    def configure_search(props: [], tolerance: 0.1)
+      @search_props ||= []
+      @search_props = (@search_props << props).flatten
+      @similarity_threshold = tolerance
+    end
+
+    def similarity_threshold
+      @similarity_threshold.present? ? @similarity_threshold : 0.1
+    end
+
+    def search_props
+      return @search_props unless @search_props.blank?
+      self.columns.select{ |c| c.type == :string }.map(&:name)
+    end
+  end
+end
+

--- a/app/models/concerns/fuzzy_search.rb
+++ b/app/models/concerns/fuzzy_search.rb
@@ -11,18 +11,26 @@ module FuzzySearch
     # @param [float] tolerance the tolerance of the search between 0 and 1 \
     #     1 requires a perfect match and 0 lets any similarity through
     #
-    # @return [<Type>] <description>
-    #
     def configure_search(props: [], tolerance: 0.1)
       @search_props ||= []
       @search_props = (@search_props << props).flatten
       @similarity_threshold = tolerance
     end
 
+    ##
+    # Returns the search tolerance factor, a float between 0 and 1
+    #
+    # @return [float]
+    #
     def similarity_threshold
       @similarity_threshold.present? ? @similarity_threshold : 0.1
     end
 
+    ##
+    # Returns the columns that are included in the search
+    #
+    # @return [string[]]
+    #
     def search_props
       return @search_props unless @search_props.blank?
       columns.select { |c| c.type == :string }.map(&:name)
@@ -30,8 +38,6 @@ module FuzzySearch
   end
 
   included do
-
-
     ##
     # Fuzzy search entry point
     #

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,6 @@
 class Organisation < ActiveRecord::Base
+  include FuzzySearch
+
   belongs_to :organisation_type
   belongs_to :country
   belongs_to :district
@@ -6,10 +8,7 @@ class Organisation < ActiveRecord::Base
   has_many :orders
   has_many :users, through: :organisations_users
 
-  def self.search(search_text)
-    where("name_en ILIKE :search_text OR name_zh_tw ILIKE :search_text",
-      search_text: "%#{search_text}%")
-  end
+  configure_search props: [:name_en, :name_zh_tw], tolerance: 0.1
 
   def name_as_per_locale
     I18n.locale == :en ? name_en : name_zh_tw

--- a/db/migrate/20191204035945_add_indexes_to_organisations.rb
+++ b/db/migrate/20191204035945_add_indexes_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddIndexesToOrganisations < ActiveRecord::Migration
+  def change
+    add_index :organisations, :name_en
+    add_index :organisations, :name_zh_tw
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191105094920) do
+ActiveRecord::Schema.define(version: 20191204035945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -557,6 +557,8 @@ ActiveRecord::Schema.define(version: 20191105094920) do
 
   add_index "organisations", ["country_id"], name: "index_organisations_on_country_id", using: :btree
   add_index "organisations", ["district_id"], name: "index_organisations_on_district_id", using: :btree
+  add_index "organisations", ["name_en"], name: "index_organisations_on_name_en", using: :btree
+  add_index "organisations", ["name_zh_tw"], name: "index_organisations_on_name_zh_tw", using: :btree
   add_index "organisations", ["organisation_type_id"], name: "index_organisations_on_organisation_type_id", using: :btree
 
   create_table "organisations_users", force: :cascade do |t|

--- a/lib/classes/packages_inventories_importer.rb
+++ b/lib/classes/packages_inventories_importer.rb
@@ -252,10 +252,10 @@ class PackagesInventoriesImporter
     Please type 'yes' to proceed
   TEXT
 
-  BAD_PACKAGES_LOCATION_QUANTITY = '[Err] Package (%s) doesnt look dispatched but the packages_location quantity doesnt match the received qty'
-  UNINVENTORIZED_WITH_LOCATION = '[Err] Package (%s) is not inventorized but has packages_locations'
-  MULTIPLE_LOCATIONS_ERR = '[Err] Package (%s) has multiple locations'
-  NO_LOCATION_ERR = '[Err] Package (%s) doesnt look dispatched but has no location'
-  INVALID_QUANTITY = '[Err] Package (%s) has an invalid quantity of %s'
-  MISSING_ORDERS_PACKAGE = '[Err] Package (%s) looks dispatched, but has no orders_package'
+  BAD_PACKAGES_LOCATION_QUANTITY = '[Err] Package (%s) doesnt look dispatched but the packages_location quantity doesnt match the received qty'.freeze
+  UNINVENTORIZED_WITH_LOCATION = '[Err] Package (%s) is not inventorized but has packages_locations'.freeze
+  MULTIPLE_LOCATIONS_ERR = '[Err] Package (%s) has multiple locations'.freeze
+  NO_LOCATION_ERR = '[Err] Package (%s) doesnt look dispatched but has no location'.freeze
+  INVALID_QUANTITY = '[Err] Package (%s) has an invalid quantity of %s'.freeze
+  MISSING_ORDERS_PACKAGE = '[Err] Package (%s) looks dispatched, but has no orders_package'.freeze
 end

--- a/spec/factories/packages.rb
+++ b/spec/factories/packages.rb
@@ -37,21 +37,15 @@ FactoryBot.define do
     end
 
     trait :dispatched do
-      before(:create) do |package|
-        dispatch_loc = create(:location, :dispatched)
-        build(:packages_location, location: dispatch_loc, package: package, quantity: package.received_quantity).sneaky do |packages_location|
-          packages_location.save
-          package.quantity = 0;
-          package.packages_locations = [packages_location]
-          package.orders_packages = [
-            create(
-              :orders_package,
-              :with_state_dispatched,
-              package_id: package.id,
-              quantity: package.received_quantity
-            )
-          ]
-        end
+      after(:create) do |package|
+        package.orders_packages = [
+          create(
+            :orders_package,
+            :with_state_dispatched,
+            package_id: package.id,
+            quantity: package.received_quantity
+          )
+        ]
       end
     end
 

--- a/spec/models/concerns/operations/stock_operations_spec.rb
+++ b/spec/models/concerns/operations/stock_operations_spec.rb
@@ -47,7 +47,7 @@ context StockOperations do
       context 'with some quantity remaining for designated items' do
         before { create(:orders_package, package: package, quantity: 26) } # Location 1+2 have enough to fulfill this order
 
-        it 'suceeds' do
+        it 'succeeds' do
           expect { register_loss(10, location1) }.to change {
             PackagesInventory::Computer.quantity_where(location: location1, package: package)
           }.from(33).to(23)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe Organisation, type: :model do
           expect(Organisation.search("進念二十")).to include(organisation)
         end
       end
+
+      context 'typo tolerance' do
+        let(:organisation) { create :organisation, name_en: "The Steve Inc."}
+
+        before { touch(organisation) }
+
+        it { expect(Organisation.search("Stve")).to include(organisation) }
+        it { expect(Organisation.search("steve el")).to include(organisation) }
+        it { expect(Organisation.search("The Inc.")).to include(organisation) }
+        it { expect(Organisation.search("Inc Steve The.")).to include(organisation) }
+        it { expect(Organisation.search("The Inc.")).to include(organisation) }
+        it { expect(Organisation.search("The Stephen Inc.")).to include(organisation) }
+        it { expect(Organisation.search("Ic Steve The.")).to include(organisation) }
+        it { expect(Organisation.search("Patrick Corp")).not_to include(organisation) }
+      end
     end
   end
 


### PR DESCRIPTION
This is a first version of a `FuzzySearch` module, which I've plugged in to the Organisations model

Notes:

It is far from perfect, but Nokia mentioned people were having many problems especially with searches like : `'The ABC Foundation'` which are stored in the database as `'ABC Foundation, The'`

Speed can become a potential issue when searching through many fields, luckily that's not the case for Organisations. If we ever want to use it with Orders, we'll definitely need to assess performance and make improvements.

Other:

- Added a couple of sanity checks to the packages_inventory_importer. The changes were tiny so I squeezed them into this PR