### PR TITLE
GCW-3246 Wrong error message on creating user with new email and existing phone number

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,8 @@ en:
         blank: "Mobile can't be blank"
     existing_user:
       present: "User already exists in this organisation"
+    invalid:
+      user: The email or mobile already exists.
   appointment_slots:
     already_exists: "An appointment slot already exists for this time"
   operations:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -122,6 +122,8 @@ zh-tw:
         blank: "Mobile can't be blank"
     existing_user:
       present: "User already exists in this organisation"
+    invalid:
+      user: The email or mobile already exists.
   appointment_slots:
     already_exists: "An appointment slot already exists for this time"
   operations:

--- a/lib/classes/organisations_user_builder.rb
+++ b/lib/classes/organisations_user_builder.rb
@@ -27,7 +27,7 @@ class OrganisationsUserBuilder
 
   def build
     users = User.where("lower(email) = (?) OR mobile = (?)", @email&.downcase, @mobile)
-    return fail_with_error(I18n.t('organisations_user_builder.invalid.user')) unless users.count <= 1
+    return fail_with_error(I18n.t('organisations_user_builder.invalid.user')) if users.count > 1
 
     @user = build_user(users)
     return fail_with_error(@user.errors) unless @user.valid?

--- a/lib/classes/organisations_user_builder.rb
+++ b/lib/classes/organisations_user_builder.rb
@@ -32,14 +32,19 @@ class OrganisationsUserBuilder
     @user = build_user(users)
     return fail_with_error(@user.errors) unless @user.valid?
     return fail_with_error(I18n.t("organisations_user_builder.organisation.not_found")) unless organisation
-    if !user_belongs_to_organisation(@user)
-      @organisations_user = @user.organisations_users.new(organisation_id: @organisation_id, position: @position, preferred_contact_number: @preferred_contact_number)
-      TwilioService.new(@user).send_welcome_msg
-      return fail_with_error(update_user["errors"]) if update_user && update_user["errors"]
-      return_success.merge!("organisations_user" => @organisations_user)
-    else
-      return fail_with_error(I18n.t("organisations_user_builder.existing_user.present"))
-    end
+
+    return fail_with_error(I18n.t('organisations_user_builder.existing_user.present')) if user_belongs_to_organisation(@user)
+
+    @organisations_user = build_organisations_user
+    return_success.merge!("organisations_user" => @organisations_user)
+  end
+
+  def build_organisations_user
+    @organisations_user = @user.organisations_users.new(organisation_id: @organisation_id, position: @position, preferred_contact_number: @preferred_contact_number)
+    TwilioService.new(@user).send_welcome_msg
+    return fail_with_error(update_user["errors"]) if update_user && update_user["errors"]
+
+    @organisations_user
   end
 
   def build_user(obj)

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       end
     end
 
-    context 'when an existing user already exists with same email' do
+    context 'when a user is already present for a particular email' do
       it 'does not create a new organisation_user for existing email' do
         organisations_user = create :organisations_user
         user = create(:user)
@@ -107,7 +107,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       end
     end
 
-    context 'when an existing user already exists with same email' do
+    context 'when a user is already present in the organisation' do
       it 'does not create organisation_user for duplicate email' do
         organisations_user = create :organisations_user
         new_organisations_user_params[:organisation_id] = organisations_user.organisation_id.to_s

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -77,6 +77,36 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       expect(subject["errors"]).to eq([{"message" => I18n.t("organisations_user_builder.existing_user.present"), "status" => 422}])
     end
 
+    context 'when a user is already present for a particular mobile number' do
+      it 'does not create a new organisation_user for existing mobile number' do
+        organisations_user = create :organisations_user
+        user = create(:user, mobile: '+85264522773')
+        new_organisations_user_params[:user_attributes][:email] = organisations_user.user.email
+        new_organisations_user_params[:user_attributes][:mobile] = user.mobile
+        expect {
+          post :create, format: :json, organisations_user: new_organisations_user_params
+        }.to change(OrganisationsUser, :count).by(0)
+         .and change(User, :count).by(0)
+        expect(response.status).to eq(422)
+        expect(subject['errors']).to eq([{'message' => I18n.t('organisations_user_builder.invalid.user'), 'status' => 422}])
+      end
+    end
+
+    context 'when an existing user already exists with same email' do
+      it 'does not create a new organisation_user for existing email' do
+        organisations_user = create :organisations_user
+        user = create(:user)
+        new_organisations_user_params[:user_attributes][:email] = user.email
+        new_organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
+        expect {
+          post :create, format: :json, organisations_user: new_organisations_user_params
+        }.to change(OrganisationsUser, :count).by(0)
+         .and change(User, :count).by(0)
+        expect(response.status).to eq(422)
+        expect(subject['errors']).to eq([{'message' => I18n.t('organisations_user_builder.invalid.user'), 'status' => 422}])
+      end
+    end
+
     context 'when an existing user already exists with same email' do
       it 'does not create organisation_user for duplicate email' do
         organisations_user = create :organisations_user
@@ -93,41 +123,13 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
       it 'does not create organisation_user for case insensitive duplicate email' do
         organisations_user = create :organisations_user
         new_organisations_user_params[:organisation_id] = organisations_user.organisation_id.to_s
-        new_organisations_user_params[:user_attributes][:email] = organisations_user.user.email
+        new_organisations_user_params[:user_attributes][:email] = organisations_user.user.email.upcase
         expect {
           post :create, format: :json, organisations_user: new_organisations_user_params
         }.to change(OrganisationsUser, :count).by(0)
          .and change(User, :count).by(0)
         expect(response.status).to eq(422)
         expect(subject['errors']).to eq([{'message' => I18n.t("organisations_user_builder.existing_user.present"), 'status' => 422}])
-      end
-
-      it 'does not create organisation_user for duplicate mobile' do
-        organisations_user = create :organisations_user
-        user = create(:user, mobile: '+85264522773')
-        new_organisations_user_params[:user_attributes][:email] = organisations_user.user.email
-        new_organisations_user_params[:user_attributes][:mobile] = user.mobile
-        expect {
-          post :create, format: :json, organisations_user: new_organisations_user_params
-        }.to change(OrganisationsUser, :count).by(0)
-         .and change(User, :count).by(0)
-        expect(response.status).to eq(422)
-        expect(subject['errors']).to eq([{'message' => I18n.t('organisations_user_builder.invalid.user'), 'status' => 422}])
-      end
-    end
-
-    context 'when an existing user already exists with same mobile number' do
-      it 'does not create organisation_user for duplicate email' do
-        organisations_user = create :organisations_user
-        user = create(:user)
-        new_organisations_user_params[:user_attributes][:email] = user.email
-        new_organisations_user_params[:user_attributes][:mobile] = organisations_user.user.mobile
-        expect {
-          post :create, format: :json, organisations_user: new_organisations_user_params
-        }.to change(OrganisationsUser, :count).by(0)
-         .and change(User, :count).by(0)
-        expect(response.status).to eq(422)
-        expect(subject['errors']).to eq([{'message' => I18n.t('organisations_user_builder.invalid.user'), 'status' => 422}])
       end
     end
   end

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
         post :create, format: :json, organisations_user: new_organisations_user_params
       }.to change(OrganisationsUser, :count).by(0)
       expect(response.status).to eq(422)
-      expect(subject["errors"]).to eq([{"message" => "User already exists in this organisation", "status" => 422}])
+      expect(subject["errors"]).to eq([{"message" => I18n.t("organisations_user_builder.existing_user.present"), "status" => 422}])
     end
 
     context 'when an existing user already exists with same email' do
@@ -87,7 +87,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
         }.to change(OrganisationsUser, :count).by(0)
          .and change(User, :count).by(0)
         expect(response.status).to eq(422)
-        expect(subject['errors']).to eq([{'message' => 'User already exists in this organisation', 'status' => 422}])
+        expect(subject['errors']).to eq([{'message' => I18n.t("organisations_user_builder.existing_user.present"), 'status' => 422}])
       end
 
       it 'does not create organisation_user for case insensitive duplicate email' do
@@ -99,7 +99,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
         }.to change(OrganisationsUser, :count).by(0)
          .and change(User, :count).by(0)
         expect(response.status).to eq(422)
-        expect(subject['errors']).to eq([{'message' => 'User already exists in this organisation', 'status' => 422}])
+        expect(subject['errors']).to eq([{'message' => I18n.t("organisations_user_builder.existing_user.present"), 'status' => 422}])
       end
 
       it 'does not create organisation_user for duplicate mobile' do
@@ -112,7 +112,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
         }.to change(OrganisationsUser, :count).by(0)
          .and change(User, :count).by(0)
         expect(response.status).to eq(422)
-        expect(subject['errors']).to eq([{'message' => 'User already exists in this organisation', 'status' => 422}])
+        expect(subject['errors']).to eq([{'message' => I18n.t('organisations_user_builder.invalid.user'), 'status' => 422}])
       end
     end
 
@@ -127,7 +127,7 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
         }.to change(OrganisationsUser, :count).by(0)
          .and change(User, :count).by(0)
         expect(response.status).to eq(422)
-        expect(subject['errors']).to eq([{'message' => 'User already exists in this organisation', 'status' => 422}])
+        expect(subject['errors']).to eq([{'message' => I18n.t('organisations_user_builder.invalid.user'), 'status' => 422}])
       end
     end
   end


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3246

### What does this PR do?
On Charities, If an existing mobile number is entered on the Account Details page, an incorrect message appears: "Email has already been taken". This will handle the scenario.