### PR TITLE
Don't add inventory to stockit if it's disabled.

### DIFF
--- a/app/models/concerns/operations/order_fulfilment_operations.rb
+++ b/app/models/concerns/operations/order_fulfilment_operations.rb
@@ -84,7 +84,7 @@ module OrderFulfilmentOperations
         )
         unless ord_pkg.dispatched? || dispatched_count(ord_pkg) < ord_pkg.quantity
           ord_pkg.dispatch
-          ord_pkg.package.dispatch_stockit_item(ord_pkg)
+          ord_pkg.package.dispatch_stockit_item(ord_pkg) if STOCKIT_ENABLED
           ord_pkg.package.save
         end
       end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -108,7 +108,7 @@ class Package < ActiveRecord::Base
 
     before_transition on: :mark_received do |package|
       package.received_at = Time.now
-      package.add_to_stockit
+      package.add_to_stockit if STOCKIT_ENABLED
     end
 
     after_transition on: [:mark_received, :mark_missing] do |package|


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2905

### What does this PR do?

FEATURE: Now that we are moving towards a post-Stockit world, we need to handle cases where the code runs with Stockit turned off. In this case, when a new package is inventorized, we don't want to add it to Stockit and wait for a response.

### Impacted Areas

Admin App:
* Receive package
* Create new item
