### PR TITLE
Lock Push Updates

### DIFF
--- a/app/services/push_service.rb
+++ b/app/services/push_service.rb
@@ -1,5 +1,15 @@
 class PushService
+  @@locked = false
+
+  def self.locked
+    @@locked = true
+    yield
+    @@locked = false
+  end
+
   def send_update_store(channels, data)
+    return if @@locked
+
     channels = [channels].flatten.uniq
     payload = default_payload.merge(data)
     if channels.any?
@@ -8,6 +18,8 @@ class PushService
   end
 
   def send_notification(channels, app_name, data)
+    return if @@locked
+
     data[:message] = ActionView::Base.full_sanitizer.sanitize(data[:message])
     data[:date] = Time.now.to_json.tr('"','')
     channels = [channels].flatten.uniq


### PR DESCRIPTION
Provide a way to lock push_updates and prevent them from being processed.

## Background

In some maintenance scripts, we are doing bulk updates and do not wish to send a multitude of push_updates.

With this (untested) code, you can prevent push updates with the following:

```ruby
PushUpdates.locked = true
<bulk actions>
PushUpdates.locked = false
```

or use the inbuilt `locked` function:

```ruby
PushUpdates.locked do
  <bulk action>
end
```

## Credits

@patrixr for actually writing the code.