### PR TITLE
Order state transition validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (5.2.0.345)
     nio4r (2.5.2)
-    nokogiri (1.10.5)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)

--- a/app/models/concerns/operations/order_fulfilment_operations.rb
+++ b/app/models/concerns/operations/order_fulfilment_operations.rb
@@ -82,6 +82,9 @@ module OrderFulfilmentOperations
           source: ord_pkg,
           location: location
         )
+
+        ord_pkg.order.start_dispatching if ord_pkg.order.awaiting_dispatch?
+
         unless ord_pkg.dispatched? || dispatched_count(ord_pkg) < ord_pkg.quantity
           ord_pkg.dispatch
           ord_pkg.package.dispatch_stockit_item(ord_pkg) if STOCKIT_ENABLED

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -225,7 +225,7 @@ class Order < ActiveRecord::Base
     end
 
     before_transition on: :cancel do |order|
-      if OrdersPackage.where(order: order).any? { |op| op.dispatched? || op.dispatched_quantity.positive? }
+      if OrdersPackage.for_order(order.id).not_cancellable.exists?
         raise Goodcity::InvalidStateError.new(I18n.t('orders_package.cancel_requires_undispatch'))
       end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -225,6 +225,10 @@ class Order < ActiveRecord::Base
     end
 
     before_transition on: :cancel do |order|
+      if OrdersPackage.where(order: order).any? { |op| op.dispatched? || op.dispatched_quantity.positive? }
+        raise Goodcity::InvalidStateError.new(I18n.t('orders_package.cancel_requires_undispatch'))
+      end
+
       order.cancelled_at = Time.now
       order.cancelled_by = User.current_user
       order.orders_packages.each do |orders_package|

--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -27,6 +27,8 @@ class OrdersPackage < ActiveRecord::Base
   scope :designated, ->{ where(state: 'designated') }
   scope :dispatched, ->{ where(state: 'dispatched') }
   scope :for_order, ->(order_id) { joins(:order).where(orders: { id: order_id }) }
+  scope :not_cancellable, -> () { where("orders_packages.state = 'dispatched' OR dispatched_quantity > 0") }
+  scope :cancellable, -> () { where("orders_packages.state = 'designated' AND dispatched_quantity = 0") }
 
   scope :with_eager_load, ->{
     includes([

--- a/features/order_state_transitions.feature
+++ b/features/order_state_transitions.feature
@@ -1,0 +1,27 @@
+Feature: Changing the states of an order
+  As a Stock user, I transition the orders through multiple states
+
+  Scenario: Cannot dispatch a package from a Submitted order
+    Given I have an order of state "submitted"
+    And It has a orders_package of state "designated"
+    Then Dispatching the orders_package should "fail"
+
+  Scenario: Cannot dispatch a package from a Processing order
+    Given I have an order of state "processing"
+    And It has a orders_package of state "designated"
+    Then Dispatching the orders_package should "fail"
+
+  # Scenario: Dispatching a package of a Scheduled order changes the state of the order to Dispatching
+  #   Given I have an order of state "awaiting_dispatch"
+  #   And It has a orders_package of state "designated"
+  #   When I dispatch the orders_package
+  #   Then The order transitions to the "dispatching" state
+
+  # Scenario: Cancelling an order with dispatched packages fails
+  #   Given I have an order of state "dispatching"
+  #   And It has an orders_package of state "dispatched"
+  #   Then Applying the "cancel" transition to the order "fails"
+
+
+
+

--- a/features/order_state_transitions.feature
+++ b/features/order_state_transitions.feature
@@ -3,24 +3,24 @@ Feature: Changing the states of an order
 
   Scenario: Cannot dispatch a package from a Submitted order
     Given I have an order of state "submitted"
-    And It has a orders_package of state "designated"
+    And It has an orders_package of state "designated"
     Then Dispatching the orders_package should "fail"
 
   Scenario: Cannot dispatch a package from a Processing order
     Given I have an order of state "processing"
-    And It has a orders_package of state "designated"
+    And It has an orders_package of state "designated"
     Then Dispatching the orders_package should "fail"
 
-  # Scenario: Dispatching a package of a Scheduled order changes the state of the order to Dispatching
-  #   Given I have an order of state "awaiting_dispatch"
-  #   And It has a orders_package of state "designated"
-  #   When I dispatch the orders_package
-  #   Then The order transitions to the "dispatching" state
+  Scenario: Dispatching a package of a Scheduled order changes the state of the order to Dispatching
+    Given I have an order of state "awaiting_dispatch"
+    And It has an orders_package of state "designated"
+    When I dispatch the orders_package
+    Then The order transitions to the "dispatching" state
 
-  # Scenario: Cancelling an order with dispatched packages fails
-  #   Given I have an order of state "dispatching"
-  #   And It has an orders_package of state "dispatched"
-  #   Then Applying the "cancel" transition to the order "fails"
+  Scenario: An order with dispatched packages should not be cancellable
+    Given I have an order of state "dispatching"
+    And It has an orders_package of state "dispatched"
+    Then Applying the "cancel" transition to the order "fails"
 
 
 

--- a/features/order_state_transitions.feature
+++ b/features/order_state_transitions.feature
@@ -1,3 +1,4 @@
+@supervisor
 Feature: Changing the states of an order
   As a Stock user, I transition the orders through multiple states
 

--- a/features/step_definitions/order_state_transitions_steps.rb
+++ b/features/step_definitions/order_state_transitions_steps.rb
@@ -1,0 +1,25 @@
+Given(/^I have an order of state "([^"]*)"/) do |state|
+  @order = create :order, state: state
+end
+
+And(/^It has a orders_package of state "([^"]*)"/) do |state|
+  package = create :package, received_quantity: 5
+  create :packages_inventory, package: package, quantity: package.received_quantity, action: 'inventory'
+
+  @orders_package = create :orders_package, order: @order, package_id: package.id, state: state
+end
+
+Then(/Dispatching the orders_package should "([^"]*)"/) do |result|
+  expect_fail     = (result == "fail")
+
+  expect {
+    OrdersPackage::Actions::DISPATCH.run(@orders_package,
+      location_id:    @orders_package.package.locations.first.id,
+      quantity:       @orders_package.package.received_quantity,
+    )
+  }.to (
+    expect_fail ?
+      raise_error(Goodcity::OperationsError)
+      : change(PackagesInventory, :count).by(1)
+  )
+end

