### PR TITLE
Added orders_packages_count to orders JSON payload

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -55,7 +55,7 @@ module Api
       api :GET, '/v1/designations/1', "Get a order"
       def show
         root = is_browse_app? ? "order" : "designation"
-        render json: serializer.new(@order,
+        serialized_orders = serializer.new(@order,
           root: root,
           exclude_code_details: true,
           include_packages: bool_param(:include_packages, true),
@@ -65,7 +65,8 @@ module Api
           include_allowed_actions: true,
           include_orders_packages: bool_param(:include_orders_packages, true),
           exclude_stockit_set_item: true
-        )
+        ).as_json
+        render json: {meta: {counts: {orders_packages_count: @order.orders_packages.size}}}.merge(serialized_orders)
       end
 
       def transition

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -485,6 +485,15 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
     end
   end
 
+  context "GET orders/1" do
+    let(:order) { create(:order, :with_orders_packages) }
+    before{ generate_and_set_token(user) }
+    it "returns meta with count of orders_packages" do
+      get :show, id: order.id
+      expect(parsed_body['meta']['counts']['orders_packages_count']).to eql(order.orders_packages.size)
+    end
+  end
+
   describe "PUT orders/1" do
     before { generate_and_set_token(charity_user) }
 


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2932

### What does this PR do?

BUG: Provides the data to fix an incorrect count of 'Active' packages on the Order screen.

@abulsayyad123 this is just an API PR, you will need to use this count in a separate Ember PR (I've not written that). Also, note I've just implemented a count of the associated orders_packages, this includes all cancelled, designated and dispatched records. Is that the same as what is shown in the active tab?

### Impacted Areas

Orders > 12345

### Screenshots

Due to the infinite scroll feature, the count on the Active tab here is wrong.

![image](https://user-images.githubusercontent.com/149198/72658177-37d31e00-39e8-11ea-887e-0e440a1976d4.png)

The solution is to provide the total count in the JSON data 'meta' dict. For example:

![image](https://user-images.githubusercontent.com/149198/72658168-196d2280-39e8-11ea-8c7c-cd3f76f11b84.png)

### Linked PR's:

PR #894  PR #895 

### Linked Slack conversation:

https://crossroads-hk.slack.com/archives/GBJAFNVFB/p1579250342013900