### PR TITLE
added received_at in offer-company serializer

### DIFF
--- a/app/serializers/api/v1/offer_company_serializer.rb
+++ b/app/serializers/api/v1/offer_company_serializer.rb
@@ -2,7 +2,7 @@ module Api::V1
   class OfferCompanySerializer < ApplicationSerializer
     embed :ids, include: true
 
-    attributes :id, :company_id, :created_by_id
+    attributes :id, :company_id, :created_by_id, :received_at
 
     has_one  :created_by, serializer: UserSummarySerializer, root: :user
     has_one  :company, serializer: CompanySerializer

--- a/spec/serializers/api/v1/offer_company_serializer_spec.rb
+++ b/spec/serializers/api/v1/offer_company_serializer_spec.rb
@@ -12,6 +12,7 @@ context Api::V1::OfferCompanySerializer do
     expect(subject['offer']['id']).to eq(offer.id)
     expect(subject['offer']['company_id']).to eq(offer.company.id)
     expect(subject['offer']['created_by_id']).to eq(offer.created_by.id)
+    expect(subject['offer']['received_at']).to eq(offer.received_at)
   end
 
   it "should only have the user and companies associations" do


### PR DESCRIPTION
This PR is for sending `received_at` in `offer-company` serializer.

Issue: `offer-company` serializer was not sending `received_at` in response which resulted in UI bug.

Please review this PR.