### PR TITLE
Fixed bug where reviewer was not able to schedule deliveries for offers with no donor

### DIFF
--- a/app/models/concerns/push_updates_for_delivery.rb
+++ b/app/models/concerns/push_updates_for_delivery.rb
@@ -60,7 +60,7 @@ module PushUpdatesForDelivery
   def delivery_notify_message
     formatted_date = schedule.scheduled_at.strftime("%a #{schedule.scheduled_at.day.ordinalize} %b %Y")
     I18n.t("delivery.#{delivery_type.downcase.tr(' ', '_')}_message",
-      name: donor.full_name,
+      name: donor&.full_name || User&.current_user&.full_name || 'Someone',
       time: schedule.slot_name,
       date: formatted_date)
   end

--- a/spec/models/concerns/push_updates_for_delivery_spec.rb
+++ b/spec/models/concerns/push_updates_for_delivery_spec.rb
@@ -36,6 +36,51 @@ context PushUpdatesForDelivery do
       end
     end
   end
+
+  context "delivery_notify_message" do
+    subject { delivery.send(:delivery_notify_message) }
+    context "when a new drop-off is scheduled" do
+      context "by donor" do
+        it { expect(subject).to match(/#{donor.full_name} will deliver the items/) }
+      end
+      context "by reviewer" do
+        before(:each) do
+          delivery.offer.created_by = nil
+          User.current_user = reviewer
+        end
+        it { expect(subject).to match(/#{reviewer.full_name} will deliver the items/) }
+      end
+      context "from console" do
+        before(:each) do
+          delivery.offer.created_by = nil
+          User.current_user = nil
+        end
+        it { expect(subject).to match(/Someone will deliver the items/) }
+      end
+    end
+
+    context "when a new GogoVan is scheduled" do
+      let!(:delivery) { create :gogovan_delivery }
+      context "by donor" do
+        it { expect(subject).to match(/#{donor.full_name} booked a GoGoVan/) }
+      end
+      context "by reviewer" do
+        before(:each) do
+          delivery.offer.created_by = nil
+          User.current_user = reviewer
+        end
+        it { expect(subject).to match(/#{reviewer.full_name} booked a GoGoVan/) }
+      end
+      context "from console" do
+        before(:each) do
+          delivery.offer.created_by = nil
+          User.current_user = nil
+        end
+        it { expect(subject).to match(/Someone booked a GoGoVan/) }
+      end
+    end
+
+  end
   
   context "push_updates" do
     it "to donor and admin" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3059

### What does this PR do?

When an offer with no donor (created by a reviewer) was scheduled, the delivery notification was failing as it did not know who created the delivery. This PR fixes that.

### Impacted Areas

Admin app: Offer -> Create Delivery screens
