### PR TITLE
Don't return 404 if not all users can be found.

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -22,7 +22,7 @@ module Api
       def index
         return search_user_and_render_json if params[:searchText].present?
         @users = @users.except_stockit_user
-        @users = @users.find(ids_param) if ids_param.present?
+        @users = @users.where(id: ids_param) if ids_param.present?
         render json: @users, each_serializer: serializer
       end
 


### PR DESCRIPTION
### What does this PR do?

BUG: If `params[:ids_param]` is called with a user id that doesn't exist in the DB then a 404 error is thrown. Better to just return the users that are available, if any, and let the client figure out what is missing.

### Impacted Areas

NOTE: e.g. Stock app > Order listing (where a list of users is fetched) - a missing user was causing 50+ rollbar errors to be generated!
