### PR TITLE
GCW-3074 send cancellation id in response to fix it

### DIFF
--- a/app/serializers/api/v1/order_shallow_serializer.rb
+++ b/app/serializers/api/v1/order_shallow_serializer.rb
@@ -7,7 +7,7 @@ module Api::V1
       :gc_organisation_id, :processed_at, :processed_by_id, :cancelled_at, :cancelled_by_id,
       :process_completed_at, :process_completed_by_id, :closed_at, :closed_by_id, :dispatch_started_at,
       :dispatch_started_by_id, :submitted_at, :submitted_by_id, :people_helped, :beneficiary_id,
-      :address_id, :district_id, :booking_type_id, :staff_note
+      :address_id, :district_id, :booking_type_id, :staff_note, :cancellation_reason_id
 
     def local_order_id
       (object.detail_type == "LocalOrder" || object.detail_type == "StockitLocalOrder") ? object.detail_id : nil


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3074

### What does this PR do?

BUG: When we search for orders on the orders search page, order_shallow_serializer is called. In that serializer we are not sending the cancellation reason id. Due to which cancellation reason goes missing.

![Screen Shot 2020-03-03 at 1 36 48 PM](https://user-images.githubusercontent.com/26408955/75755134-10e06980-5d54-11ea-8f45-676f1bb6463a.png)

Adding this attribute in the order_shallow serializer fixes this issue.

![Screen Shot 2020-03-03 at 1 37 49 PM](https://user-images.githubusercontent.com/26408955/75755201-33728280-5d54-11ea-80a2-19ad0ab1c68f.png)
