### PR TITLE
Partial dispatch

### DIFF
--- a/app/models/concerns/inventory_computer.rb
+++ b/app/models/concerns/inventory_computer.rb
@@ -32,7 +32,7 @@ module InventoryComputer
       def designated_quantity_of(package, to_order: nil)
         query = OrdersPackage.designated.where(package: package)
         query = query.where(order: to_order) if to_order.present?
-        query.sum(:quantity)
+        query.reduce(0) { |sum, op| sum + op.quantity - op.dispatched_quantity }
       end
 
       def dispatched_quantity(package: nil, orders_package: nil)

--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -70,7 +70,7 @@ class OrdersPackage < ActiveRecord::Base
 
     before_transition on: :cancel do |orders_package, _transition|
       if orders_package.designated? && orders_package.dispatched_quantity.positive?
-        raise Goodcity::InvalidStateError.new(I18n.t('orders_package.cancel_requires_undispatch'));
+        raise Goodcity::InvalidStateError.new(I18n.t('orders_package.cancel_requires_undispatch'))
       end
       orders_package.quantity   = 0
       orders_package.updated_by = User.current_user

--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -69,6 +69,9 @@ class OrdersPackage < ActiveRecord::Base
     end
 
     before_transition on: :cancel do |orders_package, _transition|
+      if orders_package.designated? && orders_package.dispatched_quantity.positive?
+        raise Goodcity::InvalidStateError.new(I18n.t('orders_package.cancel_requires_undispatch'));
+      end
       orders_package.quantity   = 0
       orders_package.updated_by = User.current_user
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,14 +87,14 @@ en:
     has_box_error: "This item is on box %{box_number}."
     move_stockit: "You can only move it using Stockit."
     split_qty_error: "Quantity to split should be at least 1 and less than %{qty}"
-
   orders_package:
-    already_dispatched: "This has been already dispatched."
+    quantity_already_dispatched: "Some has been already dispatched, please undispatch and try again."
     order_status_error: "You need to complete processing Order first before dispatching."
     action_disabled: "Action %{name} is not possible at the moment"
     qty_not_available: "We do not currently have the requested quantity in stock"
     qty_edit_denied_for_inactive: "Quantity of already dispatched/cancelled items cannot be modified"
     invalid_qty: "Invalid quantity"
+    cancel_requires_undispatch: "Unable to cancel during dispatch, please undispatch and try again"
   organisations_user_builder:
     organisation:
       blank: "Organisation can't be blank"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -83,12 +83,13 @@ zh-tw:
     move_stockit: "You can only move it using Stockit."
     split_qty_error: "Quantity to split should be at least 1 and less than %{qty}"
   orders_package:
-    already_dispatched: "This has been already dispatched."
+    quantity_already_dispatched: "Some has been already dispatched, please undispatch and try again."
     order_status_error: "You need to complete processing Order first before dispatching."
     action_disabled: "Action %{name} is not possible at the moment"
     qty_not_available: "We do not currently have the requested quantity in stock"
     qty_edit_denied_for_inactive: "Quantity of already dispatched/cancelled items cannot be modified"
     invalid_qty: "Invalid quantity"
+    cancel_requires_undispatch: "Unable to cancel during dispatch, please undispatch and try again"
   organisations_user_builder:
     organisation:
       blank: "Organisation can't be blank"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191211032725) do
+ActiveRecord::Schema.define(version: 20200107034249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -504,9 +504,10 @@ ActiveRecord::Schema.define(version: 20191211032725) do
     t.string   "state"
     t.integer  "quantity"
     t.integer  "updated_by_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.datetime "sent_on"
+    t.integer  "dispatched_quantity", default: 0
   end
 
   add_index "orders_packages", ["order_id", "package_id"], name: "index_orders_packages_on_order_id_and_package_id", using: :btree
@@ -655,7 +656,6 @@ ActiveRecord::Schema.define(version: 20191211032725) do
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
-    t.boolean  "last_allow_web_published"
     t.integer  "weight"
     t.integer  "pieces"
     t.integer  "detail_id"
@@ -949,7 +949,7 @@ ActiveRecord::Schema.define(version: 20191211032725) do
     t.datetime "created_at"
   end
 
-  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))", using: :btree
+  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))", using: :btree
   add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
   add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree

--- a/features/orders_packages_actions.feature
+++ b/features/orders_packages_actions.feature
@@ -12,6 +12,12 @@ Feature: Listing OrdersPackage available actions
     And Their OrdersPackages are of state "designated"
     Then They should have the "edit_quantity|cancel|dispatch" actions enabled
 
+  Scenario: For active orders with partially dispatched orders_package
+    Given I have Orders with states of type: "ACTIVE_STATES"
+    And Their OrdersPackages are of state "designated"
+    And Their OrdersPackages are partially dispatched
+    Then They should have the "dispatch|undispatch" actions enabled
+
   Scenario: Editing quantity for active orders with designated orders_package
     Given I have Orders with states of type: "ACTIVE_STATES"
     And Their OrdersPackages have the following stock properties

--- a/features/step_definitions/orders_packages_actions_steps.rb
+++ b/features/step_definitions/orders_packages_actions_steps.rb
@@ -29,6 +29,14 @@ And(/^Their OrdersPackages are of state "([^"]*)"$/) do |orders_package_states|
   end
 end
 
+And(/^Their OrdersPackages are partially dispatched$/) do
+  @orders_packages_per_state.each do |_, order_packages|
+    order_packages.each do |op|
+      op.dispatched_quantity = 1
+    end
+  end
+end
+
 # We pass in quantity properties and state as a table
 And(/^Their OrdersPackages have the following stock properties$/) do |qty_table|
   properties = qty_table.hashes

