### PR TITLE
FIX: postgres_serializer fix for polymorphism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 gem 'active_model_otp', '~> 1.1.0'
 gem 'active_model_serializers', '~> 0.8.0'
 gem 'postgres_ext', '~> 2.4.0.beta.1'
-gem 'postgres_ext-serializers', git: 'https://github.com/crossroads/postgres_ext-serializers.git', ref: 'ccfc47bdeba657c079049ba5bea4304d789176cd'
+gem 'postgres_ext-serializers', git: 'https://github.com/crossroads/postgres_ext-serializers.git', ref: '530a6f7426bff9bd69b3f2773cced146ba89e65c'
 # Gem does not released for this issue-fix. Once released remove git reference.
 # "Hard-destroy of Parent record should destroy child records"
 gem 'paranoia', '~> 2.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 gem 'active_model_otp', '~> 1.1.0'
 gem 'active_model_serializers', '~> 0.8.0'
 gem 'postgres_ext', '~> 2.4.0.beta.1'
-gem 'postgres_ext-serializers', git: 'https://github.com/DockYard/postgres_ext-serializers.git', ref: '0c2d483806becd1ef7f8c9336286158cfdda1cc3'
+gem 'postgres_ext-serializers', git: 'https://github.com/crossroads/postgres_ext-serializers.git', ref: 'ccfc47bdeba657c079049ba5bea4304d789176cd'
 # Gem does not released for this issue-fix. Once released remove git reference.
 # "Hard-destroy of Parent record should destroy child records"
 gem 'paranoia', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: https://github.com/crossroads/postgres_ext-serializers.git
-  revision: ccfc47bdeba657c079049ba5bea4304d789176cd
-  ref: ccfc47bdeba657c079049ba5bea4304d789176cd
+  revision: 530a6f7426bff9bd69b3f2773cced146ba89e65c
+  ref: 530a6f7426bff9bd69b3f2773cced146ba89e65c
   specs:
     postgres_ext-serializers (0.0.3)
       active_model_serializers (~> 0.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,21 +15,21 @@ GIT
       json
 
 GIT
-  remote: https://github.com/DockYard/postgres_ext-serializers.git
-  revision: 0c2d483806becd1ef7f8c9336286158cfdda1cc3
-  ref: 0c2d483806becd1ef7f8c9336286158cfdda1cc3
-  specs:
-    postgres_ext-serializers (0.0.3)
-      active_model_serializers (~> 0.8.0)
-      postgres_ext (>= 2.1, < 4)
-
-GIT
   remote: https://github.com/crossroads/easyzpl.git
   revision: e8a7e680950335a0818ac91342dba3d76858c512
   specs:
     easyzpl (0.5.2)
       barby (>= 0.6.1)
       prawn (>= 1.0.0)
+
+GIT
+  remote: https://github.com/crossroads/postgres_ext-serializers.git
+  revision: ccfc47bdeba657c079049ba5bea4304d789176cd
+  ref: ccfc47bdeba657c079049ba5bea4304d789176cd
+  specs:
+    postgres_ext-serializers (0.0.3)
+      active_model_serializers (~> 0.8.0)
+      postgres_ext (>= 2.1, < 4)
 
 GIT
   remote: https://github.com/maccman/nestful.git

--- a/app/serializers/api/v1/item_serializer.rb
+++ b/app/serializers/api/v1/item_serializer.rb
@@ -7,7 +7,7 @@ module Api::V1
       :rejection_comments, :donor_condition_id, :rejection_reason_id
 
     has_many :packages, serializer: PackageSerializer
-    has_many :images,   serializer: ImageSerializer
+    has_many :images,   serializer: ImageSerializer, polymorphic: true
     has_one  :package_type, serializer: PackageTypeSerializer
     has_one  :rejection_reason, serializer: RejectionReasonSerializer
     has_one  :donor_condition, serializer: DonorConditionSerializer

--- a/app/serializers/api/v1/package_serializer.rb
+++ b/app/serializers/api/v1/package_serializer.rb
@@ -3,7 +3,7 @@ module Api::V1
     embed :ids, include: true
 
     has_one :package_type, serializer: PackageTypeSerializer
-    has_many :images, serializer: ImageSerializer
+    has_many :images, serializer: ImageSerializer, polymorphic: true
     has_one :item, serializer: BrowseItemSerializer
     has_many :packages_locations, serializer: PackagesLocationSerializer
     has_many :orders_packages, serializer: OrdersPackageSerializer

--- a/app/serializers/api/v1/stockit_item_serializer.rb
+++ b/app/serializers/api/v1/stockit_item_serializer.rb
@@ -6,7 +6,7 @@ module Api::V1
     has_many :packages_locations, serializer: PackagesLocationSerializer
     has_one :donor_condition, serializer: DonorConditionSerializer
     has_one :order, serializer: Api::V1::OrderShallowSerializer, root: :designation, include_items: false
-    has_many :images, serializer: StockitImageSerializer
+    has_many :images, serializer: StockitImageSerializer, polymorphic: true
     has_many :orders_packages, serializer: OrdersPackageSerializer
     has_many :offers_packages, serializer: OffersPackageSerializer
     has_many :package_actions, serializer: PackageActionsSerializer, root: :item_actions

--- a/spec/controllers/api/v1/items_controller_spec.rb
+++ b/spec/controllers/api/v1/items_controller_spec.rb
@@ -2,14 +2,46 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ItemsController, type: :controller do
 
-  let(:user)  { create :user_with_token }
+  let(:user)  { create :user_with_token, :with_can_manage_items_permission }
   let(:offer) { create :offer, created_by: user }
   let(:item)  { create(:item, offer: offer) }
   let(:serialized_item) { Api::V1::ItemSerializer.new(item).as_json }
   let(:serialized_item_json) { JSON.parse( serialized_item.to_json ) }
   let(:item_params) { item.attributes.except("id") }
+  let(:parsed_body) { JSON.parse(response.body) }
 
   subject { JSON.parse(response.body) }
+
+  describe "GET item/1" do
+    before { generate_and_set_token(user) }
+  
+    it "returns the item" do
+      get :show, id: item.id
+      expect(response.status).to eq(200)
+      expect(parsed_body['item']['id']).to eq(item.id)
+    end
+
+    describe "known bugs" do
+      describe "polymorphic serialization" do
+        let(:package)  { create :package, id: item.id }
+
+        before do
+          create(:image, imageable: item)
+          create(:image, imageable: package)
+        end
+
+        it { expect(package.id).to eq(item.id) }
+        it { expect(package.reload.images.count).to eq(1) }
+        it { expect(item.reload.images.count).to eq(1) }
+
+        it "returns only the images of the item" do
+          get :show, id: item.id
+          expect(response.status).to eq(200)
+          expect(parsed_body['item']['image_ids']).to eq([item.images.first.id])
+        end
+      end
+    end
+  end
 
   describe "DELETE item/1" do
     before { generate_and_set_token(user) }


### PR DESCRIPTION
We found a whole in postgres_ext_serializers which would ignore the type of a polymorphic relationship.

We've fixed it on our own fork here: https://github.com/crossroads/postgres_ext-serializers

This updates the Gemfile to point to the fixed version