### PR TITLE
Inventory move action fix

### DIFF
--- a/app/models/concerns/operations/location_operations.rb
+++ b/app/models/concerns/operations/location_operations.rb
@@ -52,23 +52,20 @@ module LocationOperations
       end
 
       def increment_destination
-        PackagesInventory.create(
-          package: @package,
-          quantity: @quantity,
-          action: PackagesInventory::Actions::GAIN,
-          source: @cause,
-          location: @to,
-          user: author
-        )
+        register_change(@to, @quantity)
       end
 
       def decrement_origin
+        register_change(@from, -1 * @quantity)
+      end
+
+      def register_change(location, qty_change)
         PackagesInventory.create(
           package: @package,
-          quantity: -1 * @quantity,
-          action: PackagesInventory::Actions::LOSS,
+          quantity: qty_change,
+          action: PackagesInventory::Actions::MOVE,
           source: @cause,
-          location: @from,
+          location: location,
           user: author
         )
       end

--- a/spec/controllers/api/v1/booking_types_controller_spec.rb
+++ b/spec/controllers/api/v1/booking_types_controller_spec.rb
@@ -2,26 +2,28 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::BookingTypesController, type: :controller do
   let(:reviewer) { create(:user, :reviewer) }
-  let(:booking_type) { create(:booking_type) }
   let(:parsed_body) { JSON.parse(response.body) }
+
+  before do
+    generate(:booking_types).keys.each do |name_en|
+      create(:booking_type, name_en: name_en)
+    end
+  end
 
   describe "GET booking_type" do
     before { generate_and_set_token(reviewer) }
 
     it "returns 200", :show_in_doc do
-      # Generate all booking_types options for listing in API docs
-      generate(:booking_types).keys.each do |name_en|
-        create(:booking_type, name_en: name_en)
-      end
       get :index
       expect(response.status).to eq(200)
     end
 
     it "return serialized booking_type" do
-      booking_type
       get :index
-      expect(parsed_body['booking_types'].length).to eq(1)
-      expect(parsed_body['booking_types'][0]['name_en']).to eq(booking_type.name_en)
+      expect(parsed_body['booking_types'].length).to eq(2)
+      expect(
+        parsed_body['booking_types'].map { |bt| bt['identifier'] }
+      ).to contain_exactly(*BookingType.all.pluck(:identifier))
     end
   end
 end

--- a/spec/models/concerns/operations/location_operations_spec.rb
+++ b/spec/models/concerns/operations/location_operations_spec.rb
@@ -39,24 +39,24 @@ context LocationOperations do
         expect(dest_pkg_loc.reload.quantity).to eq(17)
       end
 
-      it 'adds a loss row for the source location' do
+      it 'adds a decremental move row for the source location' do
         expect(PackagesInventory.count).to eq(2)
         expect { move(15) }.to change(PackagesInventory, :count).by(2)
 
         record = PackagesInventory.last(2).first
         expect(record.location_id).to eq(src_location.id)
-        expect(record.action).to eq('loss')
+        expect(record.action).to eq('move')
         expect(record.quantity).to eq(-15)
       end
 
 
-      it 'adds a gain row for the dest location' do
+      it 'adds an incremental move row for the dest location' do
         expect(PackagesInventory.count).to eq(2)
         expect { move(15) }.to change(PackagesInventory, :count).by(2)
 
         record = PackagesInventory.last
         expect(record.location_id).to eq(dest_location.id)
-        expect(record.action).to eq('gain')
+        expect(record.action).to eq('move')
         expect(record.quantity).to eq(15)
       end
 


### PR DESCRIPTION
##### Post-release fix

I noticed the move operation was registering a 'gain' and 'loss' instead of the 'move' action.
As of now it has no impact because loss/gain aren't yet used
This PR simply replaces the action used to 'move'

##### Other

Fixed a test that was failing randomly

