### PR TITLE
GCW-2931-Request cancellation reason for orders

### DIFF
--- a/app/controllers/api/v1/cancellation_reasons_controller.rb
+++ b/app/controllers/api/v1/cancellation_reasons_controller.rb
@@ -4,7 +4,8 @@ module Api
       load_and_authorize_resource :cancellation_reason, parent: false
 
       def index
-        render json: cancellation_reasons, each_serializer: serializer
+        reasons = @cancellation_reasons.cancellation_reasons_for(params['for'])
+        render json: reasons, each_serializer: serializer
       end
 
       def show
@@ -15,13 +16,6 @@ module Api
 
       def serializer
         Api::V1::CancellationReasonSerializer
-      end
-
-      def cancellation_reasons
-        @cancellation_reasons.cancellation_reasons_by({
-          ids: params["ids"],
-          offer: params["offer"]
-        })
       end
     end
   end

--- a/app/controllers/api/v1/cancellation_reasons_controller.rb
+++ b/app/controllers/api/v1/cancellation_reasons_controller.rb
@@ -4,7 +4,7 @@ module Api
       load_and_authorize_resource :cancellation_reason, parent: false
 
       def index
-        render json: get_cancellation_reasons, each_serializer: serializer
+        render json: cancellation_reasons, each_serializer: serializer
       end
 
       def show
@@ -17,7 +17,7 @@ module Api
         Api::V1::CancellationReasonSerializer
       end
 
