### PR TITLE
Fix case where Stockit will not send a value for number_of_people_helped

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -44,7 +44,7 @@ class Order < ActiveRecord::Base
   has_many :process_checklists, through: :orders_process_checklists
   has_many :orders_process_checklists, inverse_of: :order
 
-  validates :people_helped, numericality: { greater_than_or_equal_to: 0 }
+  validates :people_helped, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
 
   after_initialize :set_initial_state
   before_create :assign_code


### PR DESCRIPTION
### What does this PR do?

This is a hot-fix for an issue where Stockit Shipments were not being updated because they were invalid. This happened because we added a constraint for `number_of_people_helped` to not be null, however this is not compatible with Stockit shipments and local orders.

Reverting change.
