### PR TITLE
Using yml files to generate factory traits

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -4,6 +4,8 @@ class Permission < ActiveRecord::Base
   has_many :role_permissions
   has_many :roles, through: :role_permissions
 
+  validates :name, uniqueness: true
+
   scope :api_write,  -> { where(name: 'api-write').first }
   scope :reviewer,   -> { where(name: 'Reviewer').first }
   scope :supervisor, -> { where(name: 'Supervisor').first }

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,6 +1,8 @@
 class Role < ActiveRecord::Base
   include CacheableJson
 
+  validates :name, uniqueness: true
+
   has_many :user_roles
   has_many :users, through: :user_roles
   has_many :role_permissions, dependent: :destroy

--- a/app/models/role_permission.rb
+++ b/app/models/role_permission.rb
@@ -1,4 +1,6 @@
 class RolePermission < ActiveRecord::Base
   belongs_to :role
   belongs_to :permission
+
+  validates :permission_id, uniqueness: { scope: :role_id }
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -2,6 +2,8 @@ class UserRole < ActiveRecord::Base
   belongs_to :user
   belongs_to :role
 
+  validates :role_id, uniqueness: { scope: :user_id }
+
   def self.create_user_role(user_id, role_id)
     create(user_id: user_id, role_id: role_id)
   end

--- a/app/services/twilio_inbound_call_manager.rb
+++ b/app/services/twilio_inbound_call_manager.rb
@@ -165,21 +165,20 @@ class TwilioInboundCallManager
     @caller ||= User.find_by_mobile(@mobile) if @mobile.present?
   end
 
-  # TODO: ask Matt if we should change the logic here to always include all reviewers
-  # Notify all the offer's subscribed admins that a new call is incoming
-  # If none exist, notify all supervisors
+  # Notify all the offer's subscribed reviewers and supervisors that a donor is calling
+  # If none exist, notify all reviewers and supervisors
   def call_notify_channels
-    reviewer_channel = Channel.private_channels_for(offer.reviewed_by_id, ADMIN_APP)
-    subscribed_staff = Message.unscoped.joins(:subscriptions)
+    staff_ids = Message.unscoped.joins(:subscriptions)
       .select("distinct subscriptions.user_id as user_id")
-      .where(is_private: true, messageable: offer)
+      .where(is_private: false, messageable: offer)
       .map(&:user_id)
-    channel_names = Channel.private_channels_for(subscribed_staff, ADMIN_APP)
-    if (channel_names - reviewer_channel).blank?
-      channel_names = Channel.private_channels_for(User.supervisors.pluck(:id), ADMIN_APP)
+    staff_ids -= [offer.created_by_id] # includes donor which should be removed
+    staff_ids += [offer.reviewed_by_id].compact
+    if staff_ids.empty?
+      staff_ids += User.reviewers.pluck(:id)
+      staff_ids += User.supervisors.pluck(:id)
     end
-    channel_names += reviewer_channel
-    channel_names.flatten.uniq.compact
+    Channel.private_channels_for(staff_ids.uniq.compact, ADMIN_APP)
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -184,7 +184,7 @@ end
 FactoryBot.create(:user, :system)
 
 # Create API User
-FactoryBot.create(:user, :api_user, first_name: "api", last_name: "write")
+FactoryBot.create(:user, :api_write, first_name: "api", last_name: "write")
 
 # Don't run the following setup on the live server.
 # This is for dummy data

--- a/spec/controllers/api/v1/addresses_controller_spec.rb
+++ b/spec/controllers/api/v1/addresses_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::AddressesController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:address) { create(:profile_address, addressable: user) }
   let(:serialized_address) { Api::V1::AddressSerializer.new(address).as_json }
   let(:serialized_address_json) { JSON.parse( serialized_address.to_json ) }

--- a/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
-  let(:order_administrator) { create(:user, :order_administrator, :with_can_manage_settings )}
+  let(:order_administrator) { create(:user, :order_administrator, :with_can_manage_settings_permission )}
   let(:no_permission_user) { create :user }
   let(:parsed_body) { JSON.parse(response.body) }
   let(:payload) { FactoryBot.build(:appointment_slot_preset, hours: 23, minutes: 0).attributes.except('id', 'updated_at', 'created_at') }

--- a/spec/controllers/api/v1/appointment_slots_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slots_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::AppointmentSlotsController, type: :controller do
-  let(:order_administrator) { create(:user, :order_administrator, :with_can_manage_settings )}
+  let(:order_administrator) { create(:user, :order_administrator, :with_can_manage_settings_permission )}
   let(:no_permission_user) { create :user }
   let(:parsed_body) { JSON.parse(response.body) }
   let!(:appointment_type) { create(:booking_type, :appointment) }

--- a/spec/controllers/api/v1/authentication_controller_spec.rb
+++ b/spec/controllers/api/v1/authentication_controller_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe Api::V1::AuthenticationController, type: :controller do
   let(:user)   { create(:user, :with_token) }
   let(:supervisor) { create(:user, :with_token, :supervisor, :with_organisation) }
   let(:charity_user) { create(:user, :with_token, :with_charity_role, :with_can_login_to_browse_permission) }
-  let(:order_fulfilment) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Order fulfilment' => ['can_login_to_stock']} )}
+  let(:order_fulfilment) { create(:user, :with_token, :with_order_fulfilment_role, :with_can_login_to_stock_permission) }
   let(:pin)    { user.most_recent_token[:otp_code] }
   let(:mobile) { generate(:mobile) }
   let(:mobile1) { generate(:mobile) }

--- a/spec/controllers/api/v1/authentication_controller_spec.rb
+++ b/spec/controllers/api/v1/authentication_controller_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 RSpec.describe Api::V1::AuthenticationController, type: :controller do
 
