### PR TITLE
Fix package splitter controller params

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -213,7 +213,6 @@ module Api
       end
 
       def split_package
-        qty_to_split = package_params[:quantity].to_i
         package_splitter = PackageSplitter.new(@package, qty_to_split)
         package_splitter.split!
         send_stock_item_response
@@ -335,6 +334,10 @@ module Api
         ]
 
         params.require(:package).permit(attributes)
+      end
+
+      def qty_to_split
+        (params["package"] && params["package"]["quantity"] || 0).to_i
       end
 
       # comp_test_status, frequency, test_status, voltage kept for stockit sync

--- a/lib/goodcity/package_setup.rb
+++ b/lib/goodcity/package_setup.rb
@@ -17,7 +17,7 @@ module Goodcity
         if valid?(quantities) && !rehearse
           package.update_columns(quantities)
           count += 1
-        elsif valid?(quantities)
+        elsif !valid?(quantities)
           errors.add_object({ package: package.id }.merge(quantities))
         end
       end


### PR DESCRIPTION
@abulsayyad123 Found an issue with the Split Quantity feature. 

I had removed a param from the controller, which was used by the split quantity.

The reason we didn't catch this issue was because the Splitter was unit tested, but not e2e tested. So I added that here