### PR TITLE
Don't send email in staging environment.

### DIFF
--- a/app/services/sendgrid_service.rb
+++ b/app/services/sendgrid_service.rb
@@ -105,6 +105,7 @@ class SendgridService
 
   def send_email_for_order(order, template_name)
     return unless user.email.present?
+    return unless send_to_sendgrid?
     begin
       @add_bcc = true
       substitution_hash.merge!(user.email_properties)
@@ -123,6 +124,6 @@ class SendgridService
   end
 
   def send_to_sendgrid?
-    Rails.env.production? || Rails.env.staging?
+    Rails.env.production?
   end
 end


### PR DESCRIPTION
### What does this PR do?

FEATURE: Prevents sending email in non production environments

Now that we have our own outbound email IP, we wish to maintain a good reputation. Sending email to potentially bad address

### Impacted Areas

- Login via email on staging site
- Order emails on staging site
