### PR TITLE
Migrate Stockit boxes and pallets to GoodCity

### DIFF
--- a/app/models/concerns/operations/stock_operations.rb
+++ b/app/models/concerns/operations/stock_operations.rb
@@ -135,9 +135,9 @@ module StockOperations
       package.reload
     end
 
-    def pack_or_unpack(container:, package: ,location_id:, quantity: , user_id:, task: )
+    def pack_or_unpack(container:, package: ,location_id:, quantity: , user_id:, task:, strict: true)
       package.inventory_lock do
-        raise Goodcity::ActionNotAllowedError.new unless PackUnpack.action_allowed?(task)
+        raise Goodcity::ActionNotAllowedError.new unless !strict || PackUnpack.action_allowed?(task)
         PackUnpack.new(container, package, location_id, quantity, user_id).public_send(task)
       end
     end
@@ -151,20 +151,34 @@ module StockOperations
         @user_id = user_id
       end
 
-      # @TODO Raise Goodcity errors instead of returning json
-      def pack
-        return error(I18n.t("box_pallet.errors.adding_box_to_box")) if adding_box_to_a_box?
-        return error(I18n.t("box_pallet.errors.disable_addition")) unless addition_allowed?
-        return error(I18n.t("box_pallet.errors.invalid_quantity")) if invalid_quantity?
+      def pack!
+        raise Goodcity::ActionNotAllowedError.with_translation("box_pallet.errors.adding_box_to_box") if adding_box_to_a_box?
+        raise Goodcity::ActionNotAllowedError.with_translation("box_pallet.errors.disable_addition")  unless addition_allowed?
+        raise Goodcity::InsufficientQuantityError.new(@quantity)                                      if invalid_quantity?
 
         pkg_inventory = pack_or_unpack(PackagesInventory::Actions::PACK)
         response(pkg_inventory)
       end
 
-      def unpack
-        return error(I18n.t("box_pallet.errors.disable_if_unavailable")) unless operation_allowed?
+      def unpack!
+        raise Goodcity::ActionNotAllowedError.with_translation("box_pallet.errors.disable_if_unavailable") unless operation_allowed?
+
         pkg_inventory = pack_or_unpack(PackagesInventory::Actions::UNPACK)
+        pkg_inventory
+      end
+
+      def pack
+        pkg_inventory = pack!
         response(pkg_inventory)
+      rescue Goodcity::BaseError => e
+        error(e.message)
+      end
+
+      def unpack
+        pkg_inventory = unpack!
+        response(pkg_inventory)
+      rescue Goodcity::BaseError => e
+        error(e.message)
       end
 
       private

--- a/app/models/concerns/settings_validator.rb
+++ b/app/models/concerns/settings_validator.rb
@@ -1,4 +1,6 @@
 class SettingsValidator < ActiveModel::Validator
+  @@enabled = true
+
   def initialize(options)
     super
     @keys = options[:settings][:keys]
@@ -6,6 +8,7 @@ class SettingsValidator < ActiveModel::Validator
 
   # Create setting with app_name in the beggining of the key to identify. eg 'stock.abc'
   def validate(record)
+    return unless @@enabled
     error_messages = []
     @keys.each do |key|
       unless GoodcitySetting.enabled?(key)
@@ -14,5 +17,14 @@ class SettingsValidator < ActiveModel::Validator
       end
     end
     record.errors.add(:base, error_messages.join(" ")) unless error_messages.empty?
+  end
+
+  class << self
+    def bypass
+      @@enabled = false
+      yield
+    ensure
+      @@enabled = true
+    end
   end
 end

--- a/db/package_types.yml
+++ b/db/package_types.yml
@@ -1367,6 +1367,15 @@ VP:
   :other_terms_en: Laser, Bubble jet
   :other_terms_zh_tw: '雷射打印機'
   :default_value_hk_dollar: 1200.00
+VB:
+  :default_packages: VB
+  :other_packages: VXX
+  :name_en: Box of Computers
+  :name_zh_tw: '其他電腦裝備'
+  :other_terms_en: Computer items
+  :other_terms_zh_tw: '雷射打印機'
+  :default_value_hk_dollar: 1200.00
+  :allow_box: true
 VXX:
   :default_packages: VXX
   :other_packages: 

