### PR TITLE
in Use eager_loading to avoid N+1 queries.

### DIFF
--- a/app/controllers/api/v1/orders_packages_controller.rb
+++ b/app/controllers/api/v1/orders_packages_controller.rb
@@ -90,7 +90,8 @@ module Api
           each_serializer: serializer,
           root: "orders_packages",
           include_package: true,
-          include_orders_packages: true
+          include_orders_packages: true,
+          include_allowed_actions: true
         ).as_json
       end
 

--- a/app/controllers/api/v1/orders_packages_controller.rb
+++ b/app/controllers/api/v1/orders_packages_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V1
     class OrdersPackagesController < Api::V1::ApiController
       load_and_authorize_resource :orders_package, parent: false
-      before_action :eager_load_orders_package, only: :show
 
       resource_description do
         formats ['json']
@@ -64,11 +63,8 @@ module Api
       end
 
       def show
-        render json: @orders_package, serializer: serializer
-      end
-
-      def eager_load_orders_package
         @orders_package = OrdersPackage.accessible_by(current_ability).with_eager_load.find(params[:id])
+        render json: @orders_package, serializer: serializer
       end
 
       private
@@ -87,7 +83,7 @@ module Api
       end
 
       def orders_package_by_order_id
-        records = @orders_packages.for_order(params["order_id"])
+        records = @orders_packages.with_eager_load.for_order(params["order_id"])
         orders_packages = records.page(params["page"]).per(params["per_page"])
         render json: ActiveModel::ArraySerializer.new(
           orders_packages,

--- a/app/controllers/api/v1/orders_packages_controller.rb
+++ b/app/controllers/api/v1/orders_packages_controller.rb
@@ -84,7 +84,7 @@ module Api
 
       def orders_package_by_order_id
         records = @orders_packages.with_eager_load.for_order(params["order_id"])
-        orders_packages = records.page(params["page"]).per(params["per_page"])
+        orders_packages = records.page(page).per(per_page)
         render json: ActiveModel::ArraySerializer.new(
           orders_packages,
           each_serializer: serializer,

--- a/app/controllers/api/v1/orders_packages_controller.rb
+++ b/app/controllers/api/v1/orders_packages_controller.rb
@@ -83,10 +83,11 @@ module Api
       end
 
       def orders_package_by_order_id
-        records = @orders_packages.with_eager_load.for_order(params["order_id"])
-        orders_packages = records.page(page).per(per_page)
+        @orders_packages = @orders_packages.with_eager_load
+          .for_order(params["order_id"])
+          .page(page).per(per_page)
         render json: ActiveModel::ArraySerializer.new(
-          orders_packages,
+          @orders_packages,
           each_serializer: serializer,
           root: "orders_packages",
           include_package: true,

--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -30,7 +30,7 @@ class OrdersPackage < ActiveRecord::Base
 
   scope :with_eager_load, ->{
     includes([
-      { package: [:locations, :package_type] }
+      { package: [ :locations, {package_type: [:location]}, :images, :orders_packages] }
     ])
   }
 


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2932

### What does this PR do?

FEATURE: Speeds up the `orders_packages` endpoint by using eager_loading strategies.

At a rough estimate (on a dev machine), this halves the request time (445ms is down to 275ms) and the DB load drops from 100ms to 33ms.

Before this code, the Rails log would show lots of repetitive queries when serializing json for `/orders_packages?order_id=11` requests.

```
OrdersPackage Load
Package Load
Location Load
PackageType Load
Image Load
OrdersPackage Load
Package Load
Location Load
PackageType Load
Image Load
OrdersPackage Load
Package Load
Location Load
PackageType Load
Image Load
OrdersPackage Load
Package Load
Location Load
PackageType Load
Image Load

etc etc...

Completed 200 OK in 445ms (Views: 10.3ms | ActiveRecord: 99.0ms)

```

After using eager_loading strategies the repetition is mainly gone and replaced with queries that load all of the required data from a table in one go:

```
OrdersPackage Load (0.9ms)  SELECT  "orders_packages".* FROM "orders_packages" INNER JOIN "orders" ON "orders"."id" = "orders_packages"."order_id" WHERE "orders"."id" = $1 LIMIT 25 OFFSET 0  [["id", 11]]
Package Load (1.5ms)  SELECT "packages".* FROM "packages" WHERE "packages"."deleted_at" IS NULL AND "packages"."id" IN (995, 996, 997, 998, 999, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018, 1019)
PackagesLocation Load (0.7ms)  SELECT "packages_locations".* FROM "packages_locations" WHERE "packages_locations"."package_id" IN (1005, 1010, 1006, 1007, 1008, 1009, 1014, 1011, 1012, 1017, 1013, 1015, 1019, 1016, 1018, 997, 995, 998, 996, 1000, 999, 1002, 1001, 1004, 1003)
Location Load (0.7ms)  SELECT "locations".* FROM "locations" WHERE "locations"."id" IN (1, 170, 93, 224, 286, 266, 178, 331, 81, 155, 299, 338, 248, 121, 161, 305, 337, 127, 138, 301, 148, 120)
PackageType Load (0.9ms)  SELECT "package_types".* FROM "package_types" WHERE "package_types"."id" IN (126, 8, 36, 78, 172, 63, 21, 112, 318, 115, 229, 81, 149, 175, 168, 38, 97, 62, 55, 13, 49, 122)
Location Load (0.7ms)  SELECT "locations".* FROM "locations" WHERE "locations"."id" IN (431, 1097, 1108, 1251, 827, 1386, 354, 371, 374, 392, 403, 568, 1023, 942, 488, 557, 649, 506, 974, 998, 1039, 359)
Image Load (0.6ms)  SELECT "images".* FROM "images" WHERE "images"."deleted_at" IS NULL AND "images"."imageable_type" = 'Package' AND "images"."imageable_id" IN (1005, 1010, 1006, 1007, 1008, 1009, 1014, 1011, 1012, 1017, 1013, 1015, 1019, 1016, 1018, 997, 995, 998, 996, 1000, 999, 1002, 1001, 1004, 1003)
OrdersPackage Load (0.7ms)  SELECT "orders_packages".* FROM "orders_packages" WHERE "orders_packages"."package_id" IN (1005, 1010, 1006, 1007, 1008, 1009, 1014, 1011, 1012, 1017, 1013, 1015, 1019, 1016, 1018, 997, 995, 998, 996, 1000, 999, 1002, 1001, 1004, 1003)

Completed 200 OK in 278ms (Views: 55.7ms | ActiveRecord: 33.7ms)

```

### Impacted Areas

Orders -> Package view with infinite scroll

NOTE: there are still some issues with package_types N+1 queries due to bad serializer design but I suggest we ignore those for now as the gains from deploying the current set of infinite scroll features in GCW-2932 far out weigh the optimisations that are left.

```
(0.4ms)  SELECT "package_types"."code" FROM "package_types" INNER JOIN "subpackage_types" ON "package_types"."id" = "subpackage_types"."subpackage_type_id" WHERE "subpackage_types"."package_type_id" = $1 AND "subpackage_types"."is_default" = $2  [["package_type_id", 8], ["is_default", "f"]]
```

### Linked PR's:

PR #894 

### Linked Slack conversation:

https://crossroads-hk.slack.com/archives/GBJAFNVFB/p1579250342013900
