### PR TITLE
Fixes: Box Pallet + Quantity

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -435,7 +435,7 @@ module Api
       #
       def apply_stockit_quantity_change(pkg, current:, previous:)
         OrdersPackage.where(package: pkg).where('quantity > 0').each { |ord_pkg| ord_pkg.update(quantity: current) }
-        Package::Operations.register_quantity_change(pkg, delta: current - previous, location: pkg.locations.first)
+        Package::Operations.register_quantity_change(pkg, quantity: current - previous, location: pkg.locations.first)
       end
 
       # @TODO: remove

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -435,7 +435,9 @@ module Api
       #
       def apply_stockit_quantity_change(pkg, current:, previous:)
         OrdersPackage.where(package: pkg).where('quantity > 0').each { |ord_pkg| ord_pkg.update(quantity: current) }
-        Package::Operations.register_quantity_change(pkg, quantity: current - previous, location: pkg.locations.first)
+        delta = current - previous
+        action = delta.positive? ? PackagesInventory::Actions::GAIN : PackagesInventory::Actions::LOSS
+        Package::Operations.register_quantity_change(pkg, quantity: delta.abs, action: action, location: pkg.locations.first)
       end
 
       # @TODO: remove

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -241,9 +241,9 @@ module Api
       param_group :operations
 
       def register_quantity_change
