### PR TITLE
GCW-3166- restrict draft order in recent_orders

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -401,7 +401,7 @@ class Order < ActiveRecord::Base
           left join goodcity_requests on goodcity_requests.order_id = orders.id
           join versions on versions.item_type in ('Order', 'GoodcityRequest') AND (versions.item_id = orders.id OR versions.item_id = goodcity_requests.id)
           LEFT join orders_packages on orders_packages.order_id = orders.id AND orders_packages.updated_by_id = ?
-          where orders.detail_type='GoodCity' AND versions.whodunnit = ? AND (orders.state not in ('cancelled', 'closed', 'draft') OR orders.state not in ('closed', 'cancelled'))
+          where orders.detail_type='GoodCity' AND versions.whodunnit = ? AND (orders.state not in ('cancelled', 'closed', 'draft'))
           order by GREATEST(orders_packages.updated_at, versions.created_at) DESC", user_id, user_id.to_s]
     ).uniq.first(5)
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -248,6 +248,9 @@ RSpec.describe Order, type: :model do
     let!(:order2) { create :order, :with_orders_packages, :with_state_submitted, created_by_id: user.id, submitted_by_id: user.id, status: nil, updated_at: Time.now + 1.hour }
     let!(:version2) {order2.versions.first.update(whodunnit: order2.created_by_id)}
 
+    let!(:order3) { create :order, :with_orders_packages, :with_state_draft, created_by_id: user.id, submitted_by_id: user.id, status: nil, updated_at: Time.now }
+    let!(:version3) {order3.versions.first.update(whodunnit: order3.created_by_id)}
+
     before(:each) {
       User.current_user = user
     }
@@ -261,6 +264,10 @@ RSpec.describe Order, type: :model do
 
     it "will show top 5 updated orders" do
       expect(Order.recently_used(User.current_user.id).count).to eq(2)
+    end
+
+    it "should not show draft order in recent 5 updated orders" do
+      expect(Order.recently_used(User.current_user.id).map(&:state)).to_not include('draft')
     end
 
     it "will not show updated position of order if other user has updated the record" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3166

### What does this PR do?

This PR restricts `draft` order in recently_used orders along with specs.