### PR TITLE
GCW-3082 Printers data should not be loaded into donor app

### DIFF
--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -158,7 +158,10 @@ module Api
 
       def current_user_profile
         authorize!(:current_user_profile, User)
-        render json: current_user, serializer: Api::V1::UserProfileSerializer
+        # include printers, only if its not donor or browse app
+        render json: current_user,
+               serializer: Api::V1::UserProfileSerializer,
+               include_printers: !(is_donor_app? || is_browse_app?)
       end
 
       api :POST, "/v1/auth/register_device", "Register a mobile device to receive notifications"

--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -161,7 +161,7 @@ module Api
         # include printers, only if its not donor or browse app
         render json: current_user,
                serializer: Api::V1::UserProfileSerializer,
-               include_printers: !(is_donor_app? || is_browse_app?)
+               include_printers: !(donor_app? || is_browse_app?)
       end
 
       api :POST, "/v1/auth/register_device", "Register a mobile device to receive notifications"

--- a/app/controllers/concerns/app_matcher.rb
+++ b/app/controllers/concerns/app_matcher.rb
@@ -19,7 +19,7 @@ module AppMatcher
     app_name == STOCKIT_APP
   end
 
-  def is_donor_app?
+  def donor_app?
     app_name == DONOR_APP
   end
 

--- a/app/controllers/concerns/app_matcher.rb
+++ b/app/controllers/concerns/app_matcher.rb
@@ -18,7 +18,11 @@ module AppMatcher
   def is_stockit_request?
     app_name == STOCKIT_APP
   end
-  
+
+  def is_donor_app?
+    app_name == DONOR_APP
+  end
+
   # return sanitized app name from request header
   # return 'app', 'admin', 'stock', 'browse', 'stockit'
 

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -26,6 +26,10 @@ module Api::V1
         user_id = users.id), '{}'::int[])"
     end
 
+    def include_printer?
+      @options[:include_printers]
+    end
+
     def include_attribute?
       return !@options[:user_summary] unless @options[:user_summary].nil?
       (User.current_user.try(:staff?) || User.current_user.try(:id) == id)

--- a/spec/controllers/api/v1/authentication_controller_spec.rb
+++ b/spec/controllers/api/v1/authentication_controller_spec.rb
@@ -205,6 +205,53 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
       get :current_user_profile
       expect(response.status).to eq(200)
     end
+
+    context 'donor app' do
+      before do
+        set_donor_app_header
+      end
+
+      it 'printers node should not be present in the response' do
+        get :current_user_profile
+        expect(JSON.parse(response.body).keys).not_to include('printers')
+      end
+    end
+
+    context 'donor app with supervisor logged in' do
+      before do
+        generate_and_set_token(supervisor)
+        set_donor_app_header
+      end
+
+      it 'printers node should not be present in the response' do
+        get :current_user_profile
+        expect(JSON.parse(response.body).keys).not_to include('printers')
+      end
+    end
+
+    context 'admin app' do
+      before do
+        generate_and_set_token(supervisor)
+        set_admin_app_header
+      end
+
+      it 'printers node should be present in the response' do
+        get :current_user_profile
+        expect(JSON.parse(response.body).keys).to include('printers')
+      end
+    end
+
+    context 'stock app' do
+      before do
+        generate_and_set_token(supervisor)
+        set_stock_app_header
+      end
+
+      it 'printers node should be present in the response' do
+        get :current_user_profile
+        expect(JSON.parse(response.body).keys).to include("printers")
+      end
+    end
   end
 
   # High level smoke tests to ensure correct channels are returned

--- a/spec/serializers/api/v1/user_serializer_spec.rb
+++ b/spec/serializers/api/v1/user_serializer_spec.rb
@@ -58,6 +58,8 @@ describe Api::V1::OfferSerializer do
       expect(
         donor_json['user']['last_disconnected'].to_date
       ).to eql(donor.last_disconnected.to_date)
+      expect(
+        donor_json['user']['printers']).to eql(donor.printer)
     end
   end
 


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3082

NOTE: Specify ticket link

### What does this PR do?
Removes the printers data from getting loaded in browse and donor app.

FEATURE: Specify feature name

BUG: Specify bug 

NOTE: Give a description of what this PR does. If it fixes any bug, specify cause of an issue and approach/solution added to fix that issue.


### Impacted Areas

NOTE: List any impacted areas (e.g. Dashboard > My Active Offers > scheduled )


### Screenshots

NOTE: Attach screeenshots if PR contains any UI changes

### Mockup Link

Note: Specify mockup link

### Linked PR's:

NOTE: If these changes are related to some existing PR or fixes any issue from existing PR changes, specify PR links.

### Linked Slack conversation:

NOTE: IF there is any conversation happened for current changes in any of the slack channel, mention the slack message link.

### Any Open question(s) or challenge(s):