--- a/lib/goodcity/import_boxes.rb
+++ b/lib/goodcity/import_boxes.rb
@@ -1,0 +1,144 @@
+#
+# STEPS TO RUN
+# 1. Run the following SQL on Stockit and export the data to {Rails.root}/tmp/import_boxes.csv
+#    IMPORTANT: we expect the first row in the CSV file to be a header row
+#
+#    SELECT boxes.box_number, items.inventory_number, boxes.description, boxes.comments,
+#     packages.length, packages.width, packages.height, packages.weight
+#    FROM boxes
+#    LEFT JOIN items on items.box_id=boxes.id
+#    WHERE items.sent_on is NULL
+#        AND boxes.pallet_id IS NULL
+#        AND items.quantity != 0
+#    ORDER BY boxes.box_number, items.inventory_number
+#
+# 2. Run a GoodCity rails console connected to the production environment
+#    > require 'goodcity/import_boxes'
+#    > current_user = User.find(id)
+#    > GoodCity::ImportBoxes.new(current_user).run!
+#
+# WHAT THIS SCRIPT DOES
+# The SQL generates a list of IN STOCK items that are in Stockit boxes. For convenience, each row corresponds to 1 item in 1 box.
+# Since a box can contain many items, there will be many rows with the same box details where each item inventory_number is different.
+# The script runs through the csv, generating the box the first time it encounters it and then packing the items in the box.
+# If an error is encountered, the script will log it and continue on to the next row. We plan to deal with the errata once the import is complete.
+# This script is designed to be run many times with the data set and if an item is already in the box, it will skip and carry on.
+
+# Questions: what about boxes on a pallet?
+
+class Goodcity
+  class ImportBoxes
+
+    STATUS_FAIL = 'fail'
+    STATUS_SUCCESS = 'success'
+    CSV_LOG_HEADER = ["box_number", "inventory_number", "status", "log_comment"]
+
+    def initialize(user)
+      @import_boxes_csv_file_path = File.join(Rails.root, 'tmp', 'import_boxes.csv')
+      @log_file_path = File.join(Rails.root, 'log', 'import_boxes.log')
+      @log = []
+      @user = user
+      User.current_user = user # for PaperTrail / Versions
+    end
+
+    def run!
+      CSV.foreach(@import_boxes_csv_file_path, headers: true) do |row|
+        puts "Putting package #{row["inventory_number"]} in box #{box_number}"
+        import_box(row)
+      end
+      write_log_file
+      puts "Please review the log #{@log_file_path} for any errors."
+    end
+
+    private
+
+    def import_box(row)
+      return unless validate_key_fields?(row)
+      ActiveRecord::Base.transaction do
+        begin
+          package = find_package(row)
+          box = create_box(row, package)
+          pack_package_in_box(box, package)
+          log_entry(row, STATUS_SUCCESS, "Package #{row["inventory_number"]} is in box #{box_number}")
+        rescue Exception => ex
+          # This may create a rod for our backs... 
+          #   capture error, log it, rollback and carry on
+          log_entry(row, STATUS_FAIL, ex.message)
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    # If box doesn't exist, create a package with a box package_type and inventorize it
+    def create_box(row, package)
+      # Stockit boxes get their internal details from the first item in the box so we make the same assumption here.
+      box = Package.where(inventory_number: box_number).first
+      if !box.present?
+        box = Package.new(
+          storage_type_id:    storage_type_box.id,
+          donor_condition_id: package.donor_condition_id,
+          inventory_number:   row["box_number"],
+          package_type:       package.package_type, # what if this package_type doesn't have "allow_box" set?
+          quantity:           1,
+          grade:              package.grade,
+          description:        row["description"],
+          comments:           row["comments"],
+          length:             row["length"],
+          width:              row["width"],
+          height:             row["height"],
+          weight:             row["weight"]
+        )
+        box.save!
+        Package::Operations.inventorize(box, package.locations.first.id) unless PackagesInventory.inventorized?(box)
+      end
+      box
+    end
+
+    # The package must pre-exist in GoodCity
+    def find_package(row)
+      Package.where(inventory_number: row["inventory_number"]).first
+    end
+
+    # If the package isn't already in the box
+    # Note we assume (correctly) that the full quantity of the item goes in the box and
+    #   that there is only have one location because this is a Stockit item.
+    def pack_package_in_box(box, package)
+      location_id = package.locations.first.id
+      quantity = package.received_quantity
+      Package::Operations.pack_or_unpack(box, package, location_id, quantity, @user.id, "pack")
+    end
+
+    def storage_type_box
+      @storage_type_box ||= StorageType.find_by_name("Box")
+    end
+
+    # return true if ok to continue
+    def validate_key_fields(row)
+      if row["box_number"].blank?
+        log_entry(row, STATUS_FAIL, "Missing box_number")
+      elsif row["inventory_number"].blank?
+        log_entry(row, STATUS_FAIL, "Missing inventory_number")
+      else
+        return true
+      end
+      return false
+    end
+
+    def log_entry(row, status, log_comment)
+      box_number = row["box_number"]
+      inventory_number = row["inventory_number"]
+      @log << [box_number, inventory_number, status, log_comment]
+      puts [box_number, inventory_number, status, log_comment].join(", ")
+    end
+
+    def write_log_file
+      CSV.open(@log_file_path, "wb") do |csv|
+        csv << CSV_HEADER
+        @log.each do |row|
+          csv << row
+        end
+      end
+    end
+
+  end
+end

