### PR TITLE
Remove manage_orders_packages role and replace with finer grained security

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -237,7 +237,7 @@ class Ability
   def orders_package_abilities
     if can_manage_orders_packages? || @api_user
       can [:index, :search, :show, :destroy, :exec_action], OrdersPackage
-    else 
+    else
       can [:index, :search, :show, :destroy, :exec_action], OrdersPackage, order: { created_by_id: @user_id }
       can [:index, :search, :show, :destroy, :exec_action], OrdersPackage, order: { submitted_by_id: @user_id }
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -237,6 +237,9 @@ class Ability
   def orders_package_abilities
     if can_manage_orders_packages? || @api_user
       can [:index, :search, :show, :destroy, :exec_action], OrdersPackage
+    else 
+      can [:index, :search, :show, :destroy, :exec_action], OrdersPackage, order: { created_by_id: @user_id }
+      can [:index, :search, :show, :destroy, :exec_action], OrdersPackage, order: { submitted_by_id: @user_id }
     end
   end
 

--- a/db/permissions_roles.yml
+++ b/db/permissions_roles.yml
@@ -67,7 +67,6 @@ Supervisor:
 api-write: []
 Charity:
 - can_login_to_browse
-- can_manage_orders_packages
 - can_search_browse_packages
 - can_create_goodcity_requests
 - can_create_and_read_messages

--- a/spec/models/abilities/orders_packages_abilities_spec.rb
+++ b/spec/models/abilities/orders_packages_abilities_spec.rb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 describe "OrdersPackage abilities" do
   subject(:ability) { Ability.new(user) }
-  let(:all_actions) { [:index, :search, :show] }
+  let(:all_actions) { [:index, :search, :show, :destroy, :exec_action] }
   let(:orders_package) { create :orders_package }
 
   context "when Administrator" do
@@ -29,5 +29,24 @@ describe "OrdersPackage abilities" do
   context "when normal user" do
     let(:user) { create :user }
     it{ all_actions.each { |do_action| is_expected.to_not be_able_to(do_action, orders_package) } }
+  end
+
+  context "when Charity user" do
+    let(:user) { create :user, :charity}
+    context "created the order with orders_packages" do
+      let(:order) { create :order, :with_orders_packages, created_by_id: user.id }
+      let(:orders_package) { order.orders_packages.first }
+      it{ all_actions.each { |do_action| is_expected.to be_able_to(do_action, orders_package) } }
+    end
+    context "submitted the order with orders_packages" do
+      let(:order) { create :order, :with_orders_packages, submitted_by_id: user.id }
+      let(:orders_package) { order.orders_packages.first }
+      it{ all_actions.each { |do_action| is_expected.to be_able_to(do_action, orders_package) } }
+    end
+    context "didn't create or submit the order with orders_packages" do
+      let(:order) { create :order, :with_orders_packages, created_by_id: nil, submitted_by_id: nil }
+      let(:orders_package) { order.orders_packages.first }
+      it{ all_actions.each { |do_action| is_expected.to_not be_able_to(do_action, orders_package) } }
+    end
   end
 end


### PR DESCRIPTION
### What does this PR do?

BUG: Non-admin users are able to view all orders_packages. This PR resolves that by restricting it to just ones that belong to orders they created or submitted.

NOTE: This shouldn't be merged until Browse and Stock have been well-tested for 401/403 errors

### JIRA ticket

https://jira.crossroads.org.hk/browse/GCW-2963

### Impacted Areas

* Order -> List / Show
* Browse -> Create order, View dashboard, View order
