### PR TITLE
Add extra quantity fields as a separate migration

### DIFF
--- a/db/migrate/20200226062814_add_extra_quantity_fields.rb
+++ b/db/migrate/20200226062814_add_extra_quantity_fields.rb
@@ -1,0 +1,13 @@
+class AddExtraQuantityFields < ActiveRecord::Migration
+  def change
+    add_column    :packages, :available_quantity,   :integer, default: 0
+    add_column    :packages, :on_hand_quantity,     :integer, default: 0
+    add_column    :packages, :designated_quantity,  :integer, default: 0
+    add_column    :packages, :dispatched_quantity,  :integer, default: 0
+
+    add_index :packages, :available_quantity
+    add_index :packages, :on_hand_quantity
+    add_index :packages, :designated_quantity
+    add_index :packages, :dispatched_quantity
+  end
+end


### PR DESCRIPTION
This is a cherry pick from ongoing work : https://github.com/crossroads/api.goodcity/pull/926/files

Matt wants to have those columns on the database (uninitialised) in order for him to start writing queries for his Qlik reports.

Until the other PR is merged, those will remain un-used