### PR TITLE
GCW-2985 send available-quantity of packages to browse

### DIFF
--- a/app/serializers/api/v1/package_serializer.rb
+++ b/app/serializers/api/v1/package_serializer.rb
@@ -13,7 +13,7 @@ module Api::V1
                :item_id, :state, :received_at, :rejected_at, :inventory_number,
                :created_at, :updated_at, :package_type_id, :designation_id, :sent_on,
                :offer_id, :designation_name, :grade, :donor_condition_id, :received_quantity,
-               :allow_web_publish, :detail_type, :detail_id, :on_hand_quantity
+               :allow_web_publish, :detail_type, :detail_id, :available_quantity
 
     def designation_id
       object.order_id
@@ -39,12 +39,12 @@ module Api::V1
       "stockit_sent_on"
     end
 
-    def on_hand_quantity
-      object.total_in_hand_quantity
+    def available_quantity
+      object.total_available_quantity
     end
 
-    def on_hand_quantity__sql
-      "(SELECT sum(quantity) FROM packages_inventories where packages_inventories.package_id = packages.id)"
+    def available_quantity__sql
+      "(packages.received_quantity - ((SELECT COALESCE(sum(quantity), 0) FROM orders_packages WHERE orders_packages.state = 'designated' AND orders_packages.package_id = packages.id) - (SELECT COALESCE(sum(dispatched_quantity), 0) FROM orders_packages WHERE orders_packages.state = 'designated' AND orders_packages.package_id = packages.id)))"
     end
 
     def include_orders_packages?


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2985

### What does this PR do?

**Rollback** changes from PR https://github.com/crossroads/api.goodcity/pull/916

Instead of sending on-hand-quantity of packages, send available-quantity of packages to show packages on the browse app

(available-quantity = package-received-quantity - (desginated-quantity - partial-dispatched-quantity))

Used in Browse app https://github.com/crossroads/browse.goodcity/pull/513

### Impacted Areas

NOTE: List any impacted areas (e.g. Dashboard > My Active Offers > scheduled )


### Screenshots

NOTE: Attach screeenshots if PR contains any UI changes

### Mockup Link

Note: Specify mockup link

### Linked PR's:

NOTE: If these changes are related to some existing PR or fixes any issue from existing PR changes, specify PR links.

### Linked Slack conversation:

NOTE: IF there is any conversation happened for current changes in any of the slack channel, mention the slack message link.

### Any Open question(s) or challenge(s):
