### PR TITLE
FIX=> Separate endpoint for fetching versions for Items.

### DIFF
--- a/app/controllers/api/v1/gc_organisations_controller.rb
+++ b/app/controllers/api/v1/gc_organisations_controller.rb
@@ -28,8 +28,8 @@ module Api::V1
       find_record_and_render_json(organisation_name_serializer)
     end
 
-    api :GET, '/v1/organisations/:id/organisation_orders', "List all orders associated with organisation"
-    def organisation_orders
+    api :GET, '/v1/organisations/:id/orders', "List all orders associated with organisation"
+    def orders
       organisation_orders = @organisation.orders
       orders = organisation_orders.page(page).per(per_page).order('id')
       meta = {

--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -332,6 +332,11 @@ module Api
         render json: { added_quantity: @package&.quantity_contained_in(entity_id) }, status: 200
       end
 
+      api :GET, '/v1/packages/:id/versions', "List all versions associated with package"
+      def versions
+        render json: @package.versions, each_serializer: version_serializer, root: "versions"
+      end
+
       private
 
       def render_order_status_error
@@ -340,6 +345,10 @@ module Api
 
       def stock_serializer
         Api::V1::StockitItemSerializer
+      end
+
+      def version_serializer
+        Api::V1::VersionSerializer
       end
 
       def remove_stockit_prefix(stockit_inventory_number)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -282,7 +282,7 @@ class Ability
 
   def organisations_abilities
     if can_check_organisations? || @api_user
-      can [:index, :search, :show, :organisation_orders], Organisation
+      can [:index, :search, :show, :orders], Organisation
     end
   end
 
@@ -309,7 +309,7 @@ class Ability
              search_stockit_items remove_from_set designate register_quantity_change
              mark_missing move print_inventory_label stockit_item_details
              split_package add_remove_item contained_packages parent_containers
-             fetch_added_quantity], Package
+             fetch_added_quantity versions], Package
       can %i[show create update destroy], PackageSet
       can %i[index], Restriction
       can %i[index], PackagesInventory

--- a/app/serializers/api/v1/stockit_item_serializer.rb
+++ b/app/serializers/api/v1/stockit_item_serializer.rb
@@ -12,7 +12,6 @@ module Api::V1
     has_many :package_actions, serializer: PackageActionsSerializer, root: :item_actions
     has_one :storage_type, serializer: StorageTypeSerializer
     has_one :package_set, serializer: PackageSetSerializer::StockFormat
-    has_many :versions, serializer: VersionSerializer
 
     attributes :id, :length, :width, :height, :weight, :pieces, :notes,
                :inventory_number, :created_at, :updated_at, :item_id, :is_set,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,9 @@ Rails.application.routes.draw do
         collection do
           get :package_valuation
         end
+        member do
+          get :versions
+        end
       end
 
       resources :requested_packages, only: [:index, :create, :destroy] do
@@ -104,7 +107,7 @@ Rails.application.routes.draw do
       resources :gc_organisations, only: [:index, :show] do
         get 'names', on: :collection
         member do
-          get :organisation_orders
+          get :orders
         end
       end
 

--- a/spec/controllers/api/v1/gc_organisations_controller_spec.rb
+++ b/spec/controllers/api/v1/gc_organisations_controller_spec.rb
@@ -100,18 +100,18 @@ RSpec.describe Api::V1::GcOrganisationsController, type: :controller do
       before { generate_and_set_token(supervisor) }
 
       it "returns 200" do
-        get :organisation_orders, id: organisation.id
+        get :orders, id: organisation.id
         expect(response.status).to eq(200)
       end
 
       it "returns orders associated with organisation" do
-        get :organisation_orders, id: organisation.id
+        get :orders, id: organisation.id
         expect(parsed_body['designations'].size).to eq(organisation_orders.size)
         expect(parsed_body["designations"].map { |order| order["id"] }).to eq(organisation_orders.map(&:id))
       end
 
       it "does not returns orders of different organisation" do
-        get :organisation_orders, id: organisation1.id
+        get :orders, id: organisation1.id
         expect(parsed_body['designations']).to eq([])
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::GcOrganisationsController, type: :controller do
       before { generate_and_set_token(charity_user) }
 
       it "returns 403" do
-        get :organisation_orders, id: organisation.id
+        get :orders, id: organisation.id
         expect(response.status).to eq(403)
       end
     end


### PR DESCRIPTION
This PR 
- adds separate endpoint for fetching versions for Item.
- Remove version association in StockitItem Serializer.
- Renamed `organisation_orders` endpoint to `orders`