### PR TITLE
GCW-3145 removing filter for expiry_date

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -397,7 +397,7 @@ module Api
       end
 
       def medical_attributes
-        %i[brand country_id serial_number updated_by_id expiry_date]
+        %i[brand country_id serial_number updated_by_id]
       end
 
       def get_package_type_id_value


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3145

`expiry_date` was passed through the stockit sync job, and was causing this rollbar error.