### PR TITLE
GCW-3285- Add a 'reopen' button to the offer details page

### DIFF
--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -140,6 +140,12 @@ module Api
         render json: @offer, serializer: offer_serializer
       end
 
+      api :PUT, '/v1/offers/1/reopen_offer', "Reopen closed/cancelled offer"
+      def reopen_offer
+        @offer.update_attributes({ state_event: 'reopen' })
+        render json: @offer, serializer: offer_serializer
+      end
+
       def summary
         all_offers_count = Offer.offers_count_for(self_reviewer: false).merge(
           Offer.offers_count_for(self_reviewer: true)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -232,7 +232,7 @@ class Ability
 
     if can_manage_offers?
       can [:index, :show, :update, :complete_review, :close_offer, :search,
-        :destroy, :review, :mark_inactive, :merge_offer, :receive_offer, :summary], Offer
+        :destroy, :review, :mark_inactive, :merge_offer, :receive_offer, :summary, :reopen_offer], Offer
     end
   end
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -99,6 +99,10 @@ class Offer < ActiveRecord::Base
       transition [:draft, :inactive, :cancelled] => :submitted
     end
 
+    event :reopen do
+      transition [:closed, :cancelled] => :under_review
+    end
+
     event :start_review do
       transition submitted: :under_review
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
           put :receive_offer
           put :mark_inactive
           put :merge_offer
+          put :reopen_offer
         end
       end
       resources :offers_packages, only: [:destroy]

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -54,6 +54,25 @@ RSpec.describe Offer, type: :model do
     end
   end
 
+  context "Reopen Offer" do
+    it "should reopen closed offer" do
+      offer = create :offer, :closed
+      expect{ offer.reopen }.to change(offer, :under_review?)
+    end
+
+    it "should reopen cancelled offer" do
+      offer = create :offer, :cancelled
+      expect{ offer.reopen }.to change(offer, :under_review?)
+    end
+
+    it "should not reopen offer from states other than closed and cancelled" do
+      [:submitted, :under_review, :reviewed, :scheduled, :received, :receiving, :inactive].each do |state|
+        offer = create :offer, state
+        expect{ offer.reopen }.to_not change(offer, :under_review?)
+      end
+    end
+  end
+
   describe "Class Methods" do
     describe "valid_state?" do
       it "should verify state valid or not" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3285

### What does this PR do?

FEATURE: This PR adds feature to reopen closed/cancelled offers.