### PR TITLE
Allow gaining lost boxes, and prevent actions on dispatched boxes

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,6 +3,7 @@ module Api
     class ApiController < ApplicationController
       skip_before_action :validate_token, only: [:error]
 
+      rescue_from ActiveRecord::RecordInvalid, with: :invalid_params
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
       rescue_from CanCan::AccessDenied, with: :access_denied
       rescue_from Apipie::ParamInvalid, with: :invalid_params

--- a/app/models/packages_inventory.rb
+++ b/app/models/packages_inventory.rb
@@ -23,6 +23,7 @@ class PackagesInventory < ActiveRecord::Base
     Actions::TRASH, Actions::PROCESS, Actions::RECYCLE].freeze
   QUANTITY_LOSS_ACTIONS = [Actions::LOSS, Actions::TRASH, Actions::PROCESS, Actions::RECYCLE].freeze
   QUANTITY_GAIN_ACTIONS = [Actions::GAIN].freeze
+  QUANTITY_ACTIONS = (QUANTITY_LOSS_ACTIONS + QUANTITY_GAIN_ACTIONS).freeze
   UNRESTRICTED_ACTIONS = [Actions::MOVE].freeze
   ALLOWED_ACTIONS = (INCREMENTAL_ACTIONS + DECREMENTAL_ACTIONS + UNRESTRICTED_ACTIONS).freeze
   INVENTORY_ACTIONS = (DECREMENTAL_ACTIONS + QUANTITY_GAIN_ACTIONS).freeze
@@ -121,9 +122,11 @@ class PackagesInventory < ActiveRecord::Base
     # Catch invalid actions
     errors.add(:errors, I18n.t('package_inventory.bad_action', action: action)) unless ALLOWED_ACTIONS.include?(action)
 
-    # Prevent GAIN of boxes and pallets
-    # We allow other incremental actions as they only follow up decremennts (e.g dispatch/undispatch)
-    errors.add(:errors, I18n.t('package_inventory.bad_action_for_type', type: package.storage_type.name, action: action)) if package.storage_type&.singleton? && action.eql?(Actions::GAIN)
+    # We prevent any quantity action on a dispatched box/pallet
+    if package.storage_type&.singleton? && QUANTITY_ACTIONS.include?(action) && package.dispatched_quantity.positive?
+      errors.add(:errors, I18n.t('package_inventory.action_requires_undispatch'))
+    end
+
     errors.count.zero?
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
     storage_type_max: "A %{type} is limited to a quantity of %{quantity}"
     bad_action: "Inventory action %{action} is not permitted"
     bad_action_for_type: "Inventory action %{action} is not permitted on %{type} types"
+    action_requires_undispatch: "Action not allowed on a dispatched package. Please undispatch and try again"
     invalid_dispatch_location: "'Dispatched' is not a valid inventory location"
     quantities:
       invalid_negative_quantity: Required quantity not present at location

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -144,6 +144,7 @@ zh-tw:
     storage_type_max: "A %{type} is limited to a quantity of %{quantity}"
     bad_action: "Inventory action %{action} is not permitted"
     bad_action_for_type: "Inventory action %{action} is not permitted on %{type} types"
+    action_requires_undispatch: "Action not allowed on a dispatched package. Please undispatch and try again"
     invalid_dispatch_location: "'Dispatched' is not a valid inventory location"
     quantities:
       invalid_negative_quantity: Required quantity not present at location


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3183

### Changes

`GAIN` actions were previously always forbidden on boxes due to their singleton state. However we should be allowed to restore the quantity of a box if it has been zero-ed by a `loss`.

If it has been zero-ed by a `dispatch`, we do not want to allow anyone to restore the quantity via a `GAIN`.

The overall rule is now the following:

User can modify the quantity of a box, within the [0-1] range _UNLESS_ the box has been dispatched
