### PR TITLE
Fix package_set initialization

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -225,6 +225,7 @@ module Api
                                                     include_order: false,
                                                     include_packages: false,
                                                     include_orders_packages: true,
+                                                    include_package_set: bool_param(:include_package_set, true),
                                                     include_images: true).as_json
         render json: { meta: { total_pages: records.total_pages, search: params["searchText"] } }.merge(packages)
       end

--- a/app/models/package_set.rb
+++ b/app/models/package_set.rb
@@ -19,7 +19,48 @@ class PackageSet < ActiveRecord::Base
     package_set.destroy! if package_set.present? && package_set.packages.length < 2
   end
 
+
+  # ---------------------
+  # Auto-create
+  # ---------------------
+
+  ##
+  #
+  # Upon creation of a package, it is added to a set IF:
+  #   * It belongs to an item
+  #   * It has sibling packages (via the item)
+  #   * It does not currently belong to a set
+  #
+  watch [Package], on: [:create] do |package|
+    item = package.item
+    siblings = [package, *item&.packages].uniq
+
+    next if item.blank? || package.package_set_id.present? || siblings.length < 2 || item.package_type.blank?
+
+    link_packages(siblings, item.package_type)
+  end
+
+  ##
+  # When an item has it's type set for the first time, we initialize the set for its packages
+  #
+  watch [Item], on: [:update] do |item|
+    next unless item.package_type_id_changed? && item.package_type_id_was.blank?
+
+    children = Package.where(item: item)
+
+    link_packages(children, item.package_type) if children.length > 1
+  end
+
   private
+
+  def self.link_packages(packages, package_type)
+    package_set = packages.find { |p| p.package_set_id.present? }&.package_set
+    package_set ||= PackageSet.create(description: package_type.name_en, package_type_id: package_type.id)
+
+    packages.select { |p| p.package_set_id.blank? }.each do |package|
+      package.update(package_set_id: package_set.id)
+    end
+  end
 
   def unlink_packages
     Package.where(package_set_id: id).update_all(package_set_id: nil)

--- a/lib/tasks/package_sets.rake
+++ b/lib/tasks/package_sets.rake
@@ -22,7 +22,7 @@ namespace :goodcity do
     item_ids.each do |id|
       item      = Item.find_by(id: id)
 
-      return unless item.present?
+      next unless item.present?
 
       packages  = item.packages
 

--- a/spec/models/package_set_spec.rb
+++ b/spec/models/package_set_spec.rb
@@ -65,4 +65,57 @@ RSpec.describe PackageSet, type: :model do
       end
     end
   end
+
+  describe "Package Set initialization" do
+    let(:package_set) { create(:package_set) }
+    let(:package) { create(:package) }
+    let(:item) { create(:item) }
+    let(:sibling_1) { create(:package, item: item) }
+    let(:sibling_2) { create(:package, item: item) }
+    let(:sibling_3) { create(:package, item: item) }
+    let(:sibling_4) { create(:package, item: item, package_set: package_set) }
+
+    describe "when the type of an item is set" do
+      let(:item) { create(:item, package_type_id: nil) }
+
+      before { touch(item, sibling_1, sibling_2, sibling_3) }
+
+      it "adds the item's packages to a set of the same type" do
+        expect {
+          item.update(package_type: package_type)
+        }.to change(PackageSet, :count).from(0).to(1)
+      end
+    end
+
+    describe "on creation of packages" do    
+      before { touch(package_set) }
+  
+      it 'is not assigned a package set if it doesnt have sibling packages' do
+        expect { touch(package) }.not_to change(PackageSet, :count)
+        expect(package.package_set_id).to be_nil
+      end
+  
+      it 'is assigned a package set if it has sibling packages' do
+        expect { touch(sibling_1) }.not_to change(PackageSet, :count)
+        expect { touch(sibling_2) }.to change(PackageSet, :count).by(1)
+  
+        expect(sibling_1.reload.package_set_id).to eq(sibling_2.reload.package_set_id)
+  
+        expect { touch(sibling_3) }.not_to change(PackageSet, :count)
+        expect(sibling_3.reload.package_set_id).to eq(sibling_2.reload.package_set_id)
+      end
+  
+      it 'is assigned a package set with a description equal to the package type' do
+        touch(sibling_1, sibling_2)
+        expect(sibling_1.reload.package_set.description).to eq(item.package_type.name_en)
+      end
+  
+      it 'it can be created with an explicit set which is different from the siblings' do
+        expect([sibling_1, sibling_2, sibling_3].map(&:reload).map(&:package_set_id).uniq.length).to eq(1)
+  
+        expect { touch(sibling_4) }.not_to change(PackageSet, :count)
+        expect(sibling_4.reload.package_set_id).not_to eq(sibling_1.reload.package_set_id)
+      end
+    end
+  end
 end

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -87,45 +87,6 @@ RSpec.describe Package, type: :model do
     end
   end
 
-  describe "Package Set initialization on create" do
-    let(:package_set) { create(:package_set) }
-    let(:package) { create(:package) }
-    let(:item) { create(:item) }
-    let(:sibling_1) { create(:package, item: item) }
-    let(:sibling_2) { create(:package, item: item) }
-    let(:sibling_3) { create(:package, item: item) }
-    let(:sibling_4) { create(:package, item: item, package_set: package_set) }
-
-    before { touch(package_set) }
-
-    it 'is not assigned a package set if it doesnt have sibling packages' do
-      expect { touch(package) }.not_to change(PackageSet, :count)
-      expect(package.package_set_id).to be_nil
-    end
-
-    it 'is assigned a package set if it has sibling packages' do
-      expect { touch(sibling_1) }.not_to change(PackageSet, :count)
-      expect { touch(sibling_2) }.to change(PackageSet, :count).by(1)
-
-      expect(sibling_1.reload.package_set_id).to eq(sibling_2.reload.package_set_id)
-
-      expect { touch(sibling_3) }.not_to change(PackageSet, :count)
-      expect(sibling_3.reload.package_set_id).to eq(sibling_2.reload.package_set_id)
-    end
-
-    it 'is assigned a package set with a description equal to the package type' do
-      touch(sibling_1, sibling_2)
-      expect(sibling_1.reload.package_set.description).to eq(item.package_type.name_en)
-    end
-
-    it 'it can be created with an explicit set which is different from the siblings' do
-      expect([sibling_1, sibling_2, sibling_3].map(&:reload).map(&:package_set_id).uniq.length).to eq(1)
-
-      expect { touch(sibling_4) }.not_to change(PackageSet, :count)
-      expect(sibling_4.reload.package_set_id).not_to eq(sibling_1.reload.package_set_id)
-    end
-  end
-
   describe "state" do
     describe "#mark_received" do
       it "should set received_at value" do


### PR DESCRIPTION
Issue: Admin creates packages for an item _before_ ever setting the `package_type` of that item. Therefore the api doesn't know how to initialize the set because it doesn't have a type.

This fixes that issue by initializing the set when the type is defined.