### PR TITLE
Quantity setup: clamp negative values

### DIFF
--- a/lib/goodcity/package_setup.rb
+++ b/lib/goodcity/package_setup.rb
@@ -9,13 +9,17 @@ module Goodcity
       quantities.values.map.select { |q| q < 0 }.empty?
     end
 
+    def clamped(quantities)
+      Hash[quantities.map{|k,v| [k, [0, v].max] } ]
+    end
+
     def compute_quantities(rehearse: false)
       errors = CsvWriter.new
       count = 0
       iterate do |package|
         quantities = PackagesInventory::Computer.package_quantity_summary(package)
-        if valid?(quantities) && !rehearse
-          package.update_columns(quantities)
+        if !rehearse
+          package.update_columns clamped(quantities)
           count += 1
         elsif !valid?(quantities)
           errors.add_object({ package: package.id }.merge(quantities))


### PR DESCRIPTION
As the data health fixes have been taking a while, this change will allow us to release quantities immediately.  And fix the bad data later on (probably once stockit is turned off)