### PR TITLE
GCW-3051 fix duplicate record creation for booking type

### DIFF
--- a/app/models/booking_type.rb
+++ b/app/models/booking_type.rb
@@ -2,6 +2,8 @@
 class BookingType < ActiveRecord::Base
   has_many :orders
 
+  validates_uniqueness_of :name_en, :name_zh_tw
+
   def appointment?
     identifier == "appointment"
   end

--- a/db/migrate/20200226111634_add_uniqueness_constraint_to_booking_types.rb
+++ b/db/migrate/20200226111634_add_uniqueness_constraint_to_booking_types.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToBookingTypes < ActiveRecord::Migration
+  def change
+    add_index :booking_types, [:name_en, :name_zh_tw], unique: true
+  end
+end

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::OrdersController, type: :controller do
-  let(:booking_type) { create :booking_type }
+  let!(:appointment_type) { create(:booking_type, :appointment) }
+  let!(:online_order_type) { create(:booking_type, :online_order) }
   let(:charity_user) { create :user, :charity, :with_can_manage_orders_permission}
-  let!(:order) { create :order, :with_state_submitted, created_by: charity_user, booking_type: booking_type }
+  let!(:order) { create :order, :with_state_submitted, created_by: charity_user, booking_type: appointment_type }
   let!(:dispatching_order) { create :order, :with_state_dispatching }
   let!(:awaiting_dispatch_order) { create :order, :with_state_awaiting_dispatch }
   let!(:processing_order) { create :order, :with_state_processing }
@@ -18,12 +19,6 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
     parsed_body['designations']
       .map { |d| Order.find(d['id']) }
   end
-
-  before(:all) {
-    FactoryBot.generate(:booking_types).keys.each { |identifier|
-      create :booking_type, identifier: identifier
-    }
-  }
 
   # Helper
   def timeslot_of(t)
@@ -529,9 +524,9 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
       end
 
       context 'Processing checklist' do
-        let!(:checklist_it1) { create :process_checklist, booking_type: booking_type }
-        let!(:checklist_it2) { create :process_checklist, booking_type: booking_type }
-        let!(:checklist_it3) { create :process_checklist, booking_type: booking_type }
+        let!(:checklist_it1) { create :process_checklist, booking_type: appointment_type }
+        let!(:checklist_it2) { create :process_checklist, booking_type: appointment_type }
+        let!(:checklist_it3) { create :process_checklist, booking_type: appointment_type }
 
         let(:payload) do
           payload = {}

--- a/spec/controllers/api/v1/requested_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/requested_packages_controller_spec.rb
@@ -141,12 +141,6 @@ RSpec.describe Api::V1::RequestedPackagesController, type: :controller do
 
   describe "Checkout process" do
 
-    before(:all) {
-      FactoryBot.generate(:booking_types).keys.each { |identifier|
-        FactoryBot.create :booking_type, identifier: identifier
-      }
-    }
-
     context "as a guest" do
       it "returns 401" do
         post :checkout

--- a/spec/factories/booking_types.rb
+++ b/spec/factories/booking_types.rb
@@ -1,8 +1,19 @@
 FactoryBot.define do
   factory :booking_type do
-    identifier { generate(:booking_types).keys.sample }
-    name_en    { generate(:booking_types)[identifier][:name_en] }
-    name_zh_tw { generate(:booking_types)[identifier][:name_zh_tw] }
-    initialize_with { BookingType.find_or_initialize_by(identifier: identifier) }
+    trait :online_order do
+      identifier  'online-order'
+      name_zh_tw  "online order"
+      name_en     "online order"
+    end
+
+    trait :appointment do
+      identifier  'appointment'
+      name_zh_tw  "appointment"
+      name_en     "appointment"
+    end
+
+    identifier   { "abc" }
+    name_zh_tw   { identifier }
+    name_en      { identifier }
   end
 end

--- a/spec/factories/booking_types.rb
+++ b/spec/factories/booking_types.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :booking_type do
     identifier { generate(:booking_types).keys.sample }
-    name_en    { generate(:booking_types)[:name_en] }
-    name_zh_tw { generate(:booking_types)[:name_zh_tw] }
+    name_en    { generate(:booking_types)[identifier][:name_en] }
+    name_zh_tw { generate(:booking_types)[identifier][:name_zh_tw] }
     initialize_with { BookingType.find_or_initialize_by(identifier: identifier) }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -16,7 +16,9 @@ FactoryBot.define do
     association     :beneficiary
     association     :country
     association     :district
-    association     :booking_type
+    booking_type do |b|
+      BookingType.first || association(:booking_type)
+    end
 
     trait :with_orders_packages do
       after(:create) do |order|

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -114,10 +114,10 @@ FactoryBot.define do
   end
 
   factory :online_order, parent: :order do
-    booking_type { create(:booking_type, identifier: 'online-order') }
+    booking_type {BookingType.find_or_initialize_by(identifier: "online-order" ,name_en: 'online order', name_zh_tw: 'online order')}
   end
 
   factory :appointment, parent: :order do
-    booking_type { create(:booking_type, identifier: 'appointment') }
+    booking_type { BookingType.find_or_initialize_by(identifier: "appointment", name_en: "appointment", name_zh_tw: "appointment") }
   end
 end

--- a/spec/factories/process_checklists.rb
+++ b/spec/factories/process_checklists.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :process_checklist do
-    association :booking_type
+    booking_type do
+      BookingType.first || association(:booking_type)
+    end
     text_en { FFaker::Lorem.characters(5) }
     text_zh_tw { FFaker::Lorem.characters(5) }
   end

--- a/spec/models/booking_type_spec.rb
+++ b/spec/models/booking_type_spec.rb
@@ -10,4 +10,9 @@ RSpec.describe BookingType, type: :model do
     it { is_expected.to have_db_column(:name_zh_tw).of_type(:string) }
     it { is_expected.to have_db_column(:identifier).of_type(:string) }
   end
+
+  describe "Validations" do
+    it { is_expected.to validate_uniqueness_of(:name_en) }
+    it { is_expected.to validate_uniqueness_of(:name_zh_tw) }
+  end
 end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3051

### What does this PR do?

- Added a unique index to the booking_types name_en column to prevent types with the same. name.
- Added uniq validation name_en and name_zh_tw column of booking type.

Please review.

Thanks.