--- a/lib/goodcity/import_boxes.rb
+++ b/lib/goodcity/import_boxes.rb
@@ -8,7 +8,6 @@
 #    FROM boxes
 #    LEFT JOIN items on items.box_id=boxes.id
 #    WHERE items.sent_on is NULL
-#        AND boxes.pallet_id IS NULL
 #        AND items.quantity != 0
 #    ORDER BY boxes.box_number, items.inventory_number
 #

--- a/spec/lib/goodcity/import_boxes_spec.rb
+++ b/spec/lib/goodcity/import_boxes_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+require 'goodcity/import_boxes'
+
+context Goodcity::ImportBoxes do
+
+  subject { described_class.new(user) }
+
+  let(:user) { create :user }
+  let(:inventory_number) { '112233' }
+  let(:box_storage_type) { create :storage_type, :with_box }
+  let(:pallet_storage_type) { create :storage_type, :with_pallet }
+  let(:pkg_storage_type) { create :storage_type, :with_pkg }
+  let(:package) { create :package, :with_inventory_record, inventory_number: inventory_number, received_quantity: 10 }
+  let(:location) { package.locations.first }
+  let(:row) { {
+    "inventory_number"  => package.inventory_number,
+    "box_number"        => "B000001",
+    "description"       => "This is a stockit box",
+    "comments"          => "Steve was here",
+    "length"            => 10,
+    "height"            => 11,
+    "width"             => 12,
+    "weight"            => 13
+  } }
+
+  context "Importing a box" do
+
+    before do
+      touch(package, box_storage_type, pallet_storage_type, pkg_storage_type, location)
+      expect(Package.count).to eq(1)
+      expect(package.locations.count).to eq(1)
+    end
+
+    it "creates a new package of Box type" do
+      expect { subject.import_row!(row) }.to change(Package, :count).by(1)
+      expect(Package.last.storage_type).to eq(box_storage_type)
+    end
+
+    it "places the new box in the same location as the package" do
+      box = subject.import_row!(row)
+      expect(box.locations.count).to eq(1)
+      expect(box.locations.first).to eq(location)
+    end
+
+    it "packs all the package quantity into the box" do
+      box = nil
+      expect { box = subject.import_row!(row) }.to change {
+        PackagesInventory::Computer.package_quantity(package)
+      }.from(10).to(0)
+
+      expect(package.reload.on_hand_quantity).to eq(0)
+
+      inventory_row = PackagesInventory.where(package: package).last
+      expect(inventory_row.package_id).to   eq(package.id)
+      expect(inventory_row.location_id).to  eq(location.id)
+      expect(inventory_row.user_id).to      eq(user.id)
+      expect(inventory_row.action).to       eq("pack")
+      expect(inventory_row.source_type).to  eq("Package")
+      expect(inventory_row.source_id).to    eq(box.id)
+      expect(inventory_row.quantity).to     eq(-10)
+    end
+
+    it "doesn't create the box it already exists" do
+      box = subject.import_row!(row)
+
+      expect {
+        expect(subject.import_row!(row)).to eq(box)
+      }.not_to change(PackagesInventory, :count)
+    end
+
+    it "sets the box's inventory number to the stockit box_number field" do
+      box = subject.import_row!(row)
+      expect(box.inventory_number).to eq(row['box_number'])
+    end
+
+    it "sets the correct size/weight properties" do
+      box = subject.import_row!(row)
+
+      expect(box.width).to  eq(row['width'])
+      expect(box.height).to eq(row['height'])
+      expect(box.length).to eq(row['length'])
+      expect(box.weight).to eq(row['weight'])
+    end
+
+    it "raises an error if the inventory_number is missing" do
+      expect {
+        subject.import_row!(row.merge("inventory_number" => "")) 
+      }.to raise_error(Goodcity::InvalidParamsError).with_message('Missing inventory_number')
+    end
+
+    it "raises an error if the box_number is missing" do
+      expect {
+        subject.import_row!(row.merge("box_number" => "")) 
+      }.to raise_error(Goodcity::InvalidParamsError).with_message('Missing box_number')
+    end
+
+    it "raises an error if the package does not exist in goodcity" do
+      expect(Package.find_by(inventory_number: '999999')).to eq(nil)
+
+      expect {
+        subject.import_row!(row.merge("inventory_number" => "999999")) 
+      }.to raise_error(Goodcity::NotFoundError).with_message(
+        "Package with inventory number '999999' was not found"
+      )
+    end
+
+    it "raises an error if the package doesn't have its entire quantity available to be packed in the box" do
+      Package::Operations.register_loss(package, quantity: 5, location: location)
+      expect(package.reload.on_hand_quantity).to eq(5)
+      expect(package.reload.received_quantity).to eq(10)
+
+      expect {
+        subject.import_row!(row)
+        byebug
+      }.to raise_error(Goodcity::InsufficientQuantityError).with_message(
+        "The selected quantity (10) is unavailable"
+      )
+    end
+  end
+end

