### PR TITLE
GCW-3152 Return the orders_packages actions after a transition

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -68,7 +68,7 @@ module Api
       def transition
         event = params['transition'].to_sym
         @order.update_transition_and_reason(event, cancel_params) if @order.state_events.include?(event)
-        render json: @order, serializer: serializer
+        render json: serializer.new(@order, include_allowed_actions: true)
       end
 
       api :PUT, '/v1/orders/1', "Update an order"

--- a/app/controllers/api/v1/orders_packages_controller.rb
+++ b/app/controllers/api/v1/orders_packages_controller.rb
@@ -57,7 +57,7 @@ module Api
 
       def search
         @orders_packages = @orders_packages.get_records_associated_with_order_id(params["search_by_order_id"])
-        render json: @orders_packages, each_serializer: serializer
+        render json: ActiveModel::ArraySerializer.new(@orders_packages, each_serializer: serializer).as_json
       end
 
       def show


### PR DESCRIPTION
When doing an order transition, e.g closing an order, we don't receive the updated `allowed_actions` of orders_packages. Which is expected by the UI.
This PR simply adds that in the response