### PR TITLE
GCW-3215 Add case insensitivity check while creating organisation users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
   has_many :used_locations, -> { order "packages.stockit_moved_on DESC" }, class_name: "Location", through: :moved_packages, source: :location
   has_many :created_orders, -> { order "id DESC" }, class_name: "Order", foreign_key: :created_by_id
 
-  before_save :downcase_email
+  before_validation :downcase_email
 
   accepts_nested_attributes_for :address, allow_destroy: true
 

--- a/lib/classes/organisations_user_builder.rb
+++ b/lib/classes/organisations_user_builder.rb
@@ -40,7 +40,7 @@ class OrganisationsUserBuilder
   end
 
   def build_user
-    @user = User.where("email = (?) OR mobile = (?)", @email, @mobile).first_or_initialize(@user_attributes)
+    @user = User.where("lower(email) = (?) OR mobile = (?)", @email.downcase, @mobile).first_or_initialize(@user_attributes)
     assign_user_app_acessor
     @user.save
     @user

--- a/lib/classes/organisations_user_builder.rb
+++ b/lib/classes/organisations_user_builder.rb
@@ -40,7 +40,7 @@ class OrganisationsUserBuilder
   end
 
   def build_user
-    @user = User.where("lower(email) = (?) OR mobile = (?)", @email.downcase, @mobile).first_or_initialize(@user_attributes)
+    @user = User.where("lower(email) = (?) OR mobile = (?)", @email&.downcase, @mobile).first_or_initialize(@user_attributes)
     assign_user_app_acessor
     @user.save
     @user

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -76,6 +76,32 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(response.status).to eq(422)
       expect(subject["errors"]).to eq([{"message" => "User already exists in this organisation", "status" => 422}])
     end
+
+    context 'when an existing user already exists with same email' do
+      it 'does not create organisation_user for duplicate email' do
+        organisations_user = create :organisations_user
+        new_organisations_user_params[:organisation_id] = organisations_user.organisation_id.to_s
+        new_organisations_user_params[:user_attributes][:email] = organisations_user.user.email
+        expect {
+          post :create, format: :json, organisations_user: new_organisations_user_params
+        }.to change(OrganisationsUser, :count).by(0)
+         .and change(User, :count).by(0)
+        expect(response.status).to eq(422)
+        expect(subject['errors']).to eq([{'message' => 'User already exists in this organisation', 'status' => 422}])
+      end
+
+      it 'does not create organisation_user for case insensitive duplicate email' do
+        organisations_user = create :organisations_user
+        new_organisations_user_params[:organisation_id] = organisations_user.organisation_id.to_s
+        new_organisations_user_params[:user_attributes][:email] = organisations_user.user.email.upcase
+        expect {
+          post :create, format: :json, organisations_user: new_organisations_user_params
+        }.to change(OrganisationsUser, :count).by(0)
+         .and change(User, :count).by(0)
+        expect(response.status).to eq(422)
+        expect(subject['errors']).to eq([{'message' => 'User already exists in this organisation', 'status' => 422}])
+      end
+    end
   end
 
   describe "PUT organisations_user/1" do


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3215

### What does this PR do?
Fix the error when
- User already exists, create another charity user from stock app. The login of that particular user will result in an exception "User already exists"