### PR TITLE
Unique inventory number

### DIFF
--- a/db/migrate/20200327024517_make_inventory_number_unique.rb
+++ b/db/migrate/20200327024517_make_inventory_number_unique.rb
@@ -1,0 +1,8 @@
+class MakeInventoryNumberUnique < ActiveRecord::Migration
+  def change
+    def change
+      remove_index :packages, :inventory_number
+      add_index :packages, :inventory_number, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200312083123) do
+ActiveRecord::Schema.define(version: 20200327024517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -485,9 +485,9 @@ ActiveRecord::Schema.define(version: 20200312083123) do
     t.text     "cancel_reason"
     t.integer  "booking_type_id"
     t.string   "staff_note",              default: ""
+    t.integer  "cancellation_reason_id"
     t.boolean  "continuous",              default: false
     t.date     "shipment_date"
-    t.integer  "cancellation_reason_id"
   end
 
   add_index "orders", ["address_id"], name: "index_orders_on_address_id", using: :btree


### PR DESCRIPTION
This is related to https://jira.crossroads.org.hk/browse/GCW-2018

The index on `inventory_number` currently doesn't have a unicity constraint. This adds it.

This won't be merged until data fixes are in.

