### PR TITLE
GCW-3182-Issues with the Charity/Orders page

### DIFF
--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -30,7 +30,8 @@ module Api::V1
 
     api :GET, '/v1/organisations/:id/organisation_orders', "List all orders associated with organisation"
     def organisation_orders
-      orders = @organisation.orders.page(page).per(per_page).order('id')
+      organisation_orders = @organisation.orders
+      orders = organisation_orders.page(page).per(per_page).order('id')
       meta = {
         total_pages: orders.total_pages,
         total_count: orders.size
@@ -66,7 +67,7 @@ module Api::V1
       if params['ids'].present?
         records = @organisations.where(id: params['ids']).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       else
-        records = @organisations.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
+        records = @organisations.with_eager_load.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       end
       data = ActiveModel::ArraySerializer.new(records, each_serializer: serializer, root: "gc_organisations").as_json
       render json: { "meta": { total_pages: records.total_pages, "search": params["searchText"] } }.merge(data)

--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -28,6 +28,18 @@ module Api::V1
       find_record_and_render_json(organisation_name_serializer)
     end
 
+    api :GET, '/v1/organisations/:id/organisation_orders', "List all orders associated with organisation"
+    def organisation_orders
+      orders = @organisation.orders.page(page).per(per_page).order('id')
+      meta = {
+        total_pages: orders.total_pages,
+        total_count: orders.size
+      }
+      render json: { meta: meta }.merge(
+          serialized_orders(orders)
+      )
+    end
+
     private
 
     def organisation_serializer
@@ -36,6 +48,18 @@ module Api::V1
 
     def organisation_name_serializer
       Api::V1::OrganisationNamesSerializer
+    end
+
+    def order_serializer
+      Api::V1::OrderShallowSerializer
+    end
+
+    def serialized_orders(orders)
+      ActiveModel::ArraySerializer.new(
+        orders,
+        each_serializer: order_serializer,
+        root: "designations"
+      ).as_json
     end
 
     def find_record_and_render_json(serializer)

--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -67,7 +67,7 @@ module Api::V1
       if params['ids'].present?
         records = @organisations.where(id: params['ids']).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       else
-        records = @organisations.with_eager_load.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
+        records = @organisations.with_order.search(params["searchText"]).page(params["page"]).per(params["per_page"] || DEFAULT_SEARCH_COUNT)
       end
       data = ActiveModel::ArraySerializer.new(records, each_serializer: serializer, root: "gc_organisations").as_json
       render json: { "meta": { total_pages: records.total_pages, "search": params["searchText"] } }.merge(data)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -282,7 +282,7 @@ class Ability
 
   def organisations_abilities
     if can_check_organisations? || @api_user
-      can [:index, :search, :show], Organisation
+      can [:index, :search, :show, :organisation_orders], Organisation
     end
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,6 +8,8 @@ class Organisation < ActiveRecord::Base
   has_many :orders
   has_many :users, through: :organisations_users
 
+  scope :with_eager_load, -> { includes([:orders]) }
+
   configure_search props: [:name_en, :name_zh_tw], tolerance: 0.1
 
   def name_as_per_locale

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,7 +8,7 @@ class Organisation < ActiveRecord::Base
   has_many :orders
   has_many :users, through: :organisations_users
 
-  scope :with_eager_load, -> { includes([:orders]) }
+  scope :with_order, -> { includes([:orders]) }
 
   configure_search props: [:name_en, :name_zh_tw], tolerance: 0.1
 

--- a/app/serializers/api/v1/organisation_serializer.rb
+++ b/app/serializers/api/v1/organisation_serializer.rb
@@ -4,8 +4,16 @@ module Api::V1
 
     attributes :id, :name_en, :name_zh_tw, :description_en, :description_zh_tw, :registration,
       :website, :organisation_type_id, :district_id, :country_id, :created_at,
-      :updated_at
+      :updated_at, :orders_count
 
     has_many :organisations_users, serializer: OrganisationsUserSerializer
+
+    def orders_count
+      object.orders.size
+    end
+
+    def orders_count__sql
+      "(SELECT COUNT(*) FROM orders o WHERE o.organisation_id = orders.id"
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,9 @@ Rails.application.routes.draw do
       resources :organisations_users, only: [:create, :index, :update, :show]
       resources :gc_organisations, only: [:index, :show] do
         get 'names', on: :collection
+        member do
+          get :organisation_orders
+        end
       end
 
       get "recent_users", to: "users#recent_users"

--- a/spec/controllers/api/v1/gc_organisations_controller_spec.rb
+++ b/spec/controllers/api/v1/gc_organisations_controller_spec.rb
@@ -88,4 +88,30 @@ RSpec.describe Api::V1::GcOrganisationsController, type: :controller do
       expect(parsed_body).to eq(serialized_gc_organisation)
     end
   end
+
+  describe "GET orders for GC organisation" do
+    let(:organisation) { create :organisation }
+    let(:organisation1) { create :organisation }
+    let!(:organisation_orders) { create_list(:order, 2, organisation_id: organisation.id) }
+    let!(:orders) { create_list(:order, 2) }
+
+    it "returns 200" do
+      get :organisation_orders, id: organisation.id
+      expect(response.status).to eq(200)
+    end
+
+    it "returns orders associated with organisation" do
+      get :organisation_orders, id: organisation.id
+      expect(parsed_body['designations'].size).to eq(organisation_orders.size)
+      expect(parsed_body["designations"].map { |order| order["id"] }).to eq(organisation_orders.map(&:id))
+    end
+
+    it "does not returns orders of different organisation" do
+      get :organisation_orders, id: organisation1.id
+      expect(parsed_body['designations']).to eq([])
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3182

### What does this PR do?

- Added separate endpoint for fetching organisations orders with pagination
- Preload `orders` in `organisation` model for adding `ordersCount` field in `organisation` serializer.
- Added test cases for the same.

Please review this PR 