--- a/spec/lib/goodcity/import_boxes_spec.rb
+++ b/spec/lib/goodcity/import_boxes_spec.rb
@@ -10,7 +10,10 @@ context Goodcity::ImportBoxes do
   let(:box_storage_type) { create :storage_type, :with_box }
   let(:pallet_storage_type) { create :storage_type, :with_pallet }
   let(:pkg_storage_type) { create :storage_type, :with_pkg }
-  let(:package) { create :package, :with_inventory_record, inventory_number: inventory_number, received_quantity: 10 }
+  let(:computer_package_type) { create :package_type, code: "VXX"}
+  let(:box_of_computers_package_type) { create :package_type, code: "VB", allow_box: true }
+  let!(:subpackage_type) { create(:subpackage_type, package_type: box_of_computers_package_type, child_package_type: computer_package_type, is_default: false) }
+  let(:package) { create :package, :with_inventory_record, package_type: computer_package_type, inventory_number: inventory_number, received_quantity: 10 }
   let(:location) { package.locations.first }
   let(:row) { {
     "inventory_number"  => package.inventory_number,


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3294

### What does this PR do?

FEATURE: Provides an import script for migrating Stockit boxes and pallets. We will run this to import in-stock boxes/pallets just after the cutover, when these GoodCity features have been enabled.

### Impacted Areas

Packages, Boxes, Pallets

### Any Open question(s) or challenge(s):

- I haven't run the script yet. It needs testing.
- Need to write another similar script for importing pallets (there are some Stockit items on pallets)
- Need to write another script to put some boxes on pallets. This should be run once we have migrated all the boxes and pallets.
