### PR TITLE
Need to be able to mark_read on staff messages

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -210,7 +210,7 @@ class Ability
     can %i[index show create], Message, messageable_type: 'Offer' if can_manage_offer_messages?
     can %i[index show create], Message, messageable_type: 'Item' if can_manage_offer_messages?
     can %i[index show create], Message, messageable_type: 'Order' if can_manage_order_messages?
-    can %i[index show mark_read mark_all_read], Message, id: @user.subscriptions.pluck(:message_id), is_private: false
+    can %i[index show mark_read mark_all_read], Message, id: @user.subscriptions.pluck(:message_id)
 
     # Normal users can create non private messages on objects they own
     can :create, Message do |message|

--- a/spec/models/abilities/message_abilities_spec.rb
+++ b/spec/models/abilities/message_abilities_spec.rb
@@ -123,7 +123,7 @@ describe 'Message abilities' do
       end
     end
 
-    context 'when charity user recieves a message from a order admin' do
+    context 'when charity user recieves a message from an order admin' do
       let(:order_administrator) { create(:user, :order_administrator) }
       let!(:message) { create :message, is_private: is_private, messageable: order, sender: order_administrator }
 
@@ -139,6 +139,7 @@ describe 'Message abilities' do
     context 'private_message' do
       let(:is_private) { true }
       let!(:message) { create :message, is_private: is_private, messageable: order }
+      let!(:subscription) { } # nil, Charity doesn't get subscribed to private messages
       it 'is not allowed do any action' do
         all_actions.map { |action| is_expected.to_not be_able_to(action, message) }
       end


### PR DESCRIPTION
### Ticket Link: 

Hot fix

### What does this PR do?

BUG: It wasn't possible to mark private messages as read after viewing them

### Impacted Areas

Stock > Alerts > <choose private staff message>