--- a/features/step_definitions/order_state_transitions_steps.rb
+++ b/features/step_definitions/order_state_transitions_steps.rb
@@ -2,14 +2,18 @@ Given(/^I have an order of state "([^"]*)"/) do |state|
   @order = create :order, state: state
 end
 
-And(/^It has a orders_package of state "([^"]*)"/) do |state|
+And(/^It has an orders_package of state "([^"]*)"/) do |state|
   package = create :package, received_quantity: 5
   create :packages_inventory, package: package, quantity: package.received_quantity, action: 'inventory'
 
   @orders_package = create :orders_package, order: @order, package_id: package.id, state: state
 end
 
-Then(/Dispatching the orders_package should "([^"]*)"/) do |result|
+When(/^I dispatch the orders_package/) do
+  OrdersPackage::Operations.dispatch(@orders_package, quantity: @orders_package.quantity, from_location: @orders_package.package.locations.first)
+end
+
+Then(/^Dispatching the orders_package should "([^"]*)"/) do |result|
   expect_fail     = (result == "fail")
 
   expect {
@@ -18,8 +22,25 @@ Then(/Dispatching the orders_package should "([^"]*)"/) do |result|
       quantity:       @orders_package.package.received_quantity,
     )
   }.to (
-    expect_fail ?
-      raise_error(Goodcity::OperationsError)
-      : change(PackagesInventory, :count).by(1)
+    expect_fail ? raise_error(Goodcity::OperationsError) : change(PackagesInventory, :count).by(1)
+  )
+end
+
+Then(/^The order transitions to the "([^"]*)" state/) do |expected_state|
+  expect(@order.reload.state).to eq(expected_state)
+end
+
+Then(/^Applying the "([^"]*)" transition to the order "([^"]*)"/) do |transition, expected_result|
+  should_fail = expected_result.match(/^fail/)
+
+  current_state   = @order.state
+  expected_state  = transition
+
+  expect {
+    @order.fire_state_event(transition)
+  }.to (
+    should_fail ?
+      raise_error(Goodcity::InvalidStateError) :
+      change { @order.reload.state }.from(current_state).to(expected_state)
   )
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -40,6 +40,11 @@ end
 
 World(FactoryBot::Syntax::Methods)
 
+Before do
+  User.current_user ||= FactoryBot.create(:user, :supervisor)
+end
+
+
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:
 #

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -40,8 +40,8 @@ end
 
 World(FactoryBot::Syntax::Methods)
 
-Before do
-  User.current_user ||= FactoryBot.create(:user, :supervisor)
+Before('@supervisor') do
+  User.current_user = FactoryBot.create(:user, :supervisor)
 end
 
 

--- a/spec/models/concerns/operations/order_fulfilment_operations_spec.rb
+++ b/spec/models/concerns/operations/order_fulfilment_operations_spec.rb
@@ -22,9 +22,10 @@ context OrderFulfilmentOperations do
   describe 'Dispatching an orders_package' do
     let(:pkg) { create(:package, received_quantity: 30) }
     let(:location) { create(:location) }
-    let(:pkg_loc) { create(:packages_location, package: pkg, location: location, quantity: 30) }
+    let(:pkg_loc) { pkg.packages_locations.first }
 
     before do
+      initialize_inventory(pkg, location: location)
       touch(pkg_loc)
     end
 
@@ -147,6 +148,18 @@ context OrderFulfilmentOperations do
         end
       end
     end
+
+    describe 'Order state changes' do
+      let(:dispatched_qty) { 3 }
+      let(:scheduled_order) { create(:order, state: 'awaiting_dispatch') }
+      let(:orders_package) { create(:orders_package, :with_state_designated, order: scheduled_order, package: pkg, quantity: 30) }
+
+      it 'changes awaiting_dispatch orders to dispatching state' do
+        expect {
+          subject::Operations::dispatch(orders_package, from_location: location, quantity: 30)
+        }.to change { scheduled_order.reload.state }.from("awaiting_dispatch").to("dispatching")
+      end
+    end
   end
 
   describe 'Undispatching an orders_package' do
@@ -154,12 +167,14 @@ context OrderFulfilmentOperations do
     let(:dispatch_location) { create(:location, :dispatched) }
     let(:pkg) { create(:package, received_quantity: 30) }
     let(:order) { create(:order, :with_state_dispatching) }
-    let(:pkg_loc) { create(:packages_location, package: pkg, location: location, quantity: 30) }
+    let(:pkg_loc) { pkg.packages_locations.first }
     let(:src_location) { pkg_loc.location }
     let(:orders_package) { create(:orders_package, :with_state_designated, package: pkg, order: order, quantity: 30) }
 
     before do
       # Run the dispatch method to setup the test
+      initialize_inventory(pkg, location: location)
+      touch(pkg_loc)
       touch(src_location)
       touch(orders_package)
       subject::Operations::dispatch(orders_package, from_location: src_location, quantity: orders_package.quantity)

--- a/spec/support/inventory_initializer.rb
+++ b/spec/support/inventory_initializer.rb
@@ -1,12 +1,14 @@
 module InventoryInitializer
   def initialize_inventory(*packages, location: nil)
-    location ||= pkg.locations.first || FactoryBot.create(:location)
     [packages].flatten.each do |pkg|
       return if PackagesInventory.where(package: pkg).count.positive? # Already initialized
-      create :packages_inventory, package: pkg, quantity: pkg.received_quantity, action: 'inventory', location: location
+
+      dest_location = location || pkg.locations.first || FactoryBot.create(:location)
+
+      create :packages_inventory, package: pkg, quantity: pkg.received_quantity, action: 'inventory', location: dest_location
 
       pkg.orders_packages.dispatched.each do |orders_package|
-        create :packages_inventory, package: pkg, quantity: - orders_package.quantity, action: 'dispatch', location: location
+        create :packages_inventory, package: pkg, quantity: - orders_package.quantity, action: 'dispatch', location: dest_location
       end
 
       pkg.requested_packages.each(&:update_availability!)

--- a/spec/support/inventory_initializer.rb
+++ b/spec/support/inventory_initializer.rb
@@ -1,11 +1,12 @@
 module InventoryInitializer
-  def initialize_inventory(*packages)
+  def initialize_inventory(*packages, location: nil)
+    location ||= pkg.locations.first || FactoryBot.create(:location)
     [packages].flatten.each do |pkg|
       return if PackagesInventory.where(package: pkg).count.positive? # Already initialized
-      create :packages_inventory, package: pkg, quantity: pkg.received_quantity, action: 'inventory'
+      create :packages_inventory, package: pkg, quantity: pkg.received_quantity, action: 'inventory', location: location
 
       pkg.orders_packages.dispatched.each do |orders_package|
-        create :packages_inventory, package: pkg, quantity: - orders_package.quantity, action: 'dispatch', location: pkg.locations.first
+        create :packages_inventory, package: pkg, quantity: - orders_package.quantity, action: 'dispatch', location: location
       end
 
       pkg.requested_packages.each(&:update_availability!)


### PR DESCRIPTION
This covers a few regressions Matt noticed

- Cancelling an order with dispatched orders_packages should not be possible
- Dispatching an orders_package of an `awaiting_dispatch` order should put the order in the `dispatching` state
