### PR TITLE
Safe deletion of printers

### DIFF
--- a/app/models/printer.rb
+++ b/app/models/printer.rb
@@ -3,4 +3,14 @@ class Printer < ActiveRecord::Base
   belongs_to :location
 
   scope :active, -> { where(active: true) }
+
+  before_destroy :reset_user_printers
+
+  private
+
+  def reset_user_printers
+    fallback_printer_id = Printer.where.not(id: id).first&.id || nil
+    User.where(printer_id: id).update_all(printer_id: fallback_printer_id)
+  end
+
 end

--- a/db/migrate/20200522024354_add_printer_foreign_key_to_user.rb
+++ b/db/migrate/20200522024354_add_printer_foreign_key_to_user.rb
@@ -1,0 +1,5 @@
+class AddPrinterForeignKeyToUser < ActiveRecord::Migration
+  def change
+    add_foreign_key :users, :printers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,19 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200520074024) do
+ActiveRecord::Schema.define(version: 20200522024354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "btree_gin"
+  enable_extension "pg_trgm"
 
   create_table "addresses", force: :cascade do |t|
-    t.string   "flat",             limit: 255
-    t.string   "building",         limit: 255
-    t.string   "street",           limit: 255
+    t.string   "flat"
+    t.string   "building"
+    t.string   "street"
     t.integer  "district_id"
     t.integer  "addressable_id"
-    t.string   "addressable_type", limit: 255
-    t.string   "address_type",     limit: 255
+    t.string   "addressable_type"
+    t.string   "address_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -47,7 +49,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.datetime "otp_code_expiry"
-    t.string   "otp_secret_key",  limit: 255
+    t.string   "otp_secret_key"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -79,7 +81,6 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.string   "identifier"
   end
 
-  add_index "booking_types", ["identifier"], name: "index_booking_types_on_identifier", using: :btree
   add_index "booking_types", ["name_en", "name_zh_tw"], name: "index_booking_types_on_name_en_and_name_zh_tw", unique: true, using: :btree
 
   create_table "boxes", force: :cascade do |t|
@@ -156,8 +157,8 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   end
 
   create_table "contacts", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.string   "mobile",     limit: 255
+    t.string   "name"
+    t.string   "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -172,20 +173,20 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   end
 
   create_table "crossroads_transports", force: :cascade do |t|
-    t.string   "name_en",        limit: 255
-    t.string   "name_zh_tw",     limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "cost"
     t.float    "truck_size"
-    t.boolean  "is_van_allowed",             default: true
+    t.boolean  "is_van_allowed", default: true
   end
 
   create_table "deliveries", force: :cascade do |t|
     t.integer  "offer_id"
     t.integer  "contact_id"
     t.integer  "schedule_id"
-    t.string   "delivery_type",    limit: 255
+    t.string   "delivery_type"
     t.datetime "start"
     t.datetime "finish"
     t.datetime "created_at"
@@ -200,8 +201,8 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "deliveries", ["schedule_id"], name: "index_deliveries_on_schedule_id", using: :btree
 
   create_table "districts", force: :cascade do |t|
-    t.string   "name_en",      limit: 255
-    t.string   "name_zh_tw",   limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.integer  "territory_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -212,11 +213,11 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "districts", ["territory_id"], name: "index_districts_on_territory_id", using: :btree
 
   create_table "donor_conditions", force: :cascade do |t|
-    t.string   "name_en",          limit: 255
-    t.string   "name_zh_tw",       limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "visible_to_donor",             default: true, null: false
+    t.boolean  "visible_to_donor", default: true, null: false
   end
 
   create_table "electricals", force: :cascade do |t|
@@ -239,7 +240,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
 
   create_table "gogovan_orders", force: :cascade do |t|
     t.integer  "booking_id"
-    t.string   "status",         limit: 255
+    t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -254,11 +255,11 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "gogovan_orders", ["ggv_uuid"], name: "index_gogovan_orders_on_ggv_uuid", unique: true, using: :btree
 
   create_table "gogovan_transports", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "disabled",               default: false
+    t.boolean  "disabled",   default: false
   end
 
   create_table "goodcity_requests", force: :cascade do |t|
@@ -286,7 +287,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   create_table "holidays", force: :cascade do |t|
     t.datetime "holiday"
     t.integer  "year"
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -300,13 +301,13 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   end
 
   create_table "images", force: :cascade do |t|
-    t.string   "cloudinary_id",  limit: 255
-    t.boolean  "favourite",                  default: false
+    t.string   "cloudinary_id"
+    t.boolean  "favourite",      default: false
     t.integer  "item_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.integer  "angle",                      default: 0
+    t.integer  "angle",          default: 0
     t.integer  "imageable_id"
     t.string   "imageable_type"
   end
@@ -319,11 +320,11 @@ ActiveRecord::Schema.define(version: 20200520074024) do
 
   create_table "items", force: :cascade do |t|
     t.text     "donor_description"
-    t.string   "state",               limit: 255
-    t.integer  "offer_id",                        null: false
+    t.string   "state"
+    t.integer  "offer_id",            null: false
     t.integer  "package_type_id"
     t.integer  "rejection_reason_id"
-    t.string   "reject_reason",       limit: 255
+    t.string   "reject_reason"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "donor_condition_id"
@@ -344,6 +345,8 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.datetime "updated_at", null: false
   end
 
+  add_index "locations", ["area"], name: "index_locations_on_area", using: :gin
+  add_index "locations", ["building"], name: "index_locations_on_building", using: :gin
   add_index "locations", ["stockit_id"], name: "index_locations_on_stockit_id", using: :btree
 
   create_table "lookups", force: :cascade do |t|
@@ -382,18 +385,19 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer  "order_id"
   end
 
+  add_index "messages", ["body"], name: "messages_body_search_idx", using: :gin
   add_index "messages", ["item_id"], name: "index_messages_on_item_id", using: :btree
   add_index "messages", ["offer_id"], name: "index_messages_on_offer_id", using: :btree
   add_index "messages", ["order_id"], name: "index_messages_on_order_id", using: :btree
   add_index "messages", ["sender_id"], name: "index_messages_on_sender_id", using: :btree
 
   create_table "offers", force: :cascade do |t|
-    t.string   "language",                limit: 255
-    t.string   "state",                   limit: 255
-    t.string   "origin",                  limit: 255
+    t.string   "language"
+    t.string   "state"
+    t.string   "origin"
     t.boolean  "stairs"
     t.boolean  "parking"
-    t.string   "estimated_size",          limit: 255
+    t.string   "estimated_size"
     t.text     "notes"
     t.integer  "created_by_id"
     t.datetime "created_at"
@@ -414,7 +418,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer  "cancellation_reason_id"
     t.string   "cancel_reason"
     t.datetime "inactive_at"
-    t.boolean  "saleable",                            default: false
+    t.boolean  "saleable",                           default: false
     t.integer  "company_id"
   end
 
@@ -424,6 +428,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "offers", ["created_by_id"], name: "index_offers_on_created_by_id", using: :btree
   add_index "offers", ["crossroads_transport_id"], name: "index_offers_on_crossroads_transport_id", using: :btree
   add_index "offers", ["gogovan_transport_id"], name: "index_offers_on_gogovan_transport_id", using: :btree
+  add_index "offers", ["notes"], name: "offers_notes_search_idx", using: :gin
   add_index "offers", ["received_by_id"], name: "index_offers_on_received_by_id", using: :btree
   add_index "offers", ["reviewed_by_id"], name: "index_offers_on_reviewed_by_id", using: :btree
   add_index "offers", ["state"], name: "index_offers_on_state", using: :btree
@@ -501,6 +506,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "orders", ["beneficiary_id"], name: "index_orders_on_beneficiary_id", using: :btree
   add_index "orders", ["cancelled_by_id"], name: "index_orders_on_cancelled_by_id", using: :btree
   add_index "orders", ["closed_by_id"], name: "index_orders_on_closed_by_id", using: :btree
+  add_index "orders", ["code"], name: "orders_code_idx", using: :gin
   add_index "orders", ["country_id"], name: "index_orders_on_country_id", using: :btree
   add_index "orders", ["created_by_id"], name: "index_orders_on_created_by_id", using: :btree
   add_index "orders", ["detail_id", "detail_type"], name: "index_orders_on_detail_id_and_detail_type", using: :btree
@@ -633,8 +639,8 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer  "stockit_id"
     t.integer  "location_id"
     t.boolean  "allow_requests",          default: true
-    t.boolean  "allow_pieces",            default: false
     t.boolean  "allow_stock",             default: false
+    t.boolean  "allow_pieces",            default: false
     t.string   "subform"
     t.boolean  "allow_box",               default: false
     t.boolean  "allow_pallet",            default: false
@@ -644,6 +650,8 @@ ActiveRecord::Schema.define(version: 20200520074024) do
 
   add_index "package_types", ["allow_requests"], name: "index_package_types_on_allow_requests", using: :btree
   add_index "package_types", ["location_id"], name: "index_package_types_on_location_id", using: :btree
+  add_index "package_types", ["name_en"], name: "package_types_name_en_search_idx", using: :gin
+  add_index "package_types", ["name_zh_tw"], name: "package_types_name_zh_tw_search_idx", using: :gin
   add_index "package_types", ["stockit_id"], name: "index_package_types_on_stockit_id", using: :btree
   add_index "package_types", ["visible_in_selects"], name: "index_package_types_on_visible_in_selects", using: :btree
 
@@ -653,14 +661,14 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer  "height"
     t.text     "notes"
     t.integer  "item_id"
-    t.string   "state",                    limit: 255
+    t.string   "state"
     t.datetime "received_at"
     t.datetime "rejected_at"
     t.integer  "package_type_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.integer  "offer_id",                             default: 0
+    t.integer  "offer_id",                 default: 0
     t.string   "inventory_number"
     t.integer  "location_id"
     t.string   "designation_name"
@@ -677,7 +685,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer  "favourite_image_id"
     t.date     "stockit_moved_on"
     t.integer  "stockit_moved_by_id"
-    t.boolean  "saleable",                             default: false
+    t.boolean  "saleable",                 default: false
     t.string   "case_number"
     t.boolean  "allow_web_publish"
     t.integer  "received_quantity"
@@ -686,10 +694,10 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer  "detail_id"
     t.string   "detail_type"
     t.integer  "storage_type_id"
-    t.integer  "available_quantity",                   default: 0
-    t.integer  "on_hand_quantity",                     default: 0
-    t.integer  "designated_quantity",                  default: 0
-    t.integer  "dispatched_quantity",                  default: 0
+    t.integer  "available_quantity",       default: 0
+    t.integer  "on_hand_quantity",         default: 0
+    t.integer  "designated_quantity",      default: 0
+    t.integer  "dispatched_quantity",      default: 0
     t.date     "expiry_date"
     t.decimal  "value_hk_dollar"
     t.integer  "package_set_id"
@@ -698,13 +706,17 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "packages", ["allow_web_publish"], name: "index_packages_on_allow_web_publish", using: :btree
   add_index "packages", ["available_quantity"], name: "index_packages_on_available_quantity", using: :btree
   add_index "packages", ["box_id"], name: "index_packages_on_box_id", using: :btree
+  add_index "packages", ["case_number"], name: "index_packages_on_case_number", using: :gin
   add_index "packages", ["designated_quantity"], name: "index_packages_on_designated_quantity", using: :btree
+  add_index "packages", ["designation_name"], name: "index_packages_on_designation_name", using: :gin
   add_index "packages", ["detail_type", "detail_id"], name: "index_packages_on_detail_type_and_detail_id", using: :btree
   add_index "packages", ["dispatched_quantity"], name: "index_packages_on_dispatched_quantity", using: :btree
   add_index "packages", ["donor_condition_id"], name: "index_packages_on_donor_condition_id", using: :btree
   add_index "packages", ["inventory_number"], name: "index_packages_on_inventory_number", using: :btree
+  add_index "packages", ["inventory_number"], name: "inventory_numbers_search_idx", using: :gin
   add_index "packages", ["item_id"], name: "index_packages_on_item_id", using: :btree
   add_index "packages", ["location_id"], name: "index_packages_on_location_id", using: :btree
+  add_index "packages", ["notes"], name: "index_packages_on_notes", using: :gin
   add_index "packages", ["offer_id"], name: "index_packages_on_offer_id", using: :btree
   add_index "packages", ["on_hand_quantity"], name: "index_packages_on_on_hand_quantity", using: :btree
   add_index "packages", ["order_id"], name: "index_packages_on_order_id", using: :btree
@@ -768,7 +780,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   end
 
   create_table "permissions", force: :cascade do |t|
-    t.string   "name",       limit: 255
+    t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -802,10 +814,10 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   end
 
   create_table "rejection_reasons", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
+    t.string   "name_en"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_zh_tw"
   end
 
   create_table "requested_packages", force: :cascade do |t|
@@ -837,10 +849,10 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   end
 
   create_table "schedules", force: :cascade do |t|
-    t.string   "resource",     limit: 255
+    t.string   "resource"
     t.integer  "slot"
-    t.string   "slot_name",    limit: 255
-    t.string   "zone",         limit: 255
+    t.string   "slot_name"
+    t.string   "zone"
     t.datetime "scheduled_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -863,6 +875,11 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.datetime "updated_at",          null: false
   end
 
+  add_index "stockit_contacts", ["first_name"], name: "st_contacts_first_name_idx", using: :gin
+  add_index "stockit_contacts", ["last_name"], name: "st_contacts_last_name_idx", using: :gin
+  add_index "stockit_contacts", ["mobile_phone_number"], name: "st_contacts_mobile_phone_number_idx", using: :gin
+  add_index "stockit_contacts", ["phone_number"], name: "st_contacts_phone_number_idx", using: :gin
+
   create_table "stockit_local_orders", force: :cascade do |t|
     t.string   "client_name"
     t.string   "hkid_number"
@@ -873,12 +890,16 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.text     "purpose_of_goods"
   end
 
+  add_index "stockit_local_orders", ["client_name"], name: "st_local_orders_client_name_idx", using: :gin
+
   create_table "stockit_organisations", force: :cascade do |t|
     t.string   "name"
     t.integer  "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "stockit_organisations", ["name"], name: "st_organisations_name_idx", using: :gin
 
   create_table "storage_types", force: :cascade do |t|
     t.string   "name"
@@ -903,7 +924,7 @@ ActiveRecord::Schema.define(version: 20200520074024) do
     t.integer "offer_id"
     t.integer "user_id"
     t.integer "message_id"
-    t.string  "state",      limit: 255
+    t.string  "state"
     t.integer "order_id"
   end
 
@@ -915,15 +936,15 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
 
   create_table "territories", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "timeslots", force: :cascade do |t|
-    t.string   "name_en",    limit: 255
-    t.string   "name_zh_tw", limit: 255
+    t.string   "name_en"
+    t.string   "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -939,21 +960,21 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_index "user_roles", ["user_id"], name: "index_user_roles_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name",           limit: 255
-    t.string   "last_name",            limit: 255
-    t.string   "mobile",               limit: 255
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "image_id"
     t.datetime "last_connected"
     t.datetime "last_disconnected"
-    t.boolean  "disabled",                         default: false
+    t.boolean  "disabled",             default: false
     t.string   "email"
     t.string   "title"
     t.datetime "sms_reminder_sent_at"
-    t.boolean  "is_mobile_verified",               default: false
-    t.boolean  "is_email_verified",                default: false
-    t.boolean  "receive_email",                    default: false
+    t.boolean  "is_mobile_verified",   default: false
+    t.boolean  "is_email_verified",    default: false
+    t.boolean  "receive_email",        default: false
     t.string   "other_phone"
     t.integer  "printer_id"
   end
@@ -1009,5 +1030,6 @@ ActiveRecord::Schema.define(version: 20200520074024) do
   add_foreign_key "packages_inventories", "users"
   add_foreign_key "process_checklists", "booking_types"
   add_foreign_key "subscriptions", "orders"
+  add_foreign_key "users", "printers"
   add_foreign_key "valuation_matrices", "donor_conditions"
 end

--- a/spec/models/printer_spec.rb
+++ b/spec/models/printer_spec.rb
@@ -26,5 +26,21 @@ RSpec.describe Printer, type: :model do
       expect(active_printers).to_not include(inactive_printer)
     end
   end
+
+  describe "Lifecycle" do
+    describe "on destroy" do
+      let!(:printer) { create(:printer) }
+      let!(:other_printer) { create(:printer) }
+      let!(:user) { create(:user, printer: printer) }
+
+      it "updates user's printers to another valid printer" do
+        expect {
+          printer.destroy
+        }.to change { user.reload.printer_id }
+          .from(printer.id)
+          .to(other_printer.id)
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
Deleting a printer would previously leave users with an invalid printer_id.

This PR adds a foreign key constraint, and resets the user printers when the printer is deleted