### PR TITLE
Inventorize operations

### DIFF
--- a/app/models/concerns/operations/order_fulfilment_operations.rb
+++ b/app/models/concerns/operations/order_fulfilment_operations.rb
@@ -113,7 +113,7 @@ module OrderFulfilmentOperations
     end
 
     def assert_can_undispatch(ord_pkg, quantity)
-      raise Goodcity::MissingDispatchedQuantityError.new if dispatched_count(ord_pkg) < quantity
+      raise Goodcity::BadUndispatchQuantity.new if dispatched_count(ord_pkg) < quantity
     end
 
     def dispatched_count(ord_pkg)

--- a/app/models/concerns/operations/stock_operations.rb
+++ b/app/models/concerns/operations/stock_operations.rb
@@ -16,7 +16,7 @@ module StockOperations
     # @param [Location|String] the location to place the package in
     #
     def inventorize(package, location)
-      last = PackagesInventory.order('id DESC').where(package: package).first
+      last = PackagesInventory.order('id DESC').where(package: package).limit(1).first
 
       raise Goodcity::AlreadyInventorizedError if last.present? && !last.uninventory?
 
@@ -37,7 +37,7 @@ module StockOperations
     # @param [Location|String] the location to place the package in
     #
     def uninventorize(package)
-      last_action = PackagesInventory.order('id DESC').where(package: package).first
+      last_action = PackagesInventory.order('id DESC').where(package: package).limit(1).first
       raise Goodcity::UninventoryError if last_action.blank? || !last_action.inventory?
       last_action.undo
     end

--- a/app/models/concerns/operations/stock_operations.rb
+++ b/app/models/concerns/operations/stock_operations.rb
@@ -5,6 +5,43 @@ module StockOperations
 
     module_function
 
+
+    ##
+    # Adds a package to the inventory
+    #
+    #
+    # @raise [Goodcity::AlreadyInventorizedError] thrown if trying to inventorize twice
+    #
+    # @param [Package|String] the package to inventorize or its id
+    # @param [Location|String] the location to place the package in
+    #
+    def inventorize(package, location)
+      last = PackagesInventory.order('id DESC').where(package: package).first
+
+      raise Goodcity::AlreadyInventorizedError if last.present? && !last.uninventory?
+
+      PackagesInventory.append_inventory(
+        package:  package,
+        quantity: package.received_quantity,
+        location: location
+      )
+    end
+
+    ##
+    # Undo the latest inventory action
+    # Will fail if
+    #
+    # @raise [Goodcity::UninventoryError] thrown if actions were taken since the initial inventory action
+    #
+    # @param [Package|String] the package to inventorize or its id
+    # @param [Location|String] the location to place the package in
+    #
+    def uninventorize(package)
+      last_action = PackagesInventory.order('id DESC').where(package: package).first
+      raise Goodcity::UninventoryError if last_action.blank? || !last_action.inventory?
+      last_action.undo
+    end
+
     ##
     # Registers the loss of some package
     #

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -130,11 +130,4 @@ class Item < ActiveRecord::Base
       package.designate_to_stockit_order(params[:order_id])
     end
   end
-
-  def move_set_to_location(location_id)
-    inventory_packages.set_items.each do |package|
-      package.move_stockit_item(location_id)
-      package.valid? && package.save
-    end
-  end
 end

--- a/app/models/packages_inventory.rb
+++ b/app/models/packages_inventory.rb
@@ -32,7 +32,7 @@ class PackagesInventory < ActiveRecord::Base
   # Undo feature
   # --------------------
 
