### PR TITLE
#Release: coronavirus lock appointments

### DIFF
--- a/app/controllers/api/v1/appointment_slots_controller.rb
+++ b/app/controllers/api/v1/appointment_slots_controller.rb
@@ -33,9 +33,10 @@ module Api
 
       api :GET, '/v1/appointment_slots/calendar', "List upcoming appointment slots aggregated by dates"
       def calendar
+        booking_type_id = params[:booking_type_id]
         from = params[:from] ? Date.parse(params[:from]) : Date.today
         to = ceil(Date.parse(params[:to]), from + MAX_CALENDAR_RANGE)
-        render json: { appointment_calendar_dates: AppointmentSlot.calendar(from, to) }, status: 200
+        render json: { appointment_calendar_dates: AppointmentSlot.calendar(from, to, booking_type: booking_type_id) }, status: 200
       end
 
       api :POST, "/v1/appointment_slots", "Add an appointment slot"

--- a/app/models/appointment_slot.rb
+++ b/app/models/appointment_slot.rb
@@ -66,9 +66,14 @@ class AppointmentSlot < ActiveRecord::Base
 
     return [] if Holiday.is_holiday?(date)
 
+    # wday is 0-indexed and starts on Sunday, as opposed to our data which is 1-indexed and start on Monday
+    # we convert Sundays which are 0 into 7 to handle that
+    day = date.wday
+    day = 7 if day.zero?
+
     # Generate slots based on preset if no special slot have been specified for that date
     AppointmentSlotPreset
-      .where(day: date.wday + 1)
+      .where(day: day)
       .ascending
       .map { |preset|
         t = date.to_datetime.in_time_zone.change(hour: preset.hours, min: preset.minutes, sec: 0)

--- a/app/models/goodcity_setting.rb
+++ b/app/models/goodcity_setting.rb
@@ -2,6 +2,16 @@ class GoodcitySetting < ActiveRecord::Base
   validates :key, uniqueness: true, presence: true
 
   def self.enabled?(key)
-    find_by(key: key)&.value&.eql?("true")
+    get(key).eql?("true")
+  end
+
+  def self.get(key, default: nil)
+    GoodcitySetting.find_by(key: key)&.value || default
+  end
+
+  def self.get_date(key, default: nil)
+    Date.parse GoodcitySetting.get(key)
+  rescue
+    default
   end
 end

--- a/db/goodcity_settings.yml
+++ b/db/goodcity_settings.yml
@@ -7,3 +7,7 @@
   key: "stock.allow_box_pallet_item_addition"
   value: "false"
   description: "Manages the settings for addition/removal of items to box"
+-
+  key: "api.appointments.prevent_booking_until"
+  value: "24-03-2020"
+  description: "If a date value is set (DD-MM-YYYY), no appointment will be allowed before that date"


### PR DESCRIPTION
This is the release PR for the following changes:

Based on the setting api.appointments.prevent_booking_until , all appointment slots are marked as locked before that specific date.

This fix is made to solve the issue of blocking appointments during the Coronavirus phase