### PR TITLE
Gcw 3093 Validate inventory numbers

### DIFF
--- a/app/models/inventory_number.rb
+++ b/app/models/inventory_number.rb
@@ -7,30 +7,52 @@ class InventoryNumber < ActiveRecord::Base
     self.create!(code: next_code)
   end
 
+  # Generates the next available inventory_number
+  #   1. Generate the sequence of all numbers up to the maximum inventory_number currently issued
+  #   2. Removes inventory_numbers that already exist in Packages and InventoryNumbers tables
+  #   3. Sort and return the lowest.
   def self.next_code
-    number = missing_code > 0 ? missing_code : (max_code + 1)
+    number = first_missing_code || (max_code + 1)
     number.to_s.rjust(6, "0")
   end
 
-  def self.missing_code
-    sql_for_missing_code = sanitize_sql_array([
-      "SELECT s.i AS first_missing_code
-       FROM generate_series(1,?) s(i)
-       WHERE NOT EXISTS (
-         SELECT 1 FROM (
-           SELECT inventory_number FROM packages WHERE inventory_number ~ '^\d+$' 
-           UNION 
-           SELECT code as inventory_number from inventory_numbers ORDER BY inventory_number
-         ) as inventory_number
-       WHERE CAST(inventory_number AS INTEGER) = s.i)
-       ORDER BY first_missing_code
-       LIMIT 1", self.count])
+  # Find the first gap in the sequence of inventory_numbers 
+  #   in the Packages and InventoryNumbers tables and return the lowest
+  def self.first_missing_code
+    # Laws of numerical analysis dictate that if there is a gap in a sequence
+    #   the first one will always be contained within this upper bound of table sizes.
+    # This enables us to put an upper limit on the series generation
+    #   and avoid slower than necessary queries.
+    max_count = [self.count, Package.count].max 
+    reg = %r/^\d+$/ # ruby '\' quoting makes it hard to inject regex in SQL query strings
+    sql_for_missing_code = sanitize_sql_array([%{
+      SELECT s.i AS first_missing_code
+      FROM generate_series(1,:max) s(i)
+      WHERE NOT EXISTS (
+        SELECT 1 FROM (
+          SELECT inventory_number FROM packages WHERE inventory_number ~ :term
+          UNION 
+          SELECT code AS inventory_number FROM inventory_numbers
+        ) AS inventory_number
+      WHERE CAST(inventory_number AS INTEGER) = s.i)
+      ORDER BY first_missing_code
+      LIMIT 1
+      }, max: max_count, term: reg.source])
 
-    missing_number = ActiveRecord::Base.connection.exec_query(sql_for_missing_code).first || {}
-    (missing_number["first_missing_code"] || 0).to_i
+    missing_number = InventoryNumber.connection.exec_query(sql_for_missing_code).first || {}
+    missing_number["first_missing_code"] # may return nil
   end
 
   def self.max_code
-    InventoryNumber.maximum('code').to_i || 0
+    reg = %r/^\d+$/ # get around \ quoting issues
+    sql_for_max_code = sanitize_sql_array([%{
+      SELECT inventory_number FROM packages WHERE inventory_number ~ :term
+      UNION
+      SELECT code AS inventory_number FROM inventory_numbers
+      ORDER BY inventory_number DESC LIMIT 1
+    }, term: reg.source])
+    result = InventoryNumber.connection.exec_query(sql_for_max_code).first || {}
+    result["inventory_number"].to_i || 0
   end
+
 end

--- a/db/cancellation_reasons.yml
+++ b/db/cancellation_reasons.yml
@@ -1,16 +1,16 @@
 ---
 Donated elsewhere:
   :name_zh_tw: Donated elsewhere
-  :visible_to_admin: true
+  :visible_to_offer: true
 
 Transport too difficult:
   :name_zh_tw: Transport too difficult
-  :visible_to_admin: true
+  :visible_to_offer: true
 
 Unwanted:
   :name_zh_tw: Unwanted
-  :visible_to_admin: false
+  :visible_to_offer: false
 
 Donor cancelled:
   :name_zh_tw: Donor cancelled
-  :visible_to_admin: true
+  :visible_to_offer: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,11 +16,8 @@ rejection_reasons.each do |name_en, value|
 end
 
 cancellation_reasons = YAML.load_file("#{Rails.root}/db/cancellation_reasons.yml")
-cancellation_reasons.each do |name_en, value|
-  FactoryBot.create(:cancellation_reason,
-    name_en: name_en,
-    name_zh_tw: value[:name_zh_tw],
-    visible_to_admin: value[:visible_to_admin] )
+cancellation_reasons.each do |name_en, attrs|
+  CancellationReason.create!(name_en: name_en, **attrs)
 end
 
 booking_types = YAML.load_file("#{Rails.root}/db/booking_types.yml")
@@ -81,7 +78,8 @@ package_types.each do |code, value|
     name_zh_tw: value[:name_zh_tw],
     other_terms_en: value[:other_terms_en],
     other_terms_zh_tw: value[:other_terms_zh_tw],
-    allow_stock: true )
+    allow_stock: true,
+    default_value_hk_dollar: value[:default_value_hk_dollar] )
 end
 
 package_types.each do |code, value|