-  REVERSABLE_ACTIONS = {
+  REVERSIBLE_ACTIONS = {
     Actions::INVENTORY    => Actions::UNINVENTORY,
     Actions::DISPATCH     => Actions::UNDISPATCH,
     Actions::GAIN         => Actions::LOSS,
@@ -42,10 +42,10 @@ class PackagesInventory < ActiveRecord::Base
   }
 
   def undo
-    raise Goodcity::InventoryError.new(I18n.t('packages_inventory.cannot_undo')) unless REVERSABLE_ACTIONS.key?(action)
+    raise Goodcity::InventoryError.new(I18n.t('packages_inventory.cannot_undo')) unless REVERSIBLE_ACTIONS.key?(action)
 
     PackagesInventory.create!({
-      action:   REVERSABLE_ACTIONS[action],
+      action:   REVERSIBLE_ACTIONS[action],
       user:     User.current_user || User.system_user,
       package:  package,
       source:   source,

--- a/app/models/packages_inventory.rb
+++ b/app/models/packages_inventory.rb
@@ -59,7 +59,7 @@ class PackagesInventory < ActiveRecord::Base
   # --------------------
 
   def inventorized?(package)
-    last = PackagesInventory.order('id DESC').where(package: package).first
+    last = PackagesInventory.order('id DESC').where(package: package).limit(1).first
     last.present? && !last.uninventory?
   end
 

--- a/app/models/packages_inventory.rb
+++ b/app/models/packages_inventory.rb
@@ -1,15 +1,16 @@
 class PackagesInventory < ActiveRecord::Base
   module Actions
-    INVENTORY   = 'inventory'.freeze
-    LOSS        = 'loss'.freeze
-    GAIN        = 'gain'.freeze
-    DISPATCH    = 'dispatch'.freeze
-    UNDISPATCH  = 'undispatch'.freeze
-    MOVE        = 'move'.freeze
+    INVENTORY     = 'inventory'.freeze
+    UNINVENTORY   = 'uninventory'.freeze
+    LOSS          = 'loss'.freeze
+    GAIN          = 'gain'.freeze
+    DISPATCH      = 'dispatch'.freeze
+    UNDISPATCH    = 'undispatch'.freeze
+    MOVE          = 'move'.freeze
   end
 
   INCREMENTAL_ACTIONS = [Actions::INVENTORY, Actions::UNDISPATCH, Actions::GAIN].freeze
-  DECREMENTAL_ACTIONS = [Actions::LOSS, Actions::DISPATCH].freeze
+  DECREMENTAL_ACTIONS = [Actions::UNINVENTORY, Actions::LOSS, Actions::DISPATCH].freeze
   UNRESTRICTED_ACTIONS = [Actions::MOVE].freeze
   ALLOWED_ACTIONS = (INCREMENTAL_ACTIONS + DECREMENTAL_ACTIONS + UNRESTRICTED_ACTIONS).freeze
 
@@ -27,7 +28,40 @@ class PackagesInventory < ActiveRecord::Base
 
   after_create { PackagesInventory.emit(self.action, self) }
 
-  # --- Helpers
+  # --------------------
+  # Undo feature
+  # --------------------
+
+  REVERSABLE_ACTIONS = {
+    Actions::INVENTORY    => Actions::UNINVENTORY,
+    Actions::DISPATCH     => Actions::UNDISPATCH,
+    Actions::GAIN         => Actions::LOSS,
+    Actions::UNINVENTORY  => Actions::INVENTORY,
+    Actions::UNDISPATCH   => Actions::DISPATCH,
+    Actions::LOSS         => Actions::GAIN
+  }
+
+  def undo
+    raise Goodcity::InventoryError.new(I18n.t('packages_inventory.cannot_undo')) unless REVERSABLE_ACTIONS.key?(action)
+
+    PackagesInventory.create!({
+      action:   REVERSABLE_ACTIONS[action],
+      user:     User.current_user || User.system_user,
+      package:  package,
+      source:   source,
+      location: location,
+      quantity: quantity * -1
+    })
+  end
+
+  # --------------------
+  # Helpers
+  # --------------------
+
+  def inventorized?(package)
+    last = PackagesInventory.order('id DESC').where(package: package).first
+    last.present? && !last.uninventory?
+  end
 
   def incremental?
     return quantity.positive? if UNRESTRICTED_ACTIONS.include?(action)
@@ -54,7 +88,10 @@ class PackagesInventory < ActiveRecord::Base
     end
   end
 
-  # --- Validations
+  # --------------------
+  # Validations
+  # --------------------
+
   validate :validate_fields, on: [:create]
 
   def validate_action

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
   delivery:
     gogovan_message: "%{name} booked a GoGoVan for %{time}, %{date}"
     drop_off_message: "%{name} will deliver the items between %{time}, %{date}"
+  packages_inventory:
+    cannot_undo: Action cannot be undone
   package:
     max_print_error: "Print value should be between 0 and %{max_barcode_qty}."
     creation_of_box/pallet_error: "Creation of %{storage_type} not allowed."
@@ -118,6 +120,8 @@ en:
       required_for_orders: Will break the quantity required for orders (%{orders}), please undesignate first
     generic:
       not_inventorized: Cannot operate on uninventorized packages
+      already_inventorized: Package already inventorized
+      uninventorize_error: Package cannot be uninventorized
       inactive_order: Operation forbidden, order %{code} is inactive
       insufficient_quantity: The selected quantity (%{quantity}) is unavailable
       bad_quantity_param: Invalid quantity (%{quantity})

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -75,6 +75,8 @@ zh-tw:
   delivery:
     gogovan_message: "%{name} 已預約 GoGoVan，時間為 %{time}, %{date}"
     drop_off_message: "%{name} 將會在以下時間 %{time}, %{date} 送抵物資。"
+  packages_inventory:
+    cannot_undo: Action cannot be undone
   package:
     max_print_error: "Print value should be between 0 and %{max_barcode_qty}."
     creation_of_box/pallet_error: "Creation of %{storage_type} not allowed."
@@ -113,6 +115,8 @@ zh-tw:
       required_for_orders: Will break the quantity required for orders (%{orders}), please undesignate first
     generic:
       not_inventorized: Cannot operate on uninventorized packages
+      already_inventorized: Package already inventorized
+      uninventorize_error: Package cannot be uninventorized
       inactive_order: Operation forbidden, order %{code} is inactive
       insufficient_quantity: The selected quantity (%{quantity}) is unavailable
       bad_quantity_param: Invalid quantity (%{quantity})

--- a/lib/goodcity/errors.rb
+++ b/lib/goodcity/errors.rb
@@ -5,23 +5,24 @@ module Goodcity
 
   class OperationsError < BaseError; end
 
-  class UnprocessedError < OperationsError
-    def initialize
-      super(I18n.t('operations.dispatch.unprocessed_order'))
+  class InventoryError < BaseError; end
+
+  def factory(base, translation_key)
+    Class.new(base) do
+      define_method(:initialize) { super(I18n.t(translation_key)) }
     end
   end
 
-  class AlreadyDispatchedError < OperationsError
-    def initialize
-      super(I18n.t('orders_package.quantity_already_dispatched'))
-    end
-  end
+  module_function :factory
 
-  class MissingQuantityError < OperationsError
-    def initialize
-      super(I18n.t('operations.move.not_enough_at_source'))
-    end
-  end
+  UnprocessedError                = factory(OperationsError, 'operations.dispatch.unprocessed_order')
+  AlreadyDispatchedError          = factory(OperationsError, 'orders_package.quantity_already_dispatched')
+  MissingQuantityError            = factory(OperationsError, 'operations.move.not_enough_at_source')
+  NotInventorizedError            = factory(OperationsError, 'operations.generic.not_inventorized')
+  AlreadyInventorizedError        = factory(OperationsError, 'operations.generic.already_inventorized')
+  UninventoryError                = factory(OperationsError, 'operations.generic.uninventorize_error')
+  MissingQuantityforDispatchError = factory(OperationsError, 'operations.dispatch.missing_quantity_for_dispatch')
+  BadUndispatchQuantity           = factory(OperationsError, 'operations.undispatch.missing_dispatched_quantity')
 
   class QuantityDesignatedError < OperationsError
     def initialize(orders)
@@ -45,18 +46,6 @@ module Goodcity
   class InactiveOrderError < OperationsError
     def initialize(order)
       super(I18n.t('operations.generic.inactive_order', code: order.code))
-    end
-  end
-
-  class NotInventorizedError < OperationsError
-    def initialize()
-      super(I18n.t('operations.generic.not_inventorized'))
-    end
-  end
-
-  class MissingQuantityforDispatchError < OperationsError
-    def initialize
-      super(I18n.t('operations.dispatch.missing_quantity_for_dispatch'))
     end
   end
 end

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -323,24 +323,6 @@ RSpec.describe Package, type: :model do
     end
   end
 
-  describe '#build_or_create_packages_location' do
-    let!(:package) { create :package }
-    let!(:location) { create :location }
-
-    it 'creates new packages_location record with provided location id if it do not exist' do
-      expect{
-        package.build_or_create_packages_location(location.id, 'create')
-      }.to change(PackagesLocation, :count).by(1)
-    end
-
-    it 'do not create packages_location record with provided location if already exist' do
-      packages_location = create :packages_location, package: package, location: location
-      expect{
-        package.build_or_create_packages_location(location.id, 'create')
-      }.to change(PackagesLocation, :count).by(0)
-    end
-  end
-
   describe '#update_designation' do
     let(:package) { create :package }
     let(:order) { create :order, state: 'submitted' }


### PR DESCRIPTION
This is the first part of [GCW-3025](https://jira.crossroads.org.hk/browse/GCW-3025)

**Note:** this PR adds internal features and tests but those are not used as of now

### Additions

#### Inventorize/Uninventorize actions

Those will be used via the admin app to record the initial quantity of a package

file : `models/concerns/operations/stock_operations.rb`

Usage:

```
Package::Operations.inventorize(package, location)
Package::Operations.uninventorize(package)
```

A package can only be uninventorized right after being inventorized. If it is modified in any way, the operation will be rejected

#### PackagesInventory > undo

Added an `undo` method to the PackagesInventory method, allowing to revert an action by adding it's opposite action to the log

e.g

```
last_action = PackagesInventory.find_by(package_id: 1, action: 'inventory')
last_action.undo
puts(PackagesInventory.last) # { action: 'uninventory', package_id: 1, ... }
```

Note: not all types of actions can be undone

### Fixes

https://jira.crossroads.org.hk/browse/GCW-3025

An exception class had be removed, I suspect through a git conflict. (I miss static typing)



