### PR TITLE
Fix concurrent package quantity updates

### DIFF
--- a/app/models/concerns/inventory_computer.rb
+++ b/app/models/concerns/inventory_computer.rb
@@ -83,8 +83,10 @@ module InventoryComputer
       end
 
       def update_package_quantities!(package)
-        package.assign_attributes package_quantity_summary(package)
-        package.save!
+        package.secured_transaction do
+          package.assign_attributes package_quantity_summary(package)
+          package.save!
+        end
       end
     end
 

--- a/app/models/concerns/secured.rb
+++ b/app/models/concerns/secured.rb
@@ -16,4 +16,10 @@ module Secured
       end
     end
   end
+
+  def secured_transaction
+    with_advisory_lock("#{self.class.name}:#{self.id}") do
+      ActiveRecord::Base.transaction { yield }
+    end
+  end
 end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -9,6 +9,7 @@ class Package < ActiveRecord::Base
   include DesignationOperations
   include StockOperations
   include Watcher
+  include Secured
 
   BROWSE_ITEM_STATES = %w(accepted submitted)
   BROWSE_OFFER_EXCLUDE_STATE = %w(cancelled inactive closed draft)


### PR DESCRIPTION
As titled, add a lock to avoid concurrent updates on the fields