-        Package::Operations.perform_action(@package,
+        Package::Operations.register_quantity_change(@package,
           quantity: params[:quantity].to_i,
-          location_id: params[:from],
+          location: params[:from],
           action: params[:action_name],
           description: params[:description])
 

--- a/app/models/concerns/operations/stock_operations.rb
+++ b/app/models/concerns/operations/stock_operations.rb
@@ -108,10 +108,8 @@ module StockOperations
     # @param [String] action: the inventory action (optional)
     # @param [String] description: notes to detail the action
     #
-    def register_quantity_change(package, quantity:, location:, action: nil, description: nil)
+    def register_quantity_change(package, quantity:, location:, action:, description: nil)
       return package if quantity.zero?
-
-      action ||= quantity.positive? ? PackagesInventory::Actions::GAIN : PackagesInventory::Actions::LOSS
 
       params = {
         quantity: quantity,

--- a/app/models/concerns/operations/stock_operations.rb
+++ b/app/models/concerns/operations/stock_operations.rb
@@ -148,6 +148,7 @@ module StockOperations
         @user_id = user_id
       end
 
+      # @TODO Raise Goodcity errors instead of returning json
       def pack
         return error(I18n.t("box_pallet.errors.adding_box_to_box")) if adding_box_to_a_box?
         return error(I18n.t("box_pallet.errors.disable_addition")) unless addition_allowed?
@@ -171,7 +172,7 @@ module StockOperations
       end
 
       def pack_or_unpack(task)
-        return unless @quantity.positive?
+        raise Goodcity::InvalidQuantityError.new(@quantity) unless @quantity.positive?
         PackagesInventory.new(
           package: @package,
           source: @cause,

--- a/app/models/packages_inventory.rb
+++ b/app/models/packages_inventory.rb
@@ -112,21 +112,30 @@ class PackagesInventory < ActiveRecord::Base
   validate :validate_fields, on: [:create]
 
   def validate_action
-    return if ALLOWED_ACTIONS.include?(action)
-    errors.add(:errors, I18n.t('package_inventory.bad_action', action: action) )
+    # Catch invalid actions
+    errors.add(:errors, I18n.t('package_inventory.bad_action', action: action)) unless ALLOWED_ACTIONS.include?(action)
+
+    # Prevent GAIN of boxes and pallets
+    # We allow other incremental actions as they only follow up decremennts (e.g dispatch/undispatch)
+    errors.add(:errors, I18n.t('package_inventory.bad_action_for_type', type: package.storage_type.name, action: action)) if package.storage_type&.singleton? && action.eql?(Actions::GAIN)
+    errors.count.zero?
   end
 
   def validate_quantity
     return errors.add(:errors, I18n.t('package_inventory.quantities.zero_invalid')) if quantity.zero?
     if incremental?
+      outcome_qty = PackagesInventory::Computer.package_quantity(package) + quantity
+      maximum_qty = package.storage_type&.capped? ? package.storage_type.max_unit_quantity : Float::INFINITY
+
       errors.add(:errors, I18n.t('package_inventory.quantities.enforced_positive', action: action)) if quantity.negative?
+      errors.add(:errors, I18n.t('package_inventory.storage_type_max', type: package.storage_type.name, quantity: maximum_qty )) if outcome_qty > maximum_qty
     else
       errors.add(:errors, I18n.t('package_inventory.quantities.enforced_negative', action: action)) if quantity.positive?
     end
+    errors.count.zero?
   end
 
   def validate_fields
-    validate_action
-    validate_quantity
+    validate_action && validate_quantity
   end
 end

--- a/app/models/storage_type.rb
+++ b/app/models/storage_type.rb
@@ -1,6 +1,14 @@
 class StorageType < ActiveRecord::Base
   has_many :packages
 
+  def singleton?
+    capped? && max_unit_quantity.eql?(1)
+  end
+
+  def capped?
+    max_unit_quantity.present? && max_unit_quantity.positive?
+  end
+
   def self.storage_type_ids(name)
     package_storage_type_id = find_by(name: "Package").id
     if name == "Pallet"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,9 @@ en:
       bad_quantity_param: Invalid quantity (%{quantity})
       action_not_allowed: Action you are trying to perform is not allowed
   package_inventory:
+    storage_type_max: "A %{type} is limited to a quantity of %{quantity}"
     bad_action: "Inventory action %{action} is not permitted"
+    bad_action_for_type: "Inventory action %{action} is not permitted on %{type} types"
     invalid_dispatch_location: "'Dispatched' is not a valid inventory location"
     quantities:
       zero_invalid: Zero is not a valid change record

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -138,7 +138,9 @@ zh-tw:
       bad_quantity_param: Invalid quantity (%{quantity})
       action_not_allowed: Action you are trying to perform is not allowed
   package_inventory:
+    storage_type_max: "A %{type} is limited to a quantity of %{quantity}"
     bad_action: "Inventory action %{action} is not permitted"
+    bad_action_for_type: "Inventory action %{action} is not permitted on %{type} types"
     invalid_dispatch_location: "'Dispatched' is not a valid inventory location"
     quantities:
       zero_invalid: Zero is not a valid change record

--- a/db/migrate/20200312083123_add_max_unit_quantity_column_to_storage_type.rb
+++ b/db/migrate/20200312083123_add_max_unit_quantity_column_to_storage_type.rb
@@ -1,0 +1,5 @@
+class AddMaxUnitQuantityColumnToStorageType < ActiveRecord::Migration
+  def change
+    add_column :storage_types, :max_unit_quantity, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200305035646) do
+ActiveRecord::Schema.define(version: 20200312083123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -878,8 +878,9 @@ ActiveRecord::Schema.define(version: 20200305035646) do
 
   create_table "storage_types", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.integer  "max_unit_quantity"
   end
 
   create_table "subpackage_types", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -139,7 +139,7 @@ end
 
 storage_types = YAML.load_file("#{Rails.root}/db/storage_types.yml")
 storage_types.each do |storage_type|
-  StorageType.find_or_create_by(storage_type)
+  StorageType.where(name: storage_type["name"]).first_or_create(storage_type)
 end
 
 # Create PackageCategories

--- a/db/storage_types.yml
+++ b/db/storage_types.yml
@@ -1,7 +1,10 @@
 ---
 -
   name: "Box"
+  max_unit_quantity: 1
 -
   name: "Pallet"
+  max_unit_quantity: 1
 -
   name: "Package"
+  max_unit_quantity: null

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -496,6 +496,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
         it "creates package with box storage type" do
           expect(GoodcitySetting.find_by(key: "stock.enable_box_pallet_creation").value).to eq(setting.value)
           package_params[:storage_type] = "Box"
+          package_params[:received_quantity] = 1
           post :create, format: :json, package: package_params
           expect(response.status).to eq(201)
           package = Package.last
@@ -506,6 +507,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
 
       it "creates package with pallet storage type" do
         package_params[:storage_type] = "Pallet"
+        package_params[:received_quantity] = 1
         post :create, format: :json, package: package_params
         expect(response.status).to eq(201)
         package = Package.last

--- a/spec/factories/packages.rb
+++ b/spec/factories/packages.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     notes                 { FFaker::Lorem.paragraph }
     state                 'expecting'
 
-    received_quantity     5
+    received_quantity     { storage_type&.singleton? ? 1 : 5 }
     on_hand_quantity      { received_quantity }
     available_quantity    { received_quantity }
     designated_quantity   0

--- a/spec/factories/storage_types.rb
+++ b/spec/factories/storage_types.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :storage_type do
     name "Box"
+    max_unit_quantity { ["Box", "Pallet"].include?(name) ? 1 : nil }
   end
 
   trait :with_box do

--- a/spec/models/concerns/operations/stock_operations_spec.rb
+++ b/spec/models/concerns/operations/stock_operations_spec.rb
@@ -303,6 +303,22 @@ context StockOperations do
         expect(response[:packages_inventory].source).to eq(box)
       end
 
+      it "raises an exception if quantity is invalid" do
+        package = packages.sample
+        Package::Operations.inventorize(package, location)
+        Package::Operations.inventorize(box, location)
+        params = {
+          item_id: package.id,
+          location_id: location.id,
+          quantity: -1,
+          task: "pack",
+          id: box.id
+        }
+        expect { pack_or_unpack(params) }.to raise_error(Goodcity::InvalidQuantityError).with_message(
+          "Invalid quantity (-1)"
+        )
+      end
+
       it "raises an exception if action is not allowed" do
         package = packages.sample
         Package::Operations.inventorize(package, location)


### PR DESCRIPTION
Various fixes related to box/pallets and quantities:

#### Changes

##### Capped box/pallets

Boxes and pallets should never have a quantity greater than `1`
This PR adds a `max_unit_quantity` column to the storage type in order to limit that number.

The `"gain"` action is forbidden on Boxes and Pallets

##### Bug: packing boxes with a negative quantity (GCW-3083)

This raises a proper error when we try to add a negative amount of items to a box or pallet

##### Some cleanup

Both @swatijadhav and I had basically implemented the same functionality. So there was a duplicate feature there. I consolidated both into a single method (her implementation, my function name)


