### PR TITLE
GCW-3209 Add processed_delta to stocktake_revisions

### DIFF
--- a/app/serializers/api/v1/stocktake_revision_serializer.rb
+++ b/app/serializers/api/v1/stocktake_revision_serializer.rb
@@ -5,7 +5,7 @@ module Api
 
       has_one :package, serializer: PackageSerializer
       
-      attributes :id, :stocktake_id, :package_id, :warning, :state, :quantity, :dirty, :created_at, :updated_at
+      attributes :id, :stocktake_id, :package_id, :warning, :state, :quantity, :dirty, :processed_delta, :created_at, :updated_at
     end
   end
 end

--- a/db/migrate/20200731075059_add_delta_to_stocktake_revision.rb
+++ b/db/migrate/20200731075059_add_delta_to_stocktake_revision.rb
@@ -1,0 +1,5 @@
+class AddDeltaToStocktakeRevision < ActiveRecord::Migration
+  def change
+    add_column :stocktake_revisions, :processed_delta, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200630031605) do
+ActiveRecord::Schema.define(version: 20200731075059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -912,15 +912,16 @@ ActiveRecord::Schema.define(version: 20200630031605) do
   add_index "stockit_organisations", ["name"], name: "st_organisations_name_idx", using: :gin
 
   create_table "stocktake_revisions", force: :cascade do |t|
-    t.integer  "stocktake_id",                      null: false
-    t.integer  "package_id",                        null: false
-    t.integer  "quantity",      default: 0,         null: false
-    t.string   "state",         default: "pending", null: false
-    t.boolean  "dirty",         default: false,     null: false
+    t.integer  "stocktake_id",                        null: false
+    t.integer  "package_id",                          null: false
+    t.integer  "quantity",        default: 0,         null: false
+    t.string   "state",           default: "pending", null: false
+    t.boolean  "dirty",           default: false,     null: false
     t.string   "warning"
     t.integer  "created_by_id"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.integer  "processed_delta", default: 0
   end
 
   add_index "stocktake_revisions", ["package_id", "stocktake_id"], name: "index_stocktake_revisions_on_package_id_and_stocktake_id", unique: true, using: :btree

--- a/spec/models/concerns/stocktake_processor_spec.rb
+++ b/spec/models/concerns/stocktake_processor_spec.rb
@@ -29,6 +29,14 @@ context StocktakeProcessor do
       expect(changed_ids).to match_array([package_1.id, package_2.id])
     end
 
+    it 'updates the processed_delta with the recorded difference' do      
+      expect { 
+        subject.process_stocktake(stocktake);
+      }.to change {
+        stocktake.reload.revisions.map(&:processed_delta)
+      }.from([0,0,0]).to([2,-2,0])
+    end
+
     it 'records a gain to account for positive differences' do
       errors = subject.process_stocktake(stocktake);
 

--- a/spec/models/stocktake_revision_spec.rb
+++ b/spec/models/stocktake_revision_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe StocktakeRevision, type: :model do
     it { is_expected.to have_db_column(:state).of_type(:string) }
     it { is_expected.to have_db_column(:quantity).of_type(:integer) }
     it { is_expected.to have_db_column(:dirty).of_type(:boolean) }
+    it { is_expected.to have_db_column(:processed_delta).of_type(:integer) }
   end
 
   describe "Validations" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3209

### What does this PR do?

When a stocktake revision is processed, we save the difference under the `processed_delta` column. That is used to view the changes that occurred in the past