--- a/spec/models/cancellation_reason_spec.rb
+++ b/spec/models/cancellation_reason_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CancellationReason, type: :model do
   it { is_expected.to validate_presence_of(:name_en) }
 
   describe "scope: visible_to_offer" do
-    let!(:offer_cancellation_reason) { create :cancellation_reason, :visible_to_offer }
-    let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
+    let!(:offer_cancellation_reason) { create :cancellation_reason, visible_to_offer: true, visible_to_order: false }
+    let!(:order_cancellation_reason) { create :cancellation_reason, visible_to_offer: false, visible_to_order: true }
 
     it "return records having visible_to_offer as true" do
       visible_scope_ids = described_class.visible_to_offer.pluck(:id)
@@ -20,8 +20,8 @@ RSpec.describe CancellationReason, type: :model do
   end
 
   describe "scope: visible_to_order" do
-    let!(:offer_cancellation_reason) { create :cancellation_reason, :visible_to_offer }
-    let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
+    let!(:offer_cancellation_reason) { create :cancellation_reason, visible_to_offer: true, visible_to_order: false }
+    let!(:order_cancellation_reason) { create :cancellation_reason, visible_to_offer: false, visible_to_order: true }
 
     it "return records having visible_to_order as true" do
       visible_scope_ids = described_class.visible_to_order.pluck(:id)
@@ -31,8 +31,8 @@ RSpec.describe CancellationReason, type: :model do
   end
 
   describe "#cancellation_reasons_for" do
-    let!(:offer_cancellation_reason) { create :cancellation_reason, :visible_to_offer }
-    let!(:order_cancellation_reason) { create :cancellation_reason, :visible_to_order }
+    let!(:offer_cancellation_reason) { create :cancellation_reason, visible_to_offer: true, visible_to_order: false }
+    let!(:order_cancellation_reason) { create :cancellation_reason, visible_to_offer: false, visible_to_order: true }
 
     it "returns order reasons if 'order' type is passed" do
       reasons = described_class.cancellation_reasons_for("order")


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2979

### What does this PR do?

FEATURE: (by @bharat619)
Validate the inventory number is below a reasonable threshold. Avoid cases where people try to set '99999999999'

BUG: Fixed a bug whereby the wrong next inventory number was being issued

There were two defects causing the code to issue the wrong next available inventory number.

1. Using regex in Postgresql via ruby strings requires extra care due to string interpolation of ' and \
2. When writing multi-line SQL statements, it's best to use %{...} ruby syntax rather than opening " " so that everything is interpolated in a way that is compatible with PostgreSQL.

### Impacted Areas

Stock: Add new item screen (getting repeated errors saying "Inventory Number is already taken")