--- a/lib/goodcity/errors.rb
+++ b/lib/goodcity/errors.rb
@@ -1,6 +1,8 @@
 module Goodcity
   class BaseError < StandardError; end
 
+  class InvalidStateError < BaseError; end
+
   class OperationsError < BaseError; end
 
   class UnprocessedError < OperationsError
@@ -11,7 +13,7 @@ module Goodcity
 
   class AlreadyDispatchedError < OperationsError
     def initialize
-      super(I18n.t('orders_package.already_dispatched'))
+      super(I18n.t('orders_package.quantity_already_dispatched'))
     end
   end
 

--- a/spec/controllers/api/v1/booking_types_controller_spec.rb
+++ b/spec/controllers/api/v1/booking_types_controller_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Api::V1::BookingTypesController, type: :controller do
   let(:parsed_body) { JSON.parse(response.body) }
 
   before do
-    generate(:booking_types).keys.each do |name_en|
-      create(:booking_type, name_en: name_en)
+    generate(:booking_types).keys.each do |identifier|
+      create(:booking_type, identifier: identifier)
     end
   end
 

--- a/spec/controllers/api/v1/orders_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_packages_controller_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Api::V1::OrdersPackagesController, type: :controller do
           it 'fails to dispatch the packages' do
             expect(current_state).to eq('designated')
 
-            put :exec_action, id: orders_package.id, action_name: 'dispatch', quantity: 10, location_id: package.locations.first
+            put :exec_action, id: orders_package.id, action_name: 'dispatch', quantity: 10, location_id: package.locations.first.id
 
             expect(status).to eq(422)
             expect(error_text).to eq("Cannot dispatch packages from an unprocessed order")

--- a/spec/controllers/api/v1/orders_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_packages_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Api::V1::OrdersPackagesController, type: :controller do
           it 'dispatches the packages successfully' do
             expect(current_state).to eq('designated')
 
-            put :exec_action, id: orders_package.id, action_name: 'dispatch'
+            put :exec_action, id: orders_package.id, action_name: 'dispatch', quantity: 10, location_id: package.locations.first
 
             expect(status).to eq(200)
             expect(new_state).to eq('dispatched')
@@ -186,7 +186,7 @@ RSpec.describe Api::V1::OrdersPackagesController, type: :controller do
           it 'fails to dispatch the packages' do
             expect(current_state).to eq('designated')
 
-            put :exec_action, id: orders_package.id, action_name: 'dispatch'
+            put :exec_action, id: orders_package.id, action_name: 'dispatch', quantity: 10, location_id: package.locations.first
 
             expect(status).to eq(422)
             expect(error_text).to eq("Cannot dispatch packages from an unprocessed order")

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
   let(:users) { create_list(:user, 2) }
 
-  let(:charity_users) { (1..26).map { create(:user, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Charity' => ['can_login_to_browse']}, last_name: 'Jones')}}
+  let(:charity_users) { ('a'..'z').map { |i|
+    create(:user, :with_multiple_roles_and_permissions,
+    roles_and_permissions: { 'Charity' => ['can_login_to_browse']}, first_name: "Jane_#{i}", last_name: 'Doe')}}
 
   let(:parsed_body) { JSON.parse(response.body) }
 

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :location do
-    building   { 10+rand(36) }
+    sequence(:building)
     area       { FFaker::Lorem.characters(1).upcase }
     stockit_id { rand(1000) }
     initialize_with {

--- a/spec/models/concerns/operations/designation_operations_spec.rb
+++ b/spec/models/concerns/operations/designation_operations_spec.rb
@@ -57,6 +57,17 @@ context DesignationOperations do
         }.from("designated").to("dispatched")
       end
 
+      it 'marks the orders_package as dispatched if the remaining undispatched quantity is dispatched' do
+        allow(Stockit::OrdersPackageSync).to receive(:create)
+        allow(Stockit::OrdersPackageSync).to receive(:update)
+
+        ord_pkg = designate(4, to_order: dispatching_order)
+        OrdersPackage::Operations.dispatch(ord_pkg, quantity: 2, from_location: package.locations.first)
+        expect { OrdersPackage::Operations.dispatch(ord_pkg, quantity: 2, from_location: package.locations.first) }.to change {
+          OrdersPackage.find(ord_pkg.id).state
+        }.from("designated").to("dispatched")
+      end
+
       it 'can designate the remaining quantity to another order' do
         expect(Stockit::OrdersPackageSync).to receive(:create).twice
 


### PR DESCRIPTION
## Main Changes

### Allowing partial dispatch

* **before** `Operations.dispatch_full_qty(op)`
* **after**    `Operations.dispatch(op, from_location: opts[:location_id], quantity: opts[:quantity])`

### `OrdersPackage` allowed actions changes

An `orders_package` in a _designated_ state now has the following actions listed:

 * undispatch _(only if partially dispatched)_
 * cancel _(only if dispatch hasn't started)_

Meaning: If you partially dispatch an `orders_package`, you won't be able to cancel it unless you first undispatch whatever has been dispatched.

### Change of the `undispatch` action

The `undispatch` action now undispatches the already dispatched quantity. As of now there is no such thing as a partial undispatch.

## Other changes

* Fixed issue where the "designated" quantity of a package didn't take into account the partially dispatched quantity

* Fixed tests that would randomly fail due to Factories using `rand()` , `initialize_with` and other edge cases