-      def get_cancellation_reasons
+      def cancellation_reasons
         @cancellation_reasons.get_cancellation_reasons_by({
           ids: params["ids"],
           offer: params["offer"],

--- a/app/controllers/api/v1/cancellation_reasons_controller.rb
+++ b/app/controllers/api/v1/cancellation_reasons_controller.rb
@@ -18,10 +18,9 @@ module Api
       end
 
       def cancellation_reasons
-        @cancellation_reasons.get_cancellation_reasons_by({
+        @cancellation_reasons.cancellation_reasons_by({
           ids: params["ids"],
-          offer: params["offer"],
-          order: params["stock"]
+          offer: params["offer"]
         })
       end
     end

--- a/app/controllers/api/v1/cancellation_reasons_controller.rb
+++ b/app/controllers/api/v1/cancellation_reasons_controller.rb
@@ -4,8 +4,7 @@ module Api
       load_and_authorize_resource :cancellation_reason, parent: false
 
       def index
-        @cancellation_reasons = @cancellation_reasons.get_cancellation_reasons_by(params)
-        render json: @cancellation_reasons, each_serializer: serializer
+        render json: get_cancellation_reasons, each_serializer: serializer
       end
 
       def show
@@ -16,6 +15,14 @@ module Api
 
       def serializer
         Api::V1::CancellationReasonSerializer
+      end
+
+      def get_cancellation_reasons
+        @cancellation_reasons.get_cancellation_reasons_by({
+          ids: params["ids"],
+          offer: params["offer"],
+          order: params["stock"]
+        })
       end
     end
   end

--- a/app/controllers/api/v1/cancellation_reasons_controller.rb
+++ b/app/controllers/api/v1/cancellation_reasons_controller.rb
@@ -6,8 +6,10 @@ module Api
       def index
         if params["ids"].present?
           @cancellation_reasons = @cancellation_reasons.where(id: params["ids"].split(",").flatten)
+        elsif params["isStock"]
+          @cancellation_reasons = @cancellation_reasons.visible_to_order
         else
-          @cancellation_reasons = @cancellation_reasons.visible
+          @cancellation_reasons = @cancellation_reasons.visible_to_offer
         end
         render json: @cancellation_reasons, each_serializer: serializer
       end

--- a/app/controllers/api/v1/cancellation_reasons_controller.rb
+++ b/app/controllers/api/v1/cancellation_reasons_controller.rb
@@ -4,13 +4,7 @@ module Api
       load_and_authorize_resource :cancellation_reason, parent: false
 
       def index
-        if params["ids"].present?
-          @cancellation_reasons = @cancellation_reasons.where(id: params["ids"].split(",").flatten)
-        elsif params["isStock"]
-          @cancellation_reasons = @cancellation_reasons.visible_to_order
-        else
-          @cancellation_reasons = @cancellation_reasons.visible_to_offer
-        end
+        @cancellation_reasons = @cancellation_reasons.get_cancellation_reasons_by(params)
         render json: @cancellation_reasons, each_serializer: serializer
       end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -70,10 +70,10 @@ module Api
 
       def transition
         transition_event = params['transition'].to_sym
-        cancellation_reason = params["cancellation_reason"]
+        cancellation_reason_id = params['cancellation_reason_id'] if params['cancellation_reason_id']
         if @order.state_events.include?(transition_event)
           @order.fire_state_event(transition_event)
-          @order.update(cancellation_reason: cancellation_reason) if cancellation_reason.presence
+          @order.update(cancellation_reason_id: cancellation_reason_id, cancel_reason: params["cancel_reason"]) if cancellation_reason_id
         end
         render json: @order, serializer: serializer
       end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -70,6 +70,7 @@ module Api
 
       def transition
         transition_event = params['transition'].to_sym
+        @order.remove_cancellation_reason if transition_event.eql?(:resubmit)
         cancellation_reason_id = params['cancellation_reason_id'] if params['cancellation_reason_id']
         if @order.state_events.include?(transition_event)
           @order.fire_state_event(transition_event)

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -120,7 +120,6 @@ module Api
 
       def update_transition_and_cancel_reason
         event = params['transition'].to_sym
-        @order.remove_cancellation_reason if event.eql?(:resubmit)
         @order.update_transition_and_reason(event, cancel_params) if @order.state_events.include?(event)
       end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -69,7 +69,8 @@ module Api
       end
 
       def transition
-        update_transition_and_cancel_reason
+        event = params['transition'].to_sym
+        @order.update_transition_and_reason(event, cancel_params) if @order.state_events.include?(event)
         render json: @order, serializer: serializer
       end
 
@@ -116,11 +117,6 @@ module Api
           include_order: false,
           include_images: true,
           exclude_stockit_set_item: true).as_json
-      end
-
-      def update_transition_and_cancel_reason
-        event = params['transition'].to_sym
-        @order.update_transition_and_reason(event, cancel_params) if @order.state_events.include?(event)
       end
 
       def cancel_params

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -119,14 +119,16 @@ module Api
       end
 
       def update_transition_and_cancel_reason
-        transition_event = params['transition'].to_sym
-        cancellation_reason_id = CancellationReason.find_by_name_en("Changed mind")&.id  if is_browse_app? && transition_event.eql?(:cancel)
-        cancellation_reason_id = params['cancellation_reason_id'] if params['cancellation_reason_id']
+        event = params['transition'].to_sym
+        @order.remove_cancellation_reason if event.eql?(:resubmit)
+        @order.update_transition_and_reason(event, cancel_params) if @order.state_events.include?(event)
+      end
 
-        @order.update_cancellation_reason_and_transition(transition_event, {
+      def cancel_params
+        {
           cancel_reason: params["cancel_reason"],
-          cancellation_reason_id: cancellation_reason_id
-        })
+          cancellation_reason_id: params['cancellation_reason_id']
+        }
       end
 
       def order_record

--- a/app/models/cancellation_reason.rb
+++ b/app/models/cancellation_reason.rb
@@ -6,7 +6,8 @@ class CancellationReason < ActiveRecord::Base
   translates :name
   validates :name_en, presence: true
 
-  scope :visible, -> { where(visible_to_admin: true) }
+  scope :visible_to_offer, -> { where(visible_to_offer: true) }
+  scope :visible_to_order, -> { where(visible_to_order: true) }
 
   def self.unwanted
     find_by(name_en: "Unwanted")

--- a/app/models/cancellation_reason.rb
+++ b/app/models/cancellation_reason.rb
@@ -20,10 +20,10 @@ class CancellationReason < ActiveRecord::Base
     find_by(name_en: "Donor cancelled")
   end
 
-  def self.get_cancellation_reasons_by(params)
-    if params["ids"]
-      where(id: params["ids"].split(",").flatten)
-    elsif params["offer"]
+  def self.get_cancellation_reasons_by(options)
+    if options[:ids]
+      where(id: options[:ids].split(",").flatten)
+    elsif options[:offer]
       visible_to_offer
     else
       visible_to_order

--- a/app/models/cancellation_reason.rb
+++ b/app/models/cancellation_reason.rb
@@ -20,13 +20,8 @@ class CancellationReason < ActiveRecord::Base
     find_by(name_en: "Donor cancelled")
   end
 
-  def self.cancellation_reasons_by(options)
-    if options[:ids]
-      where(id: options[:ids].split(",").flatten)
-    elsif options[:offer]
-      visible_to_offer
-    else
-      visible_to_order
-    end
+  def self.cancellation_reasons_for(type)
+    return where unless CANCELLATION_REASONS_TYPE.include?(type)
+    send("visible_to_#{type}")
   end
 end

--- a/app/models/cancellation_reason.rb
+++ b/app/models/cancellation_reason.rb
@@ -20,7 +20,7 @@ class CancellationReason < ActiveRecord::Base
     find_by(name_en: "Donor cancelled")
   end
 
-  def self.get_cancellation_reasons_by(options)
+  def self.cancellation_reasons_by(options)
     if options[:ids]
       where(id: options[:ids].split(",").flatten)
     elsif options[:offer]

--- a/app/models/cancellation_reason.rb
+++ b/app/models/cancellation_reason.rb
@@ -3,6 +3,7 @@ class CancellationReason < ActiveRecord::Base
   include RollbarSpecification
 
   has_many :offers
+  has_many :orders
   translates :name
   validates :name_en, presence: true
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,7 +119,7 @@ class Order < ActiveRecord::Base
     end
   end
 
-  def remove_cancellation_reason(cancellation_reason_id=nil, cancel_reason=nil)
+  def remove_cancellation_reason(cancellation_reason_id = nil, cancel_reason = nil)
     update(cancellation_reason_id: cancellation_reason_id, cancel_reason: cancel_reason)
   end
 
@@ -127,7 +127,7 @@ class Order < ActiveRecord::Base
     remove_cancellation_reason if transition_event.eql?(:resubmit)
     if state_events.include?(transition_event)
       fire_state_event(transition_event)
-      remove_cancellation_reason(cancellation_reason_id = opts[:cancellation_reason_id], cancel_reason = opts[:cancel_reason]) if opts[:cancellation_reason_id]
+      remove_cancellation_reason(opts[:cancellation_reason_id], opts[:cancel_reason]) if opts[:cancellation_reason_id]
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -75,7 +75,7 @@ class Order < ActiveRecord::Base
     "Loaded" => "dispatching",
     "Cancelled" => "cancelled",
     "Upcoming" => "awaiting_dispatch"
-  }
+  }.freeze
 
   scope :non_draft_orders, -> { where.not("state = 'draft' AND detail_type = 'GoodCity'") }
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,8 +119,16 @@ class Order < ActiveRecord::Base
     end
   end
 
-  def remove_cancellation_reason
-    update(cancellation_reason_id: nil, cancel_reason: nil)
+  def remove_cancellation_reason(cancellation_reason_id=nil, cancel_reason=nil)
+    update(cancellation_reason_id: cancellation_reason_id, cancel_reason: cancel_reason)
+  end
+
+  def update_cancellation_reason_and_transition(transition_event, opts)
+    remove_cancellation_reason if transition_event.eql?(:resubmit)
+    if state_events.include?(transition_event)
+      fire_state_event(transition_event)
+      remove_cancellation_reason(cancellation_reason_id = opts[:cancellation_reason_id], cancel_reason = opts[:cancel_reason]) if opts[:cancellation_reason_id]
+    end
   end
 
   def designate_orders_packages

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,9 +119,10 @@ class Order < ActiveRecord::Base
     end
   end
 
-  def update_transition_and_reason(event, opts)
+  def update_transition_and_reason(event, cancel_opts)
     fire_state_event(event)
-    update(cancellation_reason_id: opts[:cancellation_reason_id], cancel_reason: opts[:cancel_reason]) if opts[:cancellation_reason_id]
+    opts = cancel_opts.select{ |k| [:cancellation_reason_id, :cancel_reason].include?(k) }
+    update(opts)
   end
 
   def designate_orders_packages

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,10 +119,6 @@ class Order < ActiveRecord::Base
     end
   end
 
-  def nullify_cancellation_reason
-    update(cancellation_reason_id: nil, cancel_reason: nil)
-  end
-
   def update_transition_and_reason(event, opts)
     fire_state_event(event)
     update(cancellation_reason_id: opts[:cancellation_reason_id], cancel_reason: opts[:cancel_reason]) if opts[:cancellation_reason_id]
@@ -264,8 +260,7 @@ class Order < ActiveRecord::Base
 
     before_transition on: :resubmit do |order|
       if order.cancelled?
-        order.nullify_cancellation_reason
-        order.nullify_columns(:processed_at, :processed_by_id, :process_completed_at, :process_completed_by_id,
+        order.nullify_columns(:cancellation_reason_id, :cancel_reason, :processed_at, :processed_by_id, :process_completed_at, :process_completed_by_id,
           :cancelled_at, :cancelled_by_id, :dispatch_started_by_id, :dispatch_started_at)
       end
     end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -13,6 +13,7 @@ class Order < ActiveRecord::Base
     ]
   end
 
+  belongs_to :cancellation_reason
   belongs_to :detail, polymorphic: true, dependent: :destroy
   belongs_to :stockit_activity
   belongs_to :country
@@ -68,7 +69,7 @@ class Order < ActiveRecord::Base
   ORDER_UNPROCESSED_STATES = [INACTIVE_STATES, 'submitted', 'processing', 'draft'].flatten.uniq.freeze
 
   # Stockit Shipment Status => GoodCity State
-  SHIPMENT_STATUS_MAP = { 
+  SHIPMENT_STATUS_MAP = {
     "Processing" => "processing",
     "Sent" => "closed",
     "Loaded" => "dispatching",

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,6 +119,10 @@ class Order < ActiveRecord::Base
     end
   end
 
+  def remove_cancellation_reason
+    update(cancellation_reason_id: nil, cancel_reason: nil)
+  end
+
   def designate_orders_packages
     orders_packages.each do |orders_package|
       orders_package.update_state_to_designated

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,7 +119,7 @@ class Order < ActiveRecord::Base
     end
   end
 
-  def remove_cancellation_reason
+  def nullify_cancellation_reason
     update(cancellation_reason_id: nil, cancel_reason: nil)
   end
 
@@ -264,6 +264,7 @@ class Order < ActiveRecord::Base
 
     before_transition on: :resubmit do |order|
       if order.cancelled?
+        order.nullify_cancellation_reason
         order.nullify_columns(:processed_at, :processed_by_id, :process_completed_at, :process_completed_by_id,
           :cancelled_at, :cancelled_by_id, :dispatch_started_by_id, :dispatch_started_at)
       end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -119,16 +119,13 @@ class Order < ActiveRecord::Base
     end
   end
 
-  def remove_cancellation_reason(cancellation_reason_id = nil, cancel_reason = nil)
-    update(cancellation_reason_id: cancellation_reason_id, cancel_reason: cancel_reason)
+  def remove_cancellation_reason
+    update(cancellation_reason_id: nil, cancel_reason: nil)
   end
 
-  def update_cancellation_reason_and_transition(transition_event, opts)
-    remove_cancellation_reason if transition_event.eql?(:resubmit)
-    if state_events.include?(transition_event)
-      fire_state_event(transition_event)
-      remove_cancellation_reason(opts[:cancellation_reason_id], opts[:cancel_reason]) if opts[:cancellation_reason_id]
-    end
+  def update_transition_and_reason(event, opts)
+    fire_state_event(event)
+    update(cancellation_reason_id: opts[:cancellation_reason_id], cancel_reason: opts[:cancel_reason]) if opts[:cancellation_reason_id]
   end
 
   def designate_orders_packages

--- a/app/serializers/api/v1/order_serializer.rb
+++ b/app/serializers/api/v1/order_serializer.rb
@@ -1,6 +1,6 @@
 module Api::V1
   class OrderSerializer < OrderShallowSerializer
-    attributes :item_ids, :cancellation_reason
+    attributes :item_ids, :cancellation_reason_id, :cancel_reason
     has_one :created_by, serializer: UserProfileSerializer, root: :user
     has_one :stockit_contact, serializer: StockitContactSerializer
     has_one :stockit_organisation, serializer: StockitOrganisationSerializer, root: :organisation
@@ -23,6 +23,7 @@ module Api::V1
     has_one  :beneficiary, serializer: BeneficiarySerializer
     has_one  :address, serializer: AddressSerializer
     has_one  :district, serializer: DistrictSerializer
+    has_one  :cancellation_reason, serializer: CancellationReasonSerializer
 
     def item_ids
     end

--- a/app/serializers/api/v1/order_shallow_serializer.rb
+++ b/app/serializers/api/v1/order_shallow_serializer.rb
@@ -3,7 +3,7 @@ module Api::V1
     embed :ids, include: true
     attributes :status, :created_at, :code, :detail_type, :id, :detail_id,
       :contact_id, :local_order_id, :organisation_id, :description, :activity,
-      :country_name, :state, :purpose_description, :created_by_id, :cancellation_reason,
+      :country_name, :state, :purpose_description, :created_by_id, :cancel_reason,
       :gc_organisation_id, :processed_at, :processed_by_id, :cancelled_at, :cancelled_by_id,
       :process_completed_at, :process_completed_by_id, :closed_at, :closed_by_id, :dispatch_started_at,
       :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped, :beneficiary_id,

--- a/db/migrate/20191223131446_add_cancellation_reason_id_to_order.rb
+++ b/db/migrate/20191223131446_add_cancellation_reason_id_to_order.rb
@@ -1,0 +1,6 @@
+class AddCancellationReasonIdToOrder < ActiveRecord::Migration
+  def change
+    add_column :orders, :cancellation_reason_id, :integer
+    rename_column :orders, :cancellation_reason, :cancel_reason
+  end
+end

--- a/db/migrate/20191223134926_add_visible_to_order_to_cancellation_reason.rb
+++ b/db/migrate/20191223134926_add_visible_to_order_to_cancellation_reason.rb
@@ -1,0 +1,6 @@
+class AddVisibleToOrderToCancellationReason < ActiveRecord::Migration
+  def change
+    add_column :cancellation_reasons, :visible_to_order, :boolean, default: false
+    rename_column :cancellation_reasons, :visible_to_admin, :visible_to_offer
+  end
+end

--- a/db/order_cancellation_reasons.yml
+++ b/db/order_cancellation_reasons.yml
@@ -1,0 +1,24 @@
+---
+1:
+  :name_en: "No show"
+  :name_zh_tw: "No show"
+  :visible_to_offer: false
+  :visible_to_order: true
+
+2:
+  :name_en: "Nothing suitable"
+  :name_zh_tw: "Nothing suitable"
+  :visible_to_offer: false
+  :visible_to_order: true
+
+3:
+  :name_en: "Changed mind"
+  :name_zh_tw: "Changed mind"
+  :visible_to_offer: false
+  :visible_to_order: true
+
+4:
+  :name_en: "Other"
+  :name_zh_tw: "Other"
+  :visible_to_offer: false
+  :visible_to_order: true

--- a/db/order_cancellation_reasons.yml
+++ b/db/order_cancellation_reasons.yml
@@ -1,24 +1,24 @@
 ---
 1:
   :name_en: "No show"
-  :name_zh_tw: "No show"
+  :name_zh_tw: "沒有出席"
   :visible_to_offer: false
   :visible_to_order: true
 
 2:
   :name_en: "Nothing suitable"
-  :name_zh_tw: "Nothing suitable"
+  :name_zh_tw: "沒有適合的物品"
   :visible_to_offer: false
   :visible_to_order: true
 
 3:
   :name_en: "Changed mind"
-  :name_zh_tw: "Changed mind"
+  :name_zh_tw: "改變了主意"
   :visible_to_offer: false
   :visible_to_order: true
 
 4:
   :name_en: "Other"
-  :name_zh_tw: "Other"
+  :name_zh_tw: "其他"
   :visible_to_offer: false
   :visible_to_order: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200107034249) do
+ActiveRecord::Schema.define(version: 20200207120244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,9 +96,10 @@ ActiveRecord::Schema.define(version: 20200107034249) do
   create_table "cancellation_reasons", force: :cascade do |t|
     t.string   "name_en"
     t.string   "name_zh_tw"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.boolean  "visible_to_admin", default: true
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.boolean  "visible_to_offer", default: true
+    t.boolean  "visible_to_order", default: false
   end
 
   create_table "companies", force: :cascade do |t|
@@ -418,6 +419,11 @@ ActiveRecord::Schema.define(version: 20200107034249) do
   add_index "offers", ["reviewed_by_id"], name: "index_offers_on_reviewed_by_id", using: :btree
   add_index "offers", ["state"], name: "index_offers_on_state", using: :btree
 
+  create_table "offers_packages", force: :cascade do |t|
+    t.integer "package_id"
+    t.integer "offer_id"
+  end
+
   create_table "order_transports", force: :cascade do |t|
     t.datetime "scheduled_at"
     t.string   "timeslot"
@@ -474,9 +480,10 @@ ActiveRecord::Schema.define(version: 20200107034249) do
     t.integer  "beneficiary_id"
     t.integer  "address_id"
     t.integer  "district_id"
-    t.text     "cancellation_reason"
+    t.text     "cancel_reason"
     t.integer  "booking_type_id"
     t.string   "staff_note",              default: ""
+    t.integer  "cancellation_reason_id"
   end
 
   add_index "orders", ["address_id"], name: "index_orders_on_address_id", using: :btree
@@ -656,6 +663,7 @@ ActiveRecord::Schema.define(version: 20200107034249) do
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
+    t.boolean  "last_allow_web_published"
     t.integer  "weight"
     t.integer  "pieces"
     t.integer  "detail_id"
@@ -962,6 +970,8 @@ ActiveRecord::Schema.define(version: 20200107034249) do
   add_foreign_key "goodcity_requests", "orders"
   add_foreign_key "goodcity_requests", "package_types"
   add_foreign_key "messages", "orders"
+  add_foreign_key "offers_packages", "offers"
+  add_foreign_key "offers_packages", "packages"
   add_foreign_key "orders_process_checklists", "orders"
   add_foreign_key "orders_process_checklists", "process_checklists"
   add_foreign_key "organisations", "countries"

--- a/lib/tasks/add_new_cancellation_reasons.rake
+++ b/lib/tasks/add_new_cancellation_reasons.rake
@@ -1,0 +1,11 @@
+# rake goodcity:add_new_cancellation_reasons
+namespace :goodcity do
+  desc 'Add new roles'
+  task add_new_cancellation_reasons: :environment do
+    order_reasons = YAML.load_file("#{Rails.root}/db/order_cancellation_reasons.yml")
+
+    order_reasons.each_value do |reason|
+      CancellationReason.where(name_en: reason[:name_en]).first_or_create(reason)
+    end
+  end
+end

--- a/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
+++ b/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
@@ -8,30 +8,22 @@ RSpec.describe Api::V1::CancellationReasonsController, type: :controller do
   before { generate_and_set_token(user) }
 
   describe 'GET cancellation_reasons' do
-    it 'returns cancellation_reasons visible to offer if `offer` exist in params' do
+    it 'returns cancellation_reasons visible to offer if `for:offer` exist in params' do
       visible_to_offer = create :cancellation_reason, :visible_to_offer
       visible_to_order = create :cancellation_reason, :visible_to_order
-      get :index, offer: true
+      get :index, for: 'offer'
       expect(response.status).to eq(200)
       expect(parsed_body['cancellation_reasons'].length).to eq(1)
       expect(parsed_body['cancellation_reasons'].map{ |reason| reason["id"] }).to include(visible_to_offer.id)
     end
 
-    it 'returns cancellation_reasons visible to offer if `order` exist in params' do
+    it 'returns cancellation_reasons visible to order `for:offer` exist in params' do
       visible_to_offer = create :cancellation_reason, :visible_to_offer
       visible_to_order = create :cancellation_reason, :visible_to_order
-      get :index, order: true
+      get :index, for: 'order'
       expect(response.status).to eq(200)
       expect(parsed_body['cancellation_reasons'].length).to eq(1)
       expect(parsed_body['cancellation_reasons'].map{ |reason| reason["id"] }).to include(visible_to_order.id)
-    end
-
-    it 'returns cancellation_reasons with ids present in params' do
-      2.times { create :cancellation_reason }
-      get :index, ids: [cancellation_reason.id]
-      expect(response.status).to eq(200)
-      expect(parsed_body['cancellation_reasons'].length).to eq(1)
-      expect(parsed_body['cancellation_reasons'].map{ |reason| reason["id"] }).to eq([cancellation_reason.id])
     end
   end
 

--- a/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
+++ b/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
@@ -9,19 +9,21 @@ RSpec.describe Api::V1::CancellationReasonsController, type: :controller do
 
   describe 'GET cancellation_reasons' do
     it 'returns cancellation_reasons visible to offer if `offer` exist in params' do
-      create :cancellation_reason, :visible_to_offer
-      create :cancellation_reason, :visible_to_order
+      visible_to_offer = create :cancellation_reason, :visible_to_offer
+      visible_to_order = create :cancellation_reason, :visible_to_order
       get :index, offer: true
       expect(response.status).to eq(200)
       expect(parsed_body['cancellation_reasons'].length).to eq(1)
+      expect(parsed_body['cancellation_reasons'].map{ |reason| reason["id"] }).to include(visible_to_offer.id)
     end
 
     it 'returns cancellation_reasons visible to offer if `order` exist in params' do
-      create :cancellation_reason, :visible_to_offer
-      create :cancellation_reason, :visible_to_order
+      visible_to_offer = create :cancellation_reason, :visible_to_offer
+      visible_to_order = create :cancellation_reason, :visible_to_order
       get :index, order: true
       expect(response.status).to eq(200)
       expect(parsed_body['cancellation_reasons'].length).to eq(1)
+      expect(parsed_body['cancellation_reasons'].map{ |reason| reason["id"] }).to include(visible_to_order.id)
     end
 
     it 'returns cancellation_reasons with ids present in params' do
@@ -29,7 +31,7 @@ RSpec.describe Api::V1::CancellationReasonsController, type: :controller do
       get :index, ids: [cancellation_reason.id]
       expect(response.status).to eq(200)
       expect(parsed_body['cancellation_reasons'].length).to eq(1)
-      expect(assigns(:cancellation_reasons).to_a).to eq([cancellation_reason])
+      expect(parsed_body['cancellation_reasons'].map{ |reason| reason["id"] }).to eq([cancellation_reason.id])
     end
   end
 

--- a/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
+++ b/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
@@ -8,10 +8,18 @@ RSpec.describe Api::V1::CancellationReasonsController, type: :controller do
   before { generate_and_set_token(user) }
 
   describe 'GET cancellation_reasons' do
-    it 'returns visible cancellation_reasons if ids do not exists in params' do
-      create :cancellation_reason, :visible
-      create :cancellation_reason, :invisible
-      get :index
+    it 'returns cancellation_reasons visible to offer if `offer` exist in params' do
+      create :cancellation_reason, :visible_to_offer
+      create :cancellation_reason, :visible_to_order
+      get :index, offer: true
+      expect(response.status).to eq(200)
+      expect(parsed_body['cancellation_reasons'].length).to eq(1)
+    end
+
+    it 'returns cancellation_reasons visible to offer if `order` exist in params' do
+      create :cancellation_reason, :visible_to_offer
+      create :cancellation_reason, :visible_to_order
+      get :index, order: true
       expect(response.status).to eq(200)
       expect(parsed_body['cancellation_reasons'].length).to eq(1)
     end

--- a/spec/factories/cancellation_reasons.rb
+++ b/spec/factories/cancellation_reasons.rb
@@ -5,8 +5,12 @@ FactoryBot.define do
     visible_to_offer { generate(:cancellation_reasons)[name_en][:visible_to_offer] }
     # initialize_with { CancellationReason.find_or_initialize_by(name_en: name_en) }
 
-    trait :visible do
+    trait :visible_to_offer do
       visible_to_offer true
+    end
+
+    trait :visible_to_order do
+      visible_to_order true
     end
 
     trait :invisible do

--- a/spec/factories/cancellation_reasons.rb
+++ b/spec/factories/cancellation_reasons.rb
@@ -2,16 +2,16 @@ FactoryBot.define do
   factory :cancellation_reason do
     name_en         { generate(:cancellation_reasons).keys.sample }
     name_zh_tw      { generate(:cancellation_reasons)[name_en][:name_zh_tw] }
-    visible_to_admin { generate(:cancellation_reasons)[name_en][:visible_to_admin] }
+    visible_to_offer { generate(:cancellation_reasons)[name_en][:visible_to_offer] }
     # initialize_with { CancellationReason.find_or_initialize_by(name_en: name_en) }
 
     trait :visible do
-      visible_to_admin true
+      visible_to_offer true
     end
 
     trait :invisible do
       name_en "Unwanted"
-      visible_to_admin false
+      visible_to_offer false
     end
   end
 end

--- a/spec/models/cancellation_reason_spec.rb
+++ b/spec/models/cancellation_reason_spec.rb
@@ -9,12 +9,24 @@ RSpec.describe CancellationReason, type: :model do
   it { is_expected.to validate_presence_of(:name_en) }
 
   describe "scope: visible_to_offer" do
-    let!(:visible_reason) { create :cancellation_reason, :visible }
-    let!(:invisible_reason) { create :cancellation_reason, :invisible }
-    it "return records having visible_to_admin as true" do
+    let!(:offer_cancellation_reason) { create :cancellation_reason, :visible_to_offer }
+    let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
+
+    it "return records having visible_to_offer as true" do
       visible_scope_ids = CancellationReason.visible_to_offer.pluck(:id)
-      expect(visible_scope_ids).to include(visible_reason.id)
-      expect(visible_scope_ids).to_not include(invisible_reason.id)
+      expect(visible_scope_ids).to include(offer_cancellation_reason.id)
+      expect(visible_scope_ids).to_not include(order_cancellation_reason.id)
+    end
+  end
+
+  describe "scope: visible_to_order" do
+    let!(:offer_cancellation_reason) { create :cancellation_reason, :visible_to_offer }
+    let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
+
+    it "return records having visible_to_order as true" do
+      visible_scope_ids = CancellationReason.visible_to_order.pluck(:id)
+      expect(visible_scope_ids).to include(order_cancellation_reason.id)
+      expect(visible_scope_ids).to_not include(offer_cancellation_reason.id)
     end
   end
 

--- a/spec/models/cancellation_reason_spec.rb
+++ b/spec/models/cancellation_reason_spec.rb
@@ -4,14 +4,15 @@ RSpec.describe CancellationReason, type: :model do
 
   it { is_expected.to have_db_column(:name_en).of_type(:string) }
   it { is_expected.to have_db_column(:name_zh_tw).of_type(:string) }
-  it { is_expected.to have_db_column(:visible_to_admin).of_type(:boolean) }
+  it { is_expected.to have_db_column(:visible_to_offer).of_type(:boolean) }
+  it { is_expected.to have_db_column(:visible_to_order).of_type(:boolean) }
   it { is_expected.to validate_presence_of(:name_en) }
 
-  describe "scope: visible" do
+  describe "scope: visible_to_offer" do
     let!(:visible_reason) { create :cancellation_reason, :visible }
     let!(:invisible_reason) { create :cancellation_reason, :invisible }
     it "return records having visible_to_admin as true" do
-      visible_scope_ids = CancellationReason.visible.pluck(:id)
+      visible_scope_ids = CancellationReason.visible_to_offer.pluck(:id)
       expect(visible_scope_ids).to include(visible_reason.id)
       expect(visible_scope_ids).to_not include(invisible_reason.id)
     end

--- a/spec/models/cancellation_reason_spec.rb
+++ b/spec/models/cancellation_reason_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CancellationReason, type: :model do
     let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
 
     it "return records having visible_to_offer as true" do
-      visible_scope_ids = CancellationReason.visible_to_offer.pluck(:id)
+      visible_scope_ids = described_class.visible_to_offer.pluck(:id)
       expect(visible_scope_ids).to include(offer_cancellation_reason.id)
       expect(visible_scope_ids).to_not include(order_cancellation_reason.id)
     end
@@ -24,7 +24,7 @@ RSpec.describe CancellationReason, type: :model do
     let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
 
     it "return records having visible_to_order as true" do
-      visible_scope_ids = CancellationReason.visible_to_order.pluck(:id)
+      visible_scope_ids = described_class.visible_to_order.pluck(:id)
       expect(visible_scope_ids).to include(order_cancellation_reason.id)
       expect(visible_scope_ids).to_not include(offer_cancellation_reason.id)
     end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Order, type: :model do
     it { is_expected.to belong_to :beneficiary }
     it { is_expected.to belong_to :address }
     it { is_expected.to belong_to :district }
+    it { is_expected.to belong_to :cancellation_reason }
     it { is_expected.to belong_to(:created_by).class_name('User') }
     it { is_expected.to belong_to(:processed_by).class_name('User') }
 
@@ -60,7 +61,7 @@ RSpec.describe Order, type: :model do
     it{ is_expected.to have_db_column(:code).of_type(:string)}
     it{ is_expected.to have_db_column(:detail_type).of_type(:string)}
     it{ is_expected.to have_db_column(:description).of_type(:text)}
-    it{ is_expected.to have_db_column(:cancellation_reason).of_type(:text)}
+    it{ is_expected.to have_db_column(:cancel_reason).of_type(:text)}
     it{ is_expected.to have_db_column(:state).of_type(:string)}
     it{ is_expected.to have_db_column(:purpose_description).of_type(:text)}
     it{ is_expected.to have_db_column(:created_at).of_type(:datetime)}


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2931

### What does this PR do?

FEATURE: 
 1) Adding cancellation Reason for Orders on stock 
 2) assigning default cancellation_reason of "Changed mind".  
 3) removing cancellation reason on resubmitting the order.

### Impacted Areas

Go to specific order. Click "Cancel order" popup appears with cancellation message and options.


### Screenshots

![image-2019-12-17-14-57-24-480](https://user-images.githubusercontent.com/37627094/71614853-1abee280-2bd4-11ea-9a47-71dff5c3745f.png)
