### PR TITLE
GCW-3169 Update Message Default Scope

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -50,12 +50,7 @@ module Api
       param_group :message
       def create
         @message.sender_id = current_user.id
-
-        if @message.save
-          render json: serializer.new(@message).as_json, status: 201
-        else
-          render json: @message.errors, status: 422
-        end
+        save_and_render_object(@message)
       end
 
       api :PUT, "/v1/messages/:id/mark_read", "Mark message as read"

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -50,7 +50,12 @@ module Api
       param_group :message
       def create
         @message.sender_id = current_user.id
-        save_and_render_object(@message)
+
+        if @message.save
+          render json: serializer.new(@message).as_json, status: 201
+        else
+          render json: @message.errors, status: 422
+        end
       end
 
       api :PUT, "/v1/messages/:id/mark_read", "Mark message as read"

--- a/app/models/concerns/message_subscriptions.rb
+++ b/app/models/concerns/message_subscriptions.rb
@@ -72,13 +72,13 @@ module MessageSubscriptions
   end
 
   # A private subscriber is defined as :
-  #   > A supervisor or reviewer who has answered the private thread
+  #   > An admin/stock app user who has answered the private thread
   def private_subscribers_to(obj)
-    User.staff
-        .joins(messages: [:subscriptions])
+    User.joins("INNER JOIN messages ON messages.sender_id = users.id AND messages.deleted_at IS NULL")
+        .joins("INNER JOIN subscriptions ON subscriptions.message_id = messages.id")
         .where(messages: { is_private: true })
         .where(subscriptions: { subscribable: obj })
-        .pluck(:id)
+        .pluck(:id).uniq
   end
 
   def first_message?

--- a/app/models/concerns/message_subscriptions.rb
+++ b/app/models/concerns/message_subscriptions.rb
@@ -74,8 +74,7 @@ module MessageSubscriptions
   # A private subscriber is defined as :
   #   > An admin/stock app user who has answered the private thread
   def private_subscribers_to(obj)
-    User.joins("INNER JOIN messages ON messages.sender_id = users.id AND messages.deleted_at IS NULL")
-        .joins("INNER JOIN subscriptions ON subscriptions.message_id = messages.id")
+    User.joins(messages: [:subscriptions])
         .where(messages: { is_private: true })
         .where(subscriptions: { subscribable: obj })
         .pluck(:id).uniq

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,8 +16,8 @@ class Message < ActiveRecord::Base
   validates :body, presence: true
 
   default_scope do
-    unless User.current_user.try(:staff?)
-      where("is_private = 'f'")
+    unless User.current_user.try(:can_manage_private_messages?)
+      where(is_private: false)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,6 +178,11 @@ class User < ActiveRecord::Base
     User.current_user.id != id&.to_i
   end
 
+  def can_manage_private_messages?
+    (user_permissions_names &
+    ["can_manage_offer_messages", "can_manage_order_messages", "can_manage_package_messages"]).any?
+  end
+
   def admin?
     administrator?
   end

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -56,32 +56,32 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
       end
 
       it "for one offer" do
-        3.times { create :subscription, state: 'unread', subscribable: offer, user: user, message: (create :message, messageable: offer, is_private: false) }
+        3.times { create :subscription, state: 'unread', subscribable: offer, user: user, message: (create :message, messageable: offer) }
 
         get :index, offer_id: offer.id
         expect(subject['messages'].length).to eq(3)
       end
 
       it "for multiple offers" do
-        3.times { create :subscription, state: 'unread', subscribable: offer, user: user, message: (create :message, messageable: offer, is_private: false) }
+        3.times { create :subscription, state: 'unread', subscribable: offer, user: user, message: (create :message, messageable: offer) }
 
-        3.times { create :subscription, state: 'unread', subscribable: offer2, user: user, message: (create :message, messageable: offer2, is_private: false) }
+        3.times { create :subscription, state: 'unread', subscribable: offer2, user: user, message: (create :message, messageable: offer2) }
         get :index, offer_id: "#{offer.id},#{offer2.id}"
         expect(subject['messages'].length).to eq(6)
       end
 
       it "for one order" do
-        3.times { create :subscription, state: 'unread', subscribable: order, user: user, message: (create :message, messageable: order, is_private: false) }
+        3.times { create :subscription, state: 'unread', subscribable: order, user: user, message: (create :message, messageable: order) }
 
-        3.times { create :subscription, state: 'unread', subscribable: order2, user: user, message: (create :message, messageable: order2, is_private: false) }
+        3.times { create :subscription, state: 'unread', subscribable: order2, user: user, message: (create :message, messageable: order2) }
         get :index, order_id: order.id
         expect(subject['messages'].length).to eq(3)
       end
 
       it "for multiple orders" do
-        3.times { create :subscription, state: 'unread', subscribable: order, user: user, message: (create :message, messageable: order, is_private: false) }
+        3.times { create :subscription, state: 'unread', subscribable: order, user: user, message: (create :message, messageable: order) }
 
-        3.times { create :subscription, state: "unread", subscribable: order2, user: user, message: (create :message, messageable: order2, is_private: false) }
+        3.times { create :subscription, state: "unread", subscribable: order2, user: user, message: (create :message, messageable: order2) }
         get :index, order_id: "#{order.id},#{order2.id}"
         expect(subject['messages'].length).to eq(6)
       end
@@ -180,6 +180,22 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
           expect(subject['message']['order_id']).to eq(order.id)
         }.to change { Message.count }
       end
+    end
+  end
+
+  describe 'create package message' do
+    let(:stock_user) { create(:user_with_token, :with_can_manage_private_messages, :with_can_manage_package_messages) }
+    let(:message_params) {
+      FactoryBot.attributes_for(:message, :private, sender: user.id, messageable_id: (create :package).id, messageable_type: "Package")
+    }
+
+    before do
+      generate_and_set_token(stock_user)
+    end
+
+    it 'from stock admin user' do
+      post :create, message: message_params
+      expect(response.status).to eq(201)
     end
   end
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -86,7 +86,7 @@ describe Message, type: :model do
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it "should not allow donor to access private messages" do
+    it "should allow reviewer to access private messages" do
       User.current_user = reviewer
       expect(Message.all).to include(private_message)
     end


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3169

### What does this PR do?
Update Message Default Scope, to allow users to access private messages who has message related permission (any one from ["can_manage_offer_messages", "can_manage_order_messages", "can_manage_package_messages"])