-  let(:user)   { create(:user_with_token) }
-  let(:supervisor) { create(:user_with_token, :supervisor, :with_organisation) }
-  let(:charity_user) { create(:user_with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Charity' => ['can_login_to_browse']}) }
-  let(:order_fulfilment) { create(:user_with_token, :with_multiple_roles_and_permissions,
+  let(:user)   { create(:user, :with_token) }
+  let(:supervisor) { create(:user, :with_token, :supervisor, :with_organisation) }
+  let(:charity_user) { create(:user, :with_token, :with_charity_role, :with_can_login_to_browse_permission) }
+  let(:order_fulfilment) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Order fulfilment' => ['can_login_to_stock']} )}
   let(:pin)    { user.most_recent_token[:otp_code] }
   let(:mobile) { generate(:mobile) }

--- a/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
+++ b/spec/controllers/api/v1/cancellation_reasons_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::CancellationReasonsController, type: :controller do
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:cancellation_reason) { create :cancellation_reason }
   let(:parsed_body) { JSON.parse(response.body) }
 

--- a/spec/controllers/api/v1/computer_accessories_controller_spec.rb
+++ b/spec/controllers/api/v1/computer_accessories_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ComputerAccessoriesController, type: :controller do
 
-  let(:user) { create(:user_with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
+  let(:user) { create(:user, :with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
   let(:computer_accessory_params) { FactoryBot.attributes_for(:computer_accessory) }
 
   before do

--- a/spec/controllers/api/v1/computers_controller_spec.rb
+++ b/spec/controllers/api/v1/computers_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ComputersController, type: :controller do
 
-  let(:user) { create(:user_with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
+  let(:user) { create(:user, :with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
   let(:computer_params) { FactoryBot.attributes_for(:computer) }
 
   before do

--- a/spec/controllers/api/v1/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/contacts_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ContactsController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:contact_params) { FactoryBot.attributes_for(:contact) }
   let(:parsed_body) { JSON.parse(response.body )}
 

--- a/spec/controllers/api/v1/countries_controller_spec.rb
+++ b/spec/controllers/api/v1/countries_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::CountriesController, type: :controller do
-  let(:user) { create(:user, :api_user) }
+  let(:user) { create(:user, :api_write) }
   let(:country_params_with_stockit_id) {
     FactoryBot.attributes_for(:country, :with_stockit_id)
   }

--- a/spec/controllers/api/v1/donor_conditions_controller_spec.rb
+++ b/spec/controllers/api/v1/donor_conditions_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::DonorConditionsController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:donor_condition) { create(:donor_condition) }
   let(:serialized_donor_condition) { Api::V1::DonorConditionSerializer.new(donor_condition).as_json }
   let(:serialized_donor_condition_json) { JSON.parse( serialized_donor_condition.to_json ) }

--- a/spec/controllers/api/v1/electricals_controller_spec.rb
+++ b/spec/controllers/api/v1/electricals_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ElectricalsController, type: :controller do
 
-  let(:user) { create(:user_with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
+  let(:user) { create(:user, :with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
   let(:electrical_params) { FactoryBot.attributes_for(:electrical) }
 
   before do

--- a/spec/controllers/api/v1/gc_organisations_controller_spec.rb
+++ b/spec/controllers/api/v1/gc_organisations_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::GcOrganisationsController, type: :controller do
-  let(:supervisor) { create(:user_with_token, :with_can_check_organisations_permission, role_name: 'Supervisor') }
+  let(:supervisor) { create(:user, :with_token, :with_can_check_organisations_permission, role_name: 'Supervisor') }
   let(:parsed_body) { JSON.parse(response.body) }
 
   before { generate_and_set_token(supervisor) }

--- a/spec/controllers/api/v1/gogovan_orders_controller_spec.rb
+++ b/spec/controllers/api/v1/gogovan_orders_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::GogovanOrdersController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:gogovan_order) { create(:gogovan_order) }
   let(:serialized_order) { Api::V1::GogovanOrderSerializer.new(gogovan_order).as_json }
   let(:serialized_order_json) { JSON.parse(serialized_order.to_json) }

--- a/spec/controllers/api/v1/goodcity_settings_controller_spec.rb
+++ b/spec/controllers/api/v1/goodcity_settings_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
 
-  let(:supervisor_with_settings_permission)  { create(:user, :with_can_manage_settings, role_name: 'Supervisor') }
-  let(:supervisor_without_settings_permission)  { create(:user, role_name: 'Supervisor') }
+  let(:supervisor_with_settings_permission) { create(:user, :with_can_manage_settings_permission, role_name: 'Supervisor') }
+  let(:reviewer_without_settings_permission) { create(:user, role_name: 'Reviewer') }
   let(:goodcity_setting) { create(:goodcity_setting) }
   let(:goodcity_setting_params) { FactoryBot.attributes_for(:goodcity_setting) }
   let(:parsed_body) { JSON.parse(response.body ) }
@@ -26,7 +26,7 @@ RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
     end
 
     context "as a user without 'can_manage_settings' permission" do
-      before { generate_and_set_token(supervisor_without_settings_permission) }
+      before { generate_and_set_token(reviewer_without_settings_permission) }
       it "returns 403" do
         post :create, goodcity_setting: goodcity_setting_params
         expect(response.status).to eq(403)
@@ -57,7 +57,7 @@ RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
     end
 
     context "as a user without 'can_manage_settings' permission" do
-      before { generate_and_set_token(supervisor_without_settings_permission) }
+      before { generate_and_set_token(reviewer_without_settings_permission) }
       it "returns 403" do
         put :update, id: goodcity_setting.id, goodcity_setting: goodcity_setting_params
         expect(response.status).to eq(403)
@@ -89,7 +89,7 @@ RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
     end
 
     context "as a user without 'can_manage_settings' permission" do
-      before { generate_and_set_token(supervisor_without_settings_permission) }
+      before { generate_and_set_token(reviewer_without_settings_permission) }
       it "returns 403" do
         delete :destroy,  id: goodcity_setting.id, goodcity_setting: goodcity_setting_params
         expect(response.status).to eq(403)

--- a/spec/controllers/api/v1/images_controller_spec.rb
+++ b/spec/controllers/api/v1/images_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ImagesController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:offer) { create :offer, created_by: user }
   let(:item)  { create :item, offer: offer }
   let(:image) { create :image, favourite: true, item: item }

--- a/spec/controllers/api/v1/inventory_numbers_controller_spec.rb
+++ b/spec/controllers/api/v1/inventory_numbers_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::InventoryNumbersController, type: :controller do
-  let(:user) { create(:user_with_token, :with_can_add_or_remove_inventory_number, role_name: 'Reviewer') }
+  let(:user) { create(:user, :with_token, :with_can_add_or_remove_inventory_number_permission, role_name: 'Reviewer') }
   let(:inventory_number) { create(:inventory_number) }
   let(:parsed_body) { JSON.parse(response.body) }
 

--- a/spec/controllers/api/v1/items_controller_spec.rb
+++ b/spec/controllers/api/v1/items_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Api::V1::ItemsController, type: :controller do
     end
 
     describe "update donor_condition" do
-      before { generate_and_set_token(create(:user, :with_can_manage_items_permission, role_name: 'can_manage_items')) }
+      before { generate_and_set_token(create(:user, :with_reviewer_role, :with_can_manage_items_permission)) }
 
       # TODO refactor this test, is not actually checking job is created
       it "should add stockit-update-item request job" do

--- a/spec/controllers/api/v1/items_controller_spec.rb
+++ b/spec/controllers/api/v1/items_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::ItemsController, type: :controller do
 
-  let(:user)  { create :user_with_token, :with_can_manage_items_permission }
+  let(:user)  { create :user, :with_token, :with_can_manage_items_permission }
   let(:offer) { create :offer, created_by: user }
   let(:item)  { create(:item, offer: offer) }
   let(:serialized_item) { Api::V1::ItemSerializer.new(item).as_json }

--- a/spec/controllers/api/v1/locations_controller_spec.rb
+++ b/spec/controllers/api/v1/locations_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::LocationsController, type: :controller do
 
-  let(:reviewer) { create(:user_with_token, :with_can_manage_locations_permission, role_name: 'Reviewer') }
+  let(:reviewer) { create(:user, :with_token, :with_can_manage_locations_permission, role_name: 'Reviewer') }
   let(:parsed_body) { JSON.parse(response.body) }
   before { generate_and_set_token(reviewer) }
 

--- a/spec/controllers/api/v1/lookups_controller_spec.rb
+++ b/spec/controllers/api/v1/lookups_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::LookupsController, type: :controller do
-  let(:user) { create(:user_with_token, :with_can_manage_package_detail_permission, role_name: "Order Fulfilment") }
+  let(:user) { create(:user, :with_token, :with_can_manage_package_detail_permission, role_name: "Order Fulfilment") }
 
   before do
     generate_and_set_token(user)

--- a/spec/controllers/api/v1/medicals_controller_spec.rb
+++ b/spec/controllers/api/v1/medicals_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::MedicalsController, type: :controller do
-  let(:user) { create(:user_with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
+  let(:user) { create(:user, :with_token, :with_can_manage_package_detail_permission, role_name: 'Order Fulfilment') }
 
   before do
     generate_and_set_token(user)

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
   end
 
   describe "GET messages/notifications" do
-    let(:user) { create(:user, :with_token, :with_can_manage_package_messages) }
+    let(:user) { create(:user, :with_token, :with_can_manage_package_messages_permission) }
     let(:package) { create :package }
     before { generate_and_set_token(user) }
 

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
 
   before { allow_any_instance_of(PushService).to receive(:notify) }
   before { allow_any_instance_of(PushService).to receive(:send_notification) }
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:offer) { create(:offer, created_by: user) }
   let(:offer2) { create(:offer, created_by: user) }
   let(:item) { create(:item, offer: offer) }
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
   subject { JSON.parse(response.body) }
 
   describe "GET messages" do
-    let(:user) { create(:user_with_token, :with_can_manage_messages_permission, role_name: 'Reviewer') }
+    let(:user) { create(:user, :with_token, :with_can_manage_offer_messages_permission, role_name: 'Reviewer') }
     before { generate_and_set_token(user) }
 
     it "return serialized messages", :show_in_doc do

--- a/spec/controllers/api/v1/offers_controller_spec.rb
+++ b/spec/controllers/api/v1/offers_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::OffersController, type: :controller do
 
   before { allow_any_instance_of(PushService).to receive(:notify) }
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:reviewer) { create(:user, :with_can_manage_offers_permission, role_name: 'Reviewer') }
   let(:supervisor) { create(:user, :with_can_manage_offers_permission, role_name: 'Supervisor') }
   let(:offer) { create(:offer, :with_transport, created_by: user) }

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
   let(:draft_order) { create :order, :with_orders_packages, :with_state_draft, status: nil }
   let(:stockit_draft_order) { create :order, :with_orders_packages, :with_state_draft, status: nil, detail_type: "StockitLocalOrder" }
   let(:user) {
-    create(:user_with_token, :with_multiple_roles_and_permissions,
+    create(:user, :with_token, :with_multiple_roles_and_permissions,
            roles_and_permissions: {"Supervisor" => ["can_manage_orders"]})
   }
   let!(:order_created_by_supervisor) { create :order, :with_state_submitted, booking_type: booking_type,  created_by: user }

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
   let!(:processing_order) { create :order, :with_state_processing, booking_type: booking_type }
   let(:draft_order) { create :order, :with_orders_packages, :with_state_draft, status: nil }
   let(:stockit_draft_order) { create :order, :with_orders_packages, :with_state_draft, status: nil, detail_type: "StockitLocalOrder" }
-  let(:user) {
-    create(:user, :with_token, :with_multiple_roles_and_permissions,
-           roles_and_permissions: {"Supervisor" => ["can_manage_orders"]})
-  }
+  let(:user) { create(:user, :with_token, :with_supervisor_role, :with_can_manage_orders_permission) }
   let!(:order_created_by_supervisor) { create :order, :with_state_submitted, booking_type: booking_type,  created_by: user }
   let(:parsed_body) { JSON.parse(response.body) }
   let(:order_params) { FactoryBot.attributes_for(:order, :with_stockit_id) }

--- a/spec/controllers/api/v1/orders_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_packages_controller_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Api::V1::OrdersPackagesController, type: :controller do
   let(:orders_package) { create :orders_package }
   let(:order) { create :order, :with_state_draft }
-  let(:user) { create(:user_with_token, :with_can_manage_orders_packages_permission, role_name: 'Reviewer') }
-  let(:charity_user) { create(:user_with_token, :with_can_manage_orders_packages_permission, role_name: 'Charity') }
+  let(:user) { create(:user, :with_token, :with_can_manage_orders_packages_permission, role_name: 'Reviewer') }
+  let(:charity_user) { create(:user, :with_token, :with_can_manage_orders_packages_permission, role_name: 'Charity') }
   let(:status) { response.status }
   subject { JSON.parse(response.body) }
 

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
-  let(:supervisor) { create(:user_with_token, :with_can_manage_organisations_users_permission, role_name: 'Supervisor') }
+  let(:supervisor) { create(:user, :with_token, :with_can_manage_organisations_users_permission, role_name: 'Supervisor') }
   before { generate_and_set_token(supervisor) }
   let(:organisation) { create :organisation }
   let(:new_organisation) { create :organisation }

--- a/spec/controllers/api/v1/package_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/package_sets_controller_spec.rb
@@ -7,14 +7,7 @@ RSpec.describe Api::V1::PackageSetsController, type: :controller do
   let(:empty_package_set) { create(:package_set, package_type_id: package_type.id) }
   let(:unauthorized_user) { create(:user) }
   let(:parsed_body) { JSON.parse(response.body) }
-  let(:authorized_user) {
-    create(:user,
-      :with_multiple_roles_and_permissions,
-      roles_and_permissions: {
-        "SomeRole" => ["can_manage_packages"]
-      }
-    )
-  }
+  let(:authorized_user) { create(:user, :with_order_fulfilment_role, :with_can_manage_packages_permission) }
 
   before { touch(package_set) }
 

--- a/spec/controllers/api/v1/package_types_controller_spec.rb
+++ b/spec/controllers/api/v1/package_types_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::PackageTypesController, type: :controller do
-  let(:user) { create(:user_with_token, :reviewer) }
+  let(:user) { create(:user, :with_token, :reviewer) }
 
   describe "GET package_types" do
     before { generate_and_set_token(user) }

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe Api::V1::PackagesController, type: :controller do
   let(:supervisor) { create(:user, :supervisor, :with_can_manage_packages_permission )}
-  let(:user) { create(:user_with_token, :with_multiple_roles_and_permissions,
+  let(:user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Reviewer' => ['can_manage_packages', 'can_manage_orders']} )}
-  let!(:stockit_user) { create(:user, :stockit_user, :api_user)}
-  let(:donor) { create(:user_with_token) }
+  let!(:stockit_user) { create(:user, :stockit_user, :api_write)}
+  let(:donor) { create(:user, :with_token) }
   let(:offer) { create :offer, created_by: donor }
   let(:item)  { create :item, offer: offer }
   let(:package_type)  { create :package_type }

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.describe Api::V1::PackagesController, type: :controller do
   let(:supervisor) { create(:user, :supervisor, :with_can_manage_packages_permission )}
-  let(:user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Reviewer' => ['can_manage_packages', 'can_manage_orders']} )}
+  let(:user) { create(:user, :with_token, :with_reviewer_role, :with_can_manage_packages_permission, :with_can_manage_orders_permission) }
   let!(:stockit_user) { create(:user, :stockit_user, :api_write)}
   let(:donor) { create(:user, :with_token) }
   let(:offer) { create :offer, created_by: donor }

--- a/spec/controllers/api/v1/packages_inventories_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_inventories_controller_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PackagesInventoriesController, type: :controller do
-  let(:user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Reviewer' => ['can_manage_packages', 'can_manage_orders']} )}
+  let(:user) { create(:user, :with_token, :with_reviewer_role, :with_can_manage_packages_permission, :with_can_manage_orders_permission) }
   let!(:package) { create(:package) }
   let!(:package1) { create(:package) }
   let!(:packages_inventory) { create(:packages_inventory, :gain, package_id: package.id) }

--- a/spec/controllers/api/v1/packages_inventories_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_inventories_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PackagesInventoriesController, type: :controller do
-  let(:user) { create(:user_with_token, :with_multiple_roles_and_permissions,
+  let(:user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Reviewer' => ['can_manage_packages', 'can_manage_orders']} )}
   let!(:package) { create(:package) }
   let!(:package1) { create(:package) }

--- a/spec/controllers/api/v1/packages_locations_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_locations_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Api::V1::PackagesLocationsController, type: :controller do
   let(:packages_location) { create :packages_location }
-  let(:user) { create(:user_with_token, :with_can_access_packages_locations_permission, role_name: 'Reviewer') }
+  let(:user) { create(:user, :with_token, :with_can_access_packages_locations_permission, role_name: 'Reviewer') }
 
   before { User.current_user = user }
   subject { JSON.parse(response.body) }

--- a/spec/controllers/api/v1/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/permissions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PermissionsController, type: :controller do
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let!(:permission) { create :permission }
   let(:serialized_permission) { Api::V1::PermissionSerializer.new(permission).as_json }
   let(:serialized_permission_json) { JSON.parse( serialized_permission.to_json ) }
@@ -19,7 +19,7 @@ RSpec.describe Api::V1::PermissionsController, type: :controller do
 
     it 'returns all permissions except api-write' do
       get :index
-      expect(subject['permissions'].length).to eq(1)
+      expect(subject['permissions'].to_a).to_not include("api-write")
     end
   end
 

--- a/spec/controllers/api/v1/printers_controller_spec.rb
+++ b/spec/controllers/api/v1/printers_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::PrintersController, type: :controller do
-  let!(:user) { create(:user, :reviewer, :with_can_access_printers) }
+  let!(:user) { create(:user, :reviewer, :with_can_access_printers_permission) }
   let!(:active_printer) { create(:printer, :active) }
   let!(:inactive_printer) { create(:printer) }
 

--- a/spec/controllers/api/v1/process_checklists_controller_spec.rb
+++ b/spec/controllers/api/v1/process_checklists_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::ProcessChecklistsController, type: :controller do
-  let(:manager) { create(:user_with_token, :with_multiple_roles_and_permissions,
+  let(:manager) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let!(:process_checklist) { create(:process_checklist) }
   let!(:process_checklist2) { create(:process_checklist) }
   let(:parsed_body) { JSON.parse(response.body) }

--- a/spec/controllers/api/v1/process_checklists_controller_spec.rb
+++ b/spec/controllers/api/v1/process_checklists_controller_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::ProcessChecklistsController, type: :controller do
-  let(:manager) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
+  let(:manager) { create(:user, :with_token, :with_supervisor_role, :with_can_manage_orders_permission) }
   let(:user) { create(:user, :with_token) }
   let!(:process_checklist) { create(:process_checklist) }
   let!(:process_checklist2) { create(:process_checklist) }

--- a/spec/controllers/api/v1/rejection_reasons_controller_specs.rb
+++ b/spec/controllers/api/v1/rejection_reasons_controller_specs.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::RejectionReasonsController, type: :controller do
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:rejection_reason) { create :rejection_reason }
   let(:serialized_rejection_reason) { Api::V1::RejectionReasonSerializer.new(rejection_reason).as_json }
   let(:serialized_rejection_reason_json) { JSON.parse( serialized_rejection_reason.to_json ) }

--- a/spec/controllers/api/v1/roles_controller_spec.rb
+++ b/spec/controllers/api/v1/roles_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::RolesController, type: :controller do
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
 
-  let(:role) { create(:role, :with_dynamic_permission, permissions: ['can_create_package']) }
+  let(:role) { create(:reviewer_role, :with_can_manage_packages_permission) }
   let(:serialized_role) { Api::V1::RoleSerializer.new(role).as_json }
   let(:serialized_role_json) { JSON.parse( serialized_role.to_json ) }
 

--- a/spec/controllers/api/v1/schedules_controller_spec.rb
+++ b/spec/controllers/api/v1/schedules_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Api::V1::SchedulesController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:schedule) { build(:schedule) }
   let(:schedule_params) { FactoryBot.attributes_for(:schedule) }
 

--- a/spec/controllers/api/v1/timeslots_controller_spec.rb
+++ b/spec/controllers/api/v1/timeslots_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::TimeslotsController, type: :controller do
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:timeslot) { create(:timeslot) }
   let(:serialized_timeslots) { Api::V1::TimeslotSerializer.new(timeslot) }
   let(:serialized_timeslots_json) { JSON.parse( serialized_timeslots.to_json ) }

--- a/spec/controllers/api/v1/twilio_outbound_controller_spec.rb
+++ b/spec/controllers/api/v1/twilio_outbound_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::TwilioOutboundController, type: :controller do
       .and_return(true)
   }
 
-  let(:user) { create(:user_with_token) }
+  let(:user) { create(:user, :with_token) }
   let(:basic_outbound_call_params) { {
     "AccountSid"     => ENV['TWILIO_ACCOUNT_SID'],
     "ApplicationSid" => ENV['TWILIO_CALL_APP_SID'],

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   let(:users) { create_list(:user, 2) }
 
   let(:charity_users) { ('a'..'z').map { |i|
-    create(:user, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Charity' => ['can_login_to_browse']}, first_name: "Jane_#{i}", last_name: 'Doe')}}
+    create(:user, :with_charity_role, :with_can_login_to_browse_permission, first_name: "Jane_#{i}", last_name: 'Doe')}}
 
   let(:parsed_body) { JSON.parse(response.body) }
 
@@ -292,8 +291,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     describe 'GET /mentionable_users' do
       let!(:reviewer) { create(:user, :reviewer) }
       let!(:donor) { create(:user) }
-      let(:supervisor) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Supervisor' => ['can_mention_users']}) }
-      let!(:order_administrator) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Order administrator' => ['can_mention_users']}) }
+      let(:supervisor) { create(:user, :with_supervisor_role, :with_can_mention_users_permission) }
+      let!(:order_administrator) { create(:user, :with_order_administrator_role, :with_can_mention_users_permission) }
       let!(:charity) { create(:user, :charity) }
       let!(:order_fulfilment) { create(:user, :order_fulfilment) }
       let!(:offer) { create(:offer, reviewed_by: reviewer, created_by: donor) }

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
   TOTAL_REQUESTS_STATES = ["submitted", "awaiting_dispatch", "closed", "cancelled"]
 
-  let(:supervisor_user) { create(:user_with_token, :with_can_read_or_modify_user_permission, :with_can_manage_user_roles, role_name: 'Supervisor') }
-  let(:reviewer_user) { create(:user_with_token, :with_can_create_user_permission, role_name: "Reviewer") }
+  let(:supervisor_user) { create(:user, :with_token, :with_can_read_or_modify_user_permission, :with_can_manage_user_roles_permission, role_name: 'Supervisor') }
+  let(:reviewer_user) { create(:user, :with_token, :with_can_create_donor_permission, role_name: "Reviewer") }
   let(:system_admin_user) {
     create :user,
-      :with_can_read_or_modify_user_permission, :with_can_disable_user,
+      :with_can_read_or_modify_user_permission, :with_can_disable_user_permission,
       role_name: "System administrator"
   }
 
@@ -90,7 +90,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   end
 
   describe "POST users" do
-    let(:reviewer) { create(:user_with_token, :reviewer) }
+    let(:reviewer) { create(:user, :with_token, :reviewer) }
     let(:role) { create(:role, name: "System administrator" , level: 15) }
     let(:existing_user) { create(:user) }
 
@@ -170,7 +170,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   describe "PUT user/1" do
 
     context "Reviewer" do
-      let(:reviewer) { create(:user_with_token, :reviewer) }
+      let(:reviewer) { create(:user, :with_token, :reviewer) }
       let(:role) { create(:role, name: "Supervisor") }
 
       before { generate_and_set_token(reviewer_user) }
@@ -202,7 +202,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     context "as a Supervisor" do
-      let(:supervisor) { create(:user_with_token, :supervisor) }
+      let(:supervisor) { create(:user, :with_token, :supervisor) }
       let(:charity_role) { create(:role, name: "Charity") }
 
       before { generate_and_set_token(supervisor_user) }
@@ -237,7 +237,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         it "I cannot change the roles of a System Administrator [higher level role]" do
           put :update, id: system_admin_user.id,
              user: {user_role_ids: [charity_role.id]}
-
           expect(response.status).to eq(200)
           expect(system_admin_user.roles.pluck(:id)).to_not include(charity_role.id)
         end
@@ -245,7 +244,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     context "as a System Administrator user" do
-      let(:supervisor) { create(:user_with_token, :supervisor) }
+      let(:supervisor) { create(:user, :with_token, :supervisor) }
       before { generate_and_set_token(system_admin_user) }
 
       context "when I edit another user's details" do

--- a/spec/factories/auth_tokens.rb
+++ b/spec/factories/auth_tokens.rb
@@ -1,11 +1,9 @@
-# Read about factories at https://github.com/thoughtbot/factory_bot
+#
+# create(:auth_token) - does NOT associate with a user
+# create(:user_with_auth_token) - correct way to generate a user with auth_token
+#
 FactoryBot.define do
   factory :auth_token do
-    association :user
-    otp_code_expiry { Time.now + 10.hours }
-  end
-
-  factory :scenario_before_auth_token, parent: :auth_token do
     otp_code_expiry { Time.now + Rails.application.secrets.token['otp_code_validity'] }
   end
 end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :permission do
     name            { generate(:permissions_roles).values.flatten.uniq.sample }
-    initialize_with { Permission.find_or_initialize_by(name: name) } # limits us to our sample of permissions
+    initialize_with { Permission.find_or_initialize_by(name: name) } # avoid duplicate roles
 
     trait :api_write do
       name 'api-write'

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,7 +1,9 @@
 # USAGE:
-#   create(:role)
-#   create(:reviewer_role)
-#   create(:order_fulfilment_role)
+#   create(:role)                   # empty
+#   create(:reviewer_role)          # named, no permissions specified
+#   create(:order_fulfilment_role)  # named, no permissions specified
+#   create(:reviewer_role, :with_can_manage_offers_permission) # specify 1 permission
+#   create(:reviewer_role, :with_can_manage_offers_permission, :with_can_manage_messages_permission) # specify multiple permissions
 #
 FactoryBot.define do
 
@@ -14,211 +16,36 @@ FactoryBot.define do
       permissions { %w(can_manage_offers, can_manage_packages)}
     end
 
-    # Generate roles with associated permissions
+    # create(:reviewer_role) # No permissions, just the role
     YAML.load_file("#{Rails.root}/db/roles.yml").each do |role, attrs|
       factory "#{role.parameterize.underscore}_role", parent: :role do
         name role
         level attrs[:level]
-        after(:create) do |role, evaluator|
-          generate(:permissions_roles)[role.name].each do |permission|
-            role.permissions << (create :permission, name: permission)
+      end
+    end
+
+    # create(:reviewer_role, :with_permissions, permissions: ['can_manage_offers', 'can_manage_messages'])
+    trait :with_permissions do
+      after(:create) do |role, evaluator|
+        evaluator.permissions.each do |permission|
+          p = create(:permission, name: permission)
+          role.permissions << p unless role.permissions.include?(p)
+        end
+      end
+    end
+
+    # create(:reviewer_role, :with_can_manage_offers_permission)
+    # create(:reviewer_role, :with_can_manage_offers_permission, :with_can_manage_messages_permission)
+    YAML.load_file("#{Rails.root}/db/permissions_roles.yml").each do |role_name, permissions|
+      permissions.each do |permission|
+        trait "with_#{permission}_permission".to_sym do
+          after(:create) do |role|
+            p = create(:permission, name: permission)
+            role.permissions << p unless role.permissions.include?(p)
           end
         end
       end
     end
 
-    trait :with_dynamic_permission do
-      after(:create) do |role, evaluator|
-        evaluator.permissions.each do |permission|
-          role.permissions << (create :permission, name: permission)
-        end
-      end
-    end
-
-    trait :with_can_add_or_remove_inventory_number do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_add_or_remove_inventory_number')
-      end
-    end
-
-    trait :with_can_destroy_contacts_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_destroy_contacts')
-      end
-    end
-
-    trait :with_can_manage_package_detail_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_package_detail')
-      end
-    end
-
-    trait :with_can_remove_offers_packages_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_remove_offers_packages')
-      end
-    end
-
-    trait :with_can_manage_users_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_users')
-      end
-    end
-
-    trait :with_can_manage_stocktakes_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_stocktakes')
-      end
-    end
-
-    trait :with_can_manage_stocktake_revisions_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_stocktake_revisions')
-      end
-    end
-
-    trait :with_can_manage_holidays_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_holidays')
-      end
-    end
-
-    trait :with_can_read_versions_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: "can_read_versions")
-      end
-    end
-
-    trait :with_can_manage_messages_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_messages')
-      end
-    end
-
-    trait :with_can_add_package_types_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_add_package_types')
-      end
-    end
-
-    trait :with_can_manage_packages_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_packages')
-      end
-    end
-
-    trait :with_can_manage_deliveries do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_deliveries')
-      end
-    end
-
-    trait :with_can_manage_orders_packages_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_orders_packages')
-      end
-    end
-
-    trait :with_can_manage_organisations_users_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_organisations_users')
-      end
-    end
-
-    trait :with_can_check_organisations_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_check_organisations')
-      end
-    end
-
-    trait :with_can_read_or_modify_user_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_read_or_modify_user')
-      end
-    end
-
-    trait :with_can_create_user_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_create_donor')
-      end
-    end
-
-    trait :with_can_manage_orders_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_orders')
-      end
-    end
-
-    trait :with_can_manage_images_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_images')
-      end
-    end
-
-    trait :with_can_access_packages_locations_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_access_packages_locations')
-      end
-    end
-
-    trait :with_can_manage_locations_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_locations')
-      end
-    end
-
-    trait :with_can_manage_offers_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_offers')
-      end
-    end
-
-    trait :with_can_manage_items_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_items')
-      end
-    end
-
-    trait :with_can_manage_goodcity_requests_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_goodcity_requests')
-      end
-    end
-
-    trait :with_can_create_and_read_messages_permission do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_create_and_read_messages')
-      end
-    end
-
-    trait :with_can_manage_settings do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: 'can_manage_settings')
-      end
-    end
-
-    trait :with_can_access_printers do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: "can_access_printers")
-      end
-    end
-
-    trait :with_can_access_orders_process_checklists do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: "can_access_orders_process_checklists")
-      end
-    end
-
-    trait :with_can_disable_user do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: "can_disable_user")
-      end
-    end
-
-    trait :with_can_manage_user_roles do
-      after(:create) do |role|
-        role.permissions << (create :permission, name: "can_manage_user_roles")
-      end
-    end
   end
 end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -68,6 +68,10 @@ FactoryBot.define do
     @schedules ||= YAML.load_file("#{Rails.root}/db/schedules.yml")
   end
 
+  sequence :roles do |n|
+    @roles ||= YAML.load_file("#{Rails.root}/db/roles.yml")
+  end
+
   sequence :permissions_roles do |n|
     roles = YAML.load_file("#{Rails.root}/db/permissions_roles.yml")
     roles.each_pair { |key, value| value.flatten! }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,16 +1,24 @@
 # USAGE:
 #   create(:user)
-#   create(:user, :reviewer)
-#   create(:user, :order_administrator)
+#   create(:user, :order_administrator)       # TO BE DEPRECATED
+#   create(:user, :with_order_administrator_role)  # has the role but no permissions
+#   create(:user, :with_can_manage_packages_permission) # when you don't care which role the user gets (they'll get one)
+#   create(:user, :with_can_manage_packages_permission, role_name: "Supervisor") # can specify role if permission belongs to more than one
+#   create(:user, :with_supervisor_role, :with_can_manage_packages_permission) # alternative way to specify role
+
+# You MUST specify role_name when using more than one permission to avoid getting permissions with mixed roles:
+#   create(:user, :with_can_manage_packages_permission, :with_can_manage_offers_permission, role_name: "Supervisor")
+#   create(:user, :with_supervisor_role, :with_can_manage_packages_permission, :with_can_manage_offers_permission)
 #
 FactoryBot.define do
   factory :user, aliases: [:sender] do
     association :address
 
+    title { ["Mr", "Mrs", "Miss", "Ms"].sample }
     first_name { FFaker::Name.first_name }
     last_name { FFaker::Name.last_name }
     mobile { generate(:mobile) }
-    email { FFaker::Internet.email }
+    email { "#{rand(1000)}#{FFaker::Internet.email}" }
     last_connected { 2.days.ago }
     last_disconnected { 1.day.ago }
     disabled { false }
@@ -24,211 +32,58 @@ FactoryBot.define do
       roles_and_permissions { }
     end
 
+    # TO BE DEPRECATED
     # Role specific users. create(:user, :order_administrator)
+    # No permissions are created
     FactoryBot.generate(:permissions_roles).keys.each do |role|
       trait role.parameterize.underscore.to_sym do
         after(:create) do |user|
-          user.roles << create("#{role.parameterize.underscore}_role")
+          r = create("#{role.parameterize.underscore}_role")
+          user.roles << r unless user.roles.include?(r)
         end
       end
     end
 
-    trait :user_with_no_mobile do
-      mobile { nil }
+    # Role specific users: create(:user, :with_order_administrator_role)
+    # No permissions are created
+    FactoryBot.generate(:permissions_roles).keys.each do |role|
+      trait "with_#{role.parameterize.underscore}_role".to_sym do
+        after(:create) do |user|
+          r = create("#{role.parameterize.underscore}_role")
+          user.roles << r unless user.roles.include?(r)
+        end
+        transient do
+          # ensures if multiple permission traits are used, that they get assigned to the same role
+          role_name { role.parameterize.underscore }
+        end
+      end
     end
 
+    # create(:user, :with_<insert permission name>_permission)
+    # If more than 1 role has the same permission, then only 1 role will be defined
+    # However, you can set the particular role by using the 'role_name parameter'
+    # E.g. create(:user, :with_can_manage_packages, role_name: "Supervisor")
+    # in order to avoid a user with role Reviewer AND Supervisor
+    FactoryBot.generate(:permissions_roles).each do |role_name, permissions|
+      permissions.each do |permission|
+        trait "with_#{permission}_permission".to_sym do
+          after(:create) do |user, evaluator|
+            # create(:supervisor_role, :with_can_manage_packages_permission)
+            r = create("#{(evaluator.role_name || role_name).parameterize.underscore}_role".to_sym, "with_#{permission}_permission".to_sym)
+            user.roles << r unless user.roles.include?(r)
+          end
+        end
+      end
+    end
+
+    # create(:user, :with_token, :with_multiple_roles_and_permissions, roles_and_permissions: { 'Order fulfilment' => ['can_login_to_stock', 'can_manage_packages']} )
     trait :with_multiple_roles_and_permissions do
       after(:create) do |user, evaluator|
         evaluator.roles_and_permissions.each_pair do |role_name, permissions|
-          user.roles << create(:role, :with_dynamic_permission, name: role_name, permissions: permissions)
+          # create(:supervisor_role, :with_can_manage_packages_permission, :with_can_manage_messages_permission, ...)
+          perms = permissions.map{|permission| :"with_#{permission}_permission" }
+          user.roles << create(:"#{role_name.parameterize.underscore}_role", *perms)
         end
-      end
-    end
-
-    trait :with_can_add_or_remove_inventory_number do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_add_or_remove_inventory_number, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_destroy_contact_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_destroy_contacts_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_read_versions_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_read_versions_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_holidays_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_holidays_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_create_and_read_messages_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_create_and_read_messages_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_packages_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_packages_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_stocktakes_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_stocktakes_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_stocktake_revisions_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_stocktake_revisions_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_organisations_users_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_organisations_users_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_deliveries do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_deliveries, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_orders_packages_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_orders_packages_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_remove_offers_packages_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_remove_offers_packages_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_check_organisations_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_check_organisations_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_items_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_items_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_goodcity_requests_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_goodcity_requests_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_messages_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_messages_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_offers_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_offers_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_add_package_types_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_add_package_types_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_read_or_modify_user_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_read_or_modify_user_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_create_user_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create "#{evaluator.role_name.parameterize.underscore}_role".to_sym, :with_can_create_user_permission)
-      end
-    end
-
-    trait :with_can_manage_package_detail_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_package_detail_permission, name: evaluator.role_name)
-      end
-    end
-
-
-    trait :with_can_manage_images_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_images_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_access_packages_locations_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_access_packages_locations_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_orders_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_orders_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_locations_permission do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_locations_permission, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_manage_settings do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_manage_settings, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_access_printers do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_access_printers, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_access_orders_process_checklists do
-      after(:create) do |user, evaluator|
-        user.roles << (create :role, :with_can_access_orders_process_checklists, name: evaluator.role_name)
-      end
-    end
-
-    trait :with_can_disable_user do
-      after(:create) do |user, evaluator|
-        user.roles << (create "#{evaluator.role_name.parameterize.underscore}_role".to_sym,  :with_can_disable_user)
-      end
-    end
-
-    trait :with_can_manage_user_roles do
-      after(:create) do |user, evaluator|
-        user.roles << (create "#{evaluator.role_name.parameterize.underscore}_role".to_sym,  :with_can_manage_user_roles)
-      end
-    end
-
-    trait :api_user do
-      after(:create) do |user|
-        user.roles << create(:api_write_role)
       end
     end
 
@@ -244,10 +99,6 @@ FactoryBot.define do
       after(:create) do |user|
         user.roles << create(:system_role)
       end
-    end
-
-    trait :title do
-      title { ["Mr", "Mrs", "Miss", "Ms"].sample }
     end
 
     trait :with_organisation do
@@ -271,12 +122,11 @@ FactoryBot.define do
         user.requested_packages << (create :requested_package, user_id: user.id)
       end
     end
-  end
 
-  factory :user_with_token, parent: :user do
-    mobile { generate(:mobile) }
-    after(:create) do |user|
-      user.auth_tokens << create(:scenario_before_auth_token)
+    trait :with_token do
+      after(:create) do |user, evaluator|
+        create_list(:auth_token, 1)
+      end
     end
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,8 @@
+# USAGE:
+#   create(:user)
+#   create(:user, :reviewer)
+#   create(:user, :order_administrator)
+#
 FactoryBot.define do
   factory :user, aliases: [:sender] do
     association :address
@@ -19,10 +24,11 @@ FactoryBot.define do
       roles_and_permissions { }
     end
 
-    %i[reviewer order_fulfilment order_administrator supervisor system_administrator charity stock_administrator stock_fulfilment].each do |role|
-      trait role do
+    # Role specific users. create(:user, :order_administrator)
+    FactoryBot.generate(:permissions_roles).keys.each do |role|
+      trait role.parameterize.underscore.to_sym do
         after(:create) do |user|
-          user.roles << create("#{role}_role")
+          user.roles << create("#{role.parameterize.underscore}_role")
         end
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -76,17 +76,6 @@ FactoryBot.define do
       end
     end
 
-    # create(:user, :with_token, :with_multiple_roles_and_permissions, roles_and_permissions: { 'Order fulfilment' => ['can_login_to_stock', 'can_manage_packages']} )
-    trait :with_multiple_roles_and_permissions do
-      after(:create) do |user, evaluator|
-        evaluator.roles_and_permissions.each_pair do |role_name, permissions|
-          # create(:supervisor_role, :with_can_manage_packages_permission, :with_can_manage_messages_permission, ...)
-          perms = permissions.map{|permission| :"with_#{permission}_permission" }
-          user.roles << create(:"#{role_name.parameterize.underscore}_role", *perms)
-        end
-      end
-    end
-
     trait :stockit_user do
       first_name "Stockit"
       last_name "User"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 # USAGE:
 #   create(:user)
-#   create(:user, :order_administrator)       # TO BE DEPRECATED
+#   create(:user, :order_administrator)
 #   create(:user, :with_order_administrator_role)  # has the role but no permissions
 #   create(:user, :with_can_manage_packages_permission) # when you don't care which role the user gets (they'll get one)
 #   create(:user, :with_can_manage_packages_permission, role_name: "Supervisor") # can specify role if permission belongs to more than one
@@ -32,7 +32,6 @@ FactoryBot.define do
       roles_and_permissions { }
     end
 
-    # TO BE DEPRECATED
     # Role specific users. create(:user, :order_administrator)
     # No permissions are created
     FactoryBot.generate(:permissions_roles).keys.each do |role|

--- a/spec/lib/classes/resync_duplicate_users_spec.rb
+++ b/spec/lib/classes/resync_duplicate_users_spec.rb
@@ -61,7 +61,7 @@ describe ResyncDuplicateUsers do
     end
 
     it 'does not effect other than charity users' do
-      user = create(:user,:with_multiple_roles_and_permissions, email: 'test1@test.com', roles_and_permissions: {'Order administrator' => ['can_manage_order_messages']})
+      user = create(:user, :with_order_administrator_role, :with_can_manage_order_messages_permission, email: 'test1@test.com')
 
       user_2 = create(:user, :charity)
       user_2.update_column(:email, 'tEst1@test.com')

--- a/spec/models/abilities/contact_abilities_spec.rb
+++ b/spec/models/abilities/contact_abilities_spec.rb
@@ -7,7 +7,7 @@ describe "contact abilities" do
   let(:all_actions) { [:create, :destroy, :manage] }
 
   context "when Supervisor" do
-    let(:user)     { create(:user, :with_can_destroy_contact_permission, role_name: 'Supervisor') }
+    let(:user)     { create(:user, :with_can_destroy_contacts_permission, role_name: 'Supervisor') }
     let(:contact)  { create :contact }
     let(:can)      { [:create, :destroy] }
     let(:cannot)   { [:manage] }
@@ -16,7 +16,7 @@ describe "contact abilities" do
   end
 
   context "when Reviewer" do
-    let(:user)     { create(:user, :with_can_destroy_contact_permission, role_name: 'Reviewer') }
+    let(:user)     { create(:user, :with_can_destroy_contacts_permission, role_name: 'Reviewer') }
     let(:contact)  { create :contact }
     let(:can)      { [:create, :destroy] }
     let(:cannot)   { [:manage] }

--- a/spec/models/abilities/delivery_abilities_spec.rb
+++ b/spec/models/abilities/delivery_abilities_spec.rb
@@ -7,7 +7,7 @@ describe "Delivery abilities" do
   let(:all_actions) { [:index, :show, :create, :update, :destroy, :manage, :confirm_delivery] }
 
   context "when Supervisor" do
-    let(:user)     { create(:user, :with_can_manage_deliveries, role_name: 'Supervisor') }
+    let(:user)     { create(:user, :supervisor, :with_can_manage_deliveries_permission) }
     let(:delivery) { create :delivery }
     let(:can)      { [:index, :show, :create, :update, :destroy, :confirm_delivery] }
     let(:cannot)   { [:manage] }
@@ -16,7 +16,7 @@ describe "Delivery abilities" do
   end
 
   context "when Reviewer" do
-    let(:user)     { create(:user, :with_can_manage_deliveries, role_name: 'Reviewer') }
+    let(:user)     { create(:user, :with_can_manage_deliveries_permission, role_name: 'Reviewer') }
     let(:delivery) { create :delivery }
     let(:can)      { [:index, :show, :create, :update, :destroy, :confirm_delivery] }
     let(:cannot)   { [:manage] }

--- a/spec/models/abilities/message_abilities_spec.rb
+++ b/spec/models/abilities/message_abilities_spec.rb
@@ -9,13 +9,13 @@ describe 'Message abilities' do
   subject(:ability) { Ability.new(user) }
   let(:all_actions) { %i[index show create update destroy manage] }
   let(:sender)      { create :user }
-  let(:charity) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Charity' => ['can_login_to_browse']}) }
+  let(:charity) { create(:user, :with_charity_role, :with_can_login_to_browse_permission) }
   let(:is_private) { false }
   let(:offer) { create(:offer, created_by: user) }
   let(:message) { create :message, messageable: offer, is_private: is_private }
 
   context 'when Supervisor or Reviewer' do
-    let(:user) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Supervisor' => ['can_manage_offer_messages']}) }
+    let(:user) { create(:user, :with_supervisor_role, :with_can_manage_offer_messages_permission) }
 
     context 'and message is not is_private' do
       @can = %i[index show create]
@@ -160,7 +160,7 @@ describe 'Message abilities' do
   context 'Order Administrator/fulfilment' do
     let(:order) { create :order, created_by: charity }
     let(:message) { create :message, is_private: is_private, messageable: order }
-    let(:user) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Order administrator' => ['can_manage_order_messages']}) }
+    let(:user) { create(:user, :with_order_administrator_role, :with_can_manage_order_messages_permission) }
 
     @can = %i[index show create]
     @cannot = %i[update destroy manage]

--- a/spec/models/abilities/orders_packages_abilities_spec.rb
+++ b/spec/models/abilities/orders_packages_abilities_spec.rb
@@ -22,7 +22,7 @@ describe "OrdersPackage abilities" do
   end
 
   context "when api user" do
-    let(:user) { create(:user, :api_user) }
+    let(:user) { create(:user, :api_write) }
     it{ all_actions.each { |do_action| is_expected.to be_able_to(do_action, orders_package) } }
   end
 

--- a/spec/models/abilities/orders_process_checklists_abilities_spec.rb
+++ b/spec/models/abilities/orders_process_checklists_abilities_spec.rb
@@ -5,14 +5,14 @@ describe "OrdersProcessChecklist abilities" do
   subject(:ability) { Ability.new(user) }
 
   context "when Supervisor" do
-    let(:user) { create(:user, :supervisor, :with_can_access_orders_process_checklists) }
+    let(:user) { create(:user, :supervisor, :with_can_access_orders_process_checklists_permission) }
     let(:orders_process_checklist) { create :orders_process_checklist }
 
     it { is_expected.to be_able_to(:index, orders_process_checklist) }
   end
 
   context "when Reviewer" do
-    let(:user) { create(:user, :order_fulfilment, :with_can_access_orders_process_checklists) }
+    let(:user) { create(:user, :order_fulfilment, :with_can_access_orders_process_checklists_permission) }
     let(:orders_process_checklist) { create :orders_process_checklist }
 
     it { is_expected.to be_able_to(:index, orders_process_checklist) }

--- a/spec/models/abilities/package_abilities_spec.rb
+++ b/spec/models/abilities/package_abilities_spec.rb
@@ -66,8 +66,8 @@ describe "Package abilities" do
     it { limited_actions.each {|do_action| is_expected.to be_able_to(do_action, published_package)}}
   end
 
-  context "when api_user" do
-    let(:user) { create :user, :api_user }
+  context "when api_write" do
+    let(:user) { create :user, :api_write }
     it{  is_expected.to be_able_to(:create, package)  }
   end
 

--- a/spec/models/abilities/printer_abilities_spec.rb
+++ b/spec/models/abilities/printer_abilities_spec.rb
@@ -5,14 +5,14 @@ describe "Printer abilities" do
   subject(:ability) { Ability.new(user) }
 
   context "when Supervisor" do
-    let(:user) { create(:user, :supervisor, :with_can_access_printers) }
+    let(:user) { create(:user, :supervisor, :with_can_access_printers_permission) }
     let(:printer) { create :printer }
 
     it { is_expected.to be_able_to(:index, printer) }
   end
 
   context "when Reviewer" do
-    let(:user) { create(:user, :reviewer, :with_can_access_printers) }
+    let(:user) { create(:user, :reviewer, :with_can_access_printers_permission) }
     let(:printer) { create :printer }
 
     it { is_expected.to be_able_to(:index, printer) }

--- a/spec/models/abilities/user_abilities_spec.rb
+++ b/spec/models/abilities/user_abilities_spec.rb
@@ -7,7 +7,7 @@ describe "User abilities" do
   let(:all_actions) { %i[index show create update destroy manage current_user_profile can_read_or_modify_user] }
 
   context "when Supervisor" do
-    let(:user) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Supervisor' => ['can_mention_users', 'can_read_or_modify_user']}) }
+    let(:user) { create(:user, :with_supervisor_role, :with_can_mention_users_permission, :with_can_read_or_modify_user_permission) }
     let(:person) { create :user }
     let(:can)    { %i[create index show update current_user_profile mentionable_users] }
     let(:cannot) { %i[destroy manage] }
@@ -20,7 +20,7 @@ describe "User abilities" do
   end
 
   context "when Reviewer" do
-    let(:user) { create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Reviewer' => ['can_mention_users', 'can_read_or_modify_user']}) }
+    let(:user) { create(:user, :with_reviewer_role, :with_can_mention_users_permission, :with_can_read_or_modify_user_permission) }
     let(:person) { create :user }
     let(:can)    { %i[create index show update current_user_profile mentionable_users] }
     let(:cannot) { %i[destroy manage] }

--- a/spec/models/concerns/manage_user_roles_spec.rb
+++ b/spec/models/concerns/manage_user_roles_spec.rb
@@ -10,7 +10,7 @@ describe ManageUserRoles do
     let!(:reviewer_role) { create(:role, name: "Reviewer", level: 5) }
     let!(:supervisor_role) { create(:role, name: "Supervisor", level: 10) }
 
-    let!(:supervisor_user) { create(:user, :with_can_manage_user_roles, role_name: 'Supervisor') }
+    let!(:supervisor_user) { create(:user, :with_can_manage_user_roles_permission, role_name: 'Supervisor') }
     let!(:system_administrator) { create(:user, :system_administrator) }
     let!(:reviewer_user) { create(:user, :reviewer) }
     let!(:order_fulfilment_user) { create :user, :order_fulfilment }

--- a/spec/models/concerns/message_subscriptions_spec.rb
+++ b/spec/models/concerns/message_subscriptions_spec.rb
@@ -205,7 +205,7 @@ module Messages
         end
 
         context "should subscribe all users with permission '' if it's the first private message of the thread" do
-          let!(:order_fulfilment_user) { create :user, :with_order_fulfilment_role, :with_can_manage_order_messages }
+          let!(:order_fulfilment_user) { create :user, :with_order_fulfilment_role, :with_can_manage_order_messages_permission }
           let!(:order_administrator_user) { create :user, :with_order_administrator_role, :with_can_manage_order_messages_permission }
 
           before { User.current_user = order_fulfilment_user }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Order, type: :model do
   describe '.my_orders' do
     let(:user) { create :user, :charity, :with_can_manage_orders_permission }
     let(:supervisor) { create :user, :supervisor, :with_can_manage_orders_permission }
-    let(:authorised_by_user) { create(:user_with_token, :with_multiple_roles_and_permissions,
+    let(:authorised_by_user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
 
     ALL_ORDER_STATES.each do |state|
@@ -236,10 +236,10 @@ RSpec.describe Order, type: :model do
   end
 
   describe '.recently_used' do
-    let!(:user) { create(:user_with_token, :with_multiple_roles_and_permissions,
+    let!(:user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
 
-    let!(:user1) { create(:user_with_token, :with_multiple_roles_and_permissions,
+    let!(:user1) { create(:user, :with_token, :with_multiple_roles_and_permissions,
     roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
     let(:package1) { create(:package, :with_inventory_record)}
     let!(:order1) { create :order, :with_orders_packages, :with_state_submitted, created_by_id: user.id, submitted_by_id: user.id, status: nil, updated_at: Time.now }
@@ -944,7 +944,7 @@ RSpec.describe Order, type: :model do
 
   describe "Live updates" do
     let(:push_service) { PushService.new }
-    let(:charity_user) { create(:user_with_token, :with_multiple_roles_and_permissions,
+    let(:charity_user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
       roles_and_permissions: { 'Charity' => ['can_login_to_browse']}) }
 
     before(:each) do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -120,8 +120,7 @@ RSpec.describe Order, type: :model do
   describe '.my_orders' do
     let(:user) { create :user, :charity, :with_can_manage_orders_permission }
     let(:supervisor) { create :user, :supervisor, :with_can_manage_orders_permission }
-    let(:authorised_by_user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
+    let(:authorised_by_user) { create(:user, :with_token, :with_supervisor_role, :with_can_manage_orders_permission) }
 
     ALL_ORDER_STATES.each do |state|
       let(:"authorised_#{state}_order") { create :order, :"with_state_#{state}", created_by: user, submitted_by_id:  supervisor.id }
@@ -236,11 +235,9 @@ RSpec.describe Order, type: :model do
   end
 
   describe '.recently_used' do
-    let!(:user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
+    let!(:user) { create(:user, :with_token, :with_supervisor_role, :with_can_manage_orders_permission) }
 
-    let!(:user1) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-    roles_and_permissions: { 'Supervisor' => ['can_manage_orders']} )}
+    let!(:user1) { create(:user, :with_token, :with_supervisor_role, :with_can_manage_orders_permission) }
     let(:package1) { create(:package, :with_inventory_record)}
     let!(:order1) { create :order, :with_orders_packages, :with_state_submitted, created_by_id: user.id, submitted_by_id: user.id, status: nil, updated_at: Time.now }
     let!(:version1) {order1.versions.first.update(whodunnit: order1.created_by_id)}
@@ -944,8 +941,7 @@ RSpec.describe Order, type: :model do
 
   describe "Live updates" do
     let(:push_service) { PushService.new }
-    let(:charity_user) { create(:user, :with_token, :with_multiple_roles_and_permissions,
-      roles_and_permissions: { 'Charity' => ['can_login_to_browse']}) }
+    let(:charity_user) { create(:user, :with_token, :with_charity_role, :with_can_login_to_browse_permission) }
 
     before(:each) do
       allow(PushService).to receive(:new).and_return(push_service)

--- a/spec/models/stocktake_spec.rb
+++ b/spec/models/stocktake_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Stocktake, type: :model do
 
       stocktake.reload
 
-      expect(stocktake.revisions.map(&:package_id)).to eq(packages.map(&:id))
+      expect(stocktake.revisions.map(&:package_id)).to match_array(packages.map(&:id))
       expect(stocktake.revisions.map(&:dirty).uniq).to eq([true])
       expect(stocktake.revisions.map(&:quantity).uniq).to eq([0])
       expect(stocktake.revisions.map(&:state).uniq).to eq(['pending'])
@@ -48,9 +48,9 @@ RSpec.describe Stocktake, type: :model do
 
       stocktake.reload
 
-      expect(stocktake.revisions.map(&:package_id)).to eq(packages.map(&:id))
+      expect(stocktake.revisions.map(&:package_id)).to match_array(packages.map(&:id))
       expect(stocktake.revisions.map(&:dirty).uniq).to eq([false, true])
-      expect(stocktake.revisions.map(&:quantity).uniq).to eq([5, 0])
+      expect(stocktake.revisions.map(&:quantity).uniq).to match_array([5, 0])
       expect(stocktake.revisions.map(&:state).uniq).to eq(['processed', 'pending'])
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,29 +4,12 @@ describe User, :type => :model do
   let!(:mobile) { generate(:mobile) }
   let(:address_attributes) { {"district_id" => "9", "address_type" => "profile"} }
   let(:user_attributes) { FactoryBot.attributes_for(:user).merge("mobile" => mobile, "address_attributes" => address_attributes).stringify_keys }
-  let(:supervisor) {
-    create(:user, :with_multiple_roles_and_permissions,
-           roles_and_permissions: {"Supervisor" => ["can_login_to_stock", "can_login_to_admin"]})
-  }
-  let(:order_fulfilment_user) {
-    create(:user, :with_multiple_roles_and_permissions,
-           roles_and_permissions: {"Order fulfilment" => ["can_login_to_stock"]})
-  }
-  let(:reviewer) {
-    create(:user, :with_multiple_roles_and_permissions,
-           roles_and_permissions: {"Reviewer" => ["can_login_to_admin"]})
-  }
-  let(:charity) {
-    create(:user, :with_multiple_roles_and_permissions,
-           roles_and_permissions: {"Charity" => ["can_login_to_browse"]})
-  }
+  let(:supervisor) { create(:user, :with_supervisor_role, :with_can_login_to_stock_permission, :with_can_login_to_admin_permission) }
+  let(:order_fulfilment_user) { create(:user, :with_order_fulfilment_role, :with_can_login_to_stock_permission) }
+  let(:reviewer) { create(:user, :with_reviewer_role, :with_can_login_to_admin_permission) }
+  let(:charity) { create(:user, :with_charity_role, :with_can_login_to_browse_permission) }
 
-  let(:charity_users) {
-    (1..5).map {
-      create(:user, :with_multiple_roles_and_permissions,
-             roles_and_permissions: {"Charity" => ["can_login_to_browse"]})
-    }
-  }
+  let(:charity_users) { (1..5).map { create(:user, :with_charity_role, :with_can_login_to_browse_permission) } }
 
   let(:invalid_user_attributes) { {"mobile" => "85211111112", "first_name" => "John2", "last_name" => "Dey2"} }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,7 +58,14 @@ RSpec.configure do |config|
   # Apipie can record examples using "APIPIE_RECORD=examples rake"
   config.filter_run :show_in_doc => true if ENV['APIPIE_RECORD']
 
-  FactoryBot.create :user, :system
+  # Create a system_user at beginning of specs
+  config.before(:all) do
+    FactoryBot.create(:user, :system)
+  end
+  # Clean up system_user at end of specs
+  config.after(:all) do
+    User.system.destroy_all
+  end
 
   # Default app to be 'admin' in order to not use treat_user_as_donor
   config.include ApplicationHeaders

--- a/spec/serializers/api/v1/user_serializer_spec.rb
+++ b/spec/serializers/api/v1/user_serializer_spec.rb
@@ -7,7 +7,7 @@ describe Api::V1::OfferSerializer do
   let(:donor_serializer) { Api::V1::UserSerializer.new(donor).as_json }
   let(:donor_json) { JSON.parse(donor_serializer.to_json) }
   let(:admin) { create(:user, :reviewer) }
-  let(:charity_user) { create(:user, :charity, :title) }
+  let(:charity_user) { create(:user, :charity) }
 
   context "Donor" do
     before { User.current_user = donor }

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -4,7 +4,7 @@ describe TwilioService do
 
   let(:mobile) { generate(:mobile) }
   let(:user)   { create :user, mobile: mobile }
-  let(:user_with_no_mobile) { create :user, :user_with_no_mobile, request_from_browse: true }
+  let(:user_with_no_mobile) { create :user, mobile: nil, request_from_browse: true }
   let(:twilio) { TwilioService.new(user) }
   let(:twilio_with_no_mobile_user) {  TwilioService.new(user_with_no_mobile) }
 

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -8,7 +8,7 @@ module ControllerMacros
 
   # Creates a token and sets the request header effectively logging the user in
   def generate_and_set_token(user=nil)
-    user ||= create(:user_with_token)
+    user ||= create(:user, :with_token)
     User.current_user = user
     current_time = Time.now
     jwt_config = Rails.application.secrets.jwt


### PR DESCRIPTION
### What does this PR do?

FEATURE: Ensures all permissions and roles defined in `db/permissions_roles.yml` are automatically available as traits in the User factory using the pattern `create(:user, :with_<role_name>_role, :with_<permission_name>_permission)`

If new roles or permissions are added to `db/permissions_roles.yml` then they are immediately available for use in factories.

Previously, we did

`create(:user, :with_multiple_roles_and_permissions, roles_and_permissions: {'Order administrator' => ['can_mention_users']})`

This can now be replaced with:

`create(:user, :with_order_administrator_role, :with_can_mention_users_permission)`

### Full Syntax & Examples

```
create(:user)
create(:user, :with_order_administrator_role)  # has the role but no permissions
create(:user, :with_can_manage_packages_permission) # when you don't care which role the user gets (they'll get one)
create(:user, :with_can_manage_packages_permission, role_name: "Supervisor") # can specify role if permission belongs to more than one
create(:user, :with_supervisor_role, :with_can_manage_packages_permission) # alternative way to specify role

# You MUST specify role_name when using more than one permission to avoid getting permissions with mixed roles:
create(:user, :with_can_manage_packages_permission, :with_can_manage_offers_permission, role_name: "Supervisor")
create(:user, :with_supervisor_role, :with_can_manage_packages_permission, :with_can_manage_offers_permission)
```