### PR TITLE
GCW-3249 avoid sending set packages in package-serializer response

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -54,6 +54,7 @@ module Api
           include_orders_packages: is_stock_app?,
           include_packages_locations: is_stock_app?,
           is_browse_app: is_browse_app?,
+          exclude_set_packages: true,
           include_package_set: bool_param(:include_package_set, false)
       end
 

--- a/app/serializers/api/v1/package_set_serializer.rb
+++ b/app/serializers/api/v1/package_set_serializer.rb
@@ -6,6 +6,10 @@ module Api::V1
 
     has_many :packages, serializer: PackageSerializer, include_package_set: false
 
+    def include_packages?
+      !@options[:exclude_set_packages]
+    end
+
     class StockFormat < PackageSetSerializer
       has_many :packages, serializer: StockitItemSerializer, include_images: true, include_package_set: false, root: :items
     end


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3249

### What does this PR do?
In package serializer, when package-sets are passed in response, avoid passing packages again (to fix issue of sending non-published packages.) 