### PR TITLE
Fix case where messages were not merged to new offer.

### DIFF
--- a/lib/goodcity/offer_utils.rb
+++ b/lib/goodcity/offer_utils.rb
@@ -37,7 +37,7 @@ module Goodcity
               package.update(offer_id: offer.id)
             end
             item.messages.each do |message|
-              message.update(offer_id: offer.id)
+              message.update(messageable_id: offer.id)
             end
           end
           Version.where(related_type: "Offer").where(related_id: other_offer.id).each do |version|


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3239

### What does this PR do?

BUG: It was not possible to merge offers when the offer to be merged contained messages.

This broke when we introduced polymorphism to messages and forgot to update the `offer_id` to `messageable_id`

### Impacted Areas

Admin app: Offer -> "Merge into"
