### PR TITLE
A small bug fix to ensure printers continue to work with the new model.

### DIFF
--- a/app/jobs/print_label_job.rb
+++ b/app/jobs/print_label_job.rb
@@ -3,7 +3,7 @@ class PrintLabelJob < ActiveJob::Base
     package = Package.find(package_id)
     options = { inventory_number: package.inventory_number, print_count: print_count }
     label = "Labels::#{label_type.classify}".safe_constantize.new(options)
-    printer = User.find_by_id(current_user_id).try(:printer)
+    printer = User.find_by_id(current_user_id).try(:printers).first
     PrintLabel.new(printer, label).print
   end
 end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3276

### What does this PR do?

BUG: The new printers_users table database changes were released but the code for printing to a printer was not updated to use the new model. To expediate the remediation, I have created a hotfix that will select the user's first printer in the printers_users table and print to that.

A subsequent fix should be deployed in the next release that chooses the printer based on the app being used.

### Impacted Areas

Print label
