### PR TITLE
GCW-3209 FIX: Stocktake controller ignores comments

### DIFF
--- a/app/controllers/api/v1/stocktakes_controller.rb
+++ b/app/controllers/api/v1/stocktakes_controller.rb
@@ -61,7 +61,7 @@ module Api
       private
 
       def stocktake_params
-        attributes = [:location_id, :name]
+        attributes = [:location_id, :name, :comment]
         { state: 'open' }.merge(
           params.require(:stocktake).permit(attributes)
         )

--- a/spec/controllers/api/v1/stocktakes_controller_spec.rb
+++ b/spec/controllers/api/v1/stocktakes_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Api::V1::StocktakesController, type: :controller do
     let(:other_packages) { (1..3).map { create(:package, received_quantity: 10) } }
 
     let(:payload) {
-      { location_id: location.id, name: 'lorem stocktake', state: 'open' }
+      { location_id: location.id, name: 'lorem stocktake', state: 'open', comment: 'Comment' }
     }
 
     before { initialize_inventory(other_packages, location: other_location) }
@@ -104,6 +104,7 @@ RSpec.describe Api::V1::StocktakesController, type: :controller do
 
         expect(parsed_body["stocktake"]["location_id"]).to eq(payload[:location_id])
         expect(parsed_body["stocktake"]["name"]).to eq(payload[:name])
+        expect(parsed_body["stocktake"]["comment"]).to eq(payload[:comment])
         expect(parsed_body["stocktake"]["state"]).to eq("open")
       end
 


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3209

### What does this PR do?

`:comment` was missing from the controller's allowed params. Which would cause the comment not to be saved

### Impacted Areas

Stocktake creation and listing
