### PR TITLE
Fix: unlink beneficiary from order before deletion

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -169,7 +169,7 @@ module Api
           :created_at, :organisation_id, :stockit_contact_id,
           :detail_id, :detail_type, :description,
           :state, :cancellation_reason, :state_event,
-          :stockit_organisation_id, :stockit_activity_id,
+          :stockit_activity_id,
           :people_helped, :beneficiary_id, :booking_type_id, :purpose_description,
           :address_id,:submitted_by_id, :staff_note,
           :exclude_message_sender, :include_messages,

--- a/app/controllers/api/v2/ability.rb
+++ b/app/controllers/api/v2/ability.rb
@@ -8,8 +8,8 @@ module Api
       end
 
       def user_permissions
-        return [] unless @user.present? && @role.present?
-        @user_permissions = role.permissions.map(&:name)
+        return [] unless @user.present?
+        @user_permissions ||= @role.present? ? @role.permissions.map(&:name) : super
       end
 
       # -----------------

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -19,6 +19,7 @@ module Api
       rescue_from Apipie::ParamInvalid,         with: :invalid_params
       rescue_from Apipie::ParamMissing,         with: :invalid_params
       rescue_from Goodcity::BaseError,          with: :render_goodcity_error
+      rescue_from PG::ForeignKeyViolation,      with: :foreign_key_violation
 
       def current_ability
         @current_ability ||= Api::V2::Ability.new(current_user, role: current_role)
@@ -29,7 +30,7 @@ module Api
           allowed_roles = current_user&.roles || []
           role_name     = request.headers["X-GOODCITY-ROLE"]
 
-          return current_user&.top_role if role_name.blank?
+          return nil                    if role_name.blank?
           return Role.null_role         if role_name.eql?('user')
           
           role = allowed_roles.find { |r| r.snake_name == role_name }
@@ -70,6 +71,14 @@ module Api
       # ------------------------
       # Error handlers
       # ------------------------
+
+      def foreign_key_violation
+        render_goodcity_error(
+          request.method.eql?('DELETE') ?
+            Goodcity::ForeignKeyDeletionError.new :
+            Goodcity::ForeignKeyMismatchError.new
+        )
+      end
 
       def access_denied
         render_goodcity_error Goodcity::AccessDeniedError.new

--- a/app/models/beneficiary.rb
+++ b/app/models/beneficiary.rb
@@ -7,4 +7,12 @@ class Beneficiary < ApplicationRecord
   validates :first_name, length: { maximum: 50 }, presence: true
   validates :last_name, length: { maximum: 50 }, presence: true
   validates :phone_number, length: { is: 12 }, presence: true
+
+  before_destroy :unlink_orders
+
+  private
+
+  def unlink_orders
+    Order.where(beneficiary_id: id).update_all(beneficiary_id: nil)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
     forbidden: Access Denied
     invalid_credentials: Invalid credentials
     invalid_params: Invalid or missing params
+    foreign_key_delete_violation: Another entity is dependent on the record you are trying to delete
+    foreign_key_mismatch_violation: A broken entity relationship has occurred
   warden:
     token_invalid: Invalid token
     token_expired: Expired token

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -16,6 +16,8 @@ zh-tw:
     forbidden: Access Denied
     invalid_credentials: Invalid credentials
     invalid_params: Invalid or missing params
+    foreign_key_delete_violation: Another entity is dependent on the record you are trying to delete
+    foreign_key_mismatch_violation: A broken entity relationship has occurred
   warden:
     token_invalid: 代碼不正確
     token_expired: 代碼已過期

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,1051 +13,1007 @@
 ActiveRecord::Schema.define(version: 2020_10_06_145926) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
 
-  create_table "addresses", force: :cascade do |t|
-    t.string   "flat"
-    t.string   "building"
-    t.string   "street"
-    t.integer  "district_id"
-    t.integer  "addressable_id"
-    t.string   "addressable_type"
-    t.string   "address_type"
+  create_table "addresses", id: :serial, force: :cascade do |t|
+    t.string "flat"
+    t.string "building"
+    t.string "street"
+    t.integer "district_id"
+    t.integer "addressable_id"
+    t.string "addressable_type"
+    t.string "address_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
+    t.index ["addressable_id", "addressable_type"], name: "index_addresses_on_addressable_id_and_addressable_type"
+    t.index ["district_id"], name: "index_addresses_on_district_id"
   end
 
-  add_index "addresses", ["addressable_id", "addressable_type"], name: "index_addresses_on_addressable_id_and_addressable_type", using: :btree
-  add_index "addresses", ["district_id"], name: "index_addresses_on_district_id", using: :btree
-
-  create_table "appointment_slot_presets", force: :cascade do |t|
+  create_table "appointment_slot_presets", id: :serial, force: :cascade do |t|
     t.integer "day"
     t.integer "hours"
     t.integer "minutes"
     t.integer "quota"
   end
 
-  create_table "appointment_slots", force: :cascade do |t|
+  create_table "appointment_slots", id: :serial, force: :cascade do |t|
     t.datetime "timestamp"
-    t.integer  "quota"
-    t.string   "note",      default: ""
+    t.integer "quota"
+    t.string "note", default: ""
   end
 
-  create_table "auth_tokens", force: :cascade do |t|
+  create_table "auth_tokens", id: :serial, force: :cascade do |t|
     t.datetime "otp_code_expiry"
-    t.string   "otp_secret_key"
-    t.integer  "user_id"
+    t.string "otp_secret_key"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "otp_auth_key",    limit: 30
+    t.string "otp_auth_key", limit: 30
+    t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end
 
-  add_index "auth_tokens", ["user_id"], name: "index_auth_tokens_on_user_id", using: :btree
-
-  create_table "beneficiaries", force: :cascade do |t|
-    t.integer  "identity_type_id"
-    t.integer  "created_by_id"
-    t.string   "identity_number"
-    t.string   "title"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "phone_number"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
-  end
-
-  add_index "beneficiaries", ["created_by_id"], name: "index_beneficiaries_on_created_by_id", using: :btree
-  add_index "beneficiaries", ["identity_type_id"], name: "index_beneficiaries_on_identity_type_id", using: :btree
-
-  create_table "booking_types", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "beneficiaries", id: :serial, force: :cascade do |t|
+    t.integer "identity_type_id"
+    t.integer "created_by_id"
+    t.string "identity_number"
+    t.string "title"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "identifier"
+    t.index ["created_by_id"], name: "index_beneficiaries_on_created_by_id"
+    t.index ["identity_type_id"], name: "index_beneficiaries_on_identity_type_id"
   end
 
-  add_index "booking_types", ["name_en", "name_zh_tw"], name: "index_booking_types_on_name_en_and_name_zh_tw", unique: true, using: :btree
-
-  create_table "boxes", force: :cascade do |t|
-    t.string   "box_number"
-    t.string   "description"
-    t.text     "comments"
-    t.integer  "pallet_id"
-    t.integer  "stockit_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+  create_table "booking_types", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "identifier"
+    t.index ["name_en", "name_zh_tw"], name: "index_booking_types_on_name_en_and_name_zh_tw", unique: true
   end
 
-  add_index "boxes", ["pallet_id"], name: "index_boxes_on_pallet_id", using: :btree
-
-  create_table "cancellation_reasons", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.boolean  "visible_to_offer", default: true
-    t.boolean  "visible_to_order", default: false
+  create_table "boxes", id: :serial, force: :cascade do |t|
+    t.string "box_number"
+    t.string "description"
+    t.text "comments"
+    t.integer "pallet_id"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pallet_id"], name: "index_boxes_on_pallet_id"
   end
 
-  create_table "companies", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "crm_id"
-    t.integer  "created_by_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.integer  "updated_by_id"
+  create_table "cancellation_reasons", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "visible_to_offer", default: true
+    t.boolean "visible_to_order", default: false
   end
 
-  create_table "computer_accessories", force: :cascade do |t|
-    t.string   "brand"
-    t.string   "model"
-    t.string   "serial_num"
-    t.integer  "country_id"
-    t.string   "size"
-    t.string   "interface"
-    t.string   "comp_voltage"
-    t.integer  "updated_by_id"
-    t.integer  "stockit_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.integer  "comp_test_status_id"
+  create_table "companies", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "crm_id"
+    t.integer "created_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
   end
 
-  create_table "computers", force: :cascade do |t|
-    t.string   "brand"
-    t.string   "model"
-    t.string   "serial_num"
-    t.integer  "country_id"
-    t.string   "size"
-    t.string   "cpu"
-    t.string   "ram"
-    t.string   "hdd"
-    t.string   "optical"
-    t.string   "video"
-    t.string   "sound"
-    t.string   "lan"
-    t.string   "wireless"
-    t.string   "usb"
-    t.string   "comp_voltage"
-    t.string   "os"
-    t.string   "os_serial_num"
-    t.string   "ms_office_serial_num"
-    t.string   "mar_os_serial_num"
-    t.string   "mar_ms_office_serial_num"
-    t.integer  "updated_by_id"
-    t.integer  "stockit_id"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.integer  "comp_test_status_id"
+  create_table "computer_accessories", id: :serial, force: :cascade do |t|
+    t.string "brand"
+    t.string "model"
+    t.string "serial_num"
+    t.integer "country_id"
+    t.string "size"
+    t.string "interface"
+    t.string "comp_voltage"
+    t.integer "updated_by_id"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "comp_test_status_id"
   end
 
-  create_table "contacts", force: :cascade do |t|
-    t.string   "name"
-    t.string   "mobile"
+  create_table "computers", id: :serial, force: :cascade do |t|
+    t.string "brand"
+    t.string "model"
+    t.string "serial_num"
+    t.integer "country_id"
+    t.string "size"
+    t.string "cpu"
+    t.string "ram"
+    t.string "hdd"
+    t.string "optical"
+    t.string "video"
+    t.string "sound"
+    t.string "lan"
+    t.string "wireless"
+    t.string "usb"
+    t.string "comp_voltage"
+    t.string "os"
+    t.string "os_serial_num"
+    t.string "ms_office_serial_num"
+    t.string "mar_os_serial_num"
+    t.string "mar_ms_office_serial_num"
+    t.integer "updated_by_id"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "comp_test_status_id"
+  end
+
+  create_table "contacts", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
   end
 
-  create_table "countries", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.integer  "stockit_id"
+  create_table "countries", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "crossroads_transports", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "crossroads_transports", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "cost"
-    t.float    "truck_size"
-    t.boolean  "is_van_allowed", default: true
+    t.integer "cost"
+    t.float "truck_size"
+    t.boolean "is_van_allowed", default: true
   end
 
-  create_table "deliveries", force: :cascade do |t|
-    t.integer  "offer_id"
-    t.integer  "contact_id"
-    t.integer  "schedule_id"
-    t.string   "delivery_type"
+  create_table "deliveries", id: :serial, force: :cascade do |t|
+    t.integer "offer_id"
+    t.integer "contact_id"
+    t.integer "schedule_id"
+    t.string "delivery_type"
     t.datetime "start"
     t.datetime "finish"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "gogovan_order_id"
+    t.integer "gogovan_order_id"
     t.datetime "deleted_at"
+    t.index ["contact_id"], name: "index_deliveries_on_contact_id"
+    t.index ["gogovan_order_id"], name: "index_deliveries_on_gogovan_order_id"
+    t.index ["offer_id"], name: "index_deliveries_on_offer_id"
+    t.index ["schedule_id"], name: "index_deliveries_on_schedule_id"
   end
 
-  add_index "deliveries", ["contact_id"], name: "index_deliveries_on_contact_id", using: :btree
-  add_index "deliveries", ["gogovan_order_id"], name: "index_deliveries_on_gogovan_order_id", using: :btree
-  add_index "deliveries", ["offer_id"], name: "index_deliveries_on_offer_id", using: :btree
-  add_index "deliveries", ["schedule_id"], name: "index_deliveries_on_schedule_id", using: :btree
-
-  create_table "districts", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.integer  "territory_id"
+  create_table "districts", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.integer "territory_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.float    "latitude"
-    t.float    "longitude"
+    t.float "latitude"
+    t.float "longitude"
+    t.index ["territory_id"], name: "index_districts_on_territory_id"
   end
 
-  add_index "districts", ["territory_id"], name: "index_districts_on_territory_id", using: :btree
-
-  create_table "donor_conditions", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "donor_conditions", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "visible_to_donor", default: true, null: false
+    t.boolean "visible_to_donor", default: true, null: false
   end
 
-  create_table "electricals", force: :cascade do |t|
-    t.string   "brand"
-    t.string   "model"
-    t.string   "serial_number"
-    t.integer  "country_id"
-    t.string   "standard"
-    t.string   "power"
-    t.string   "system_or_region"
-    t.date     "tested_on"
-    t.integer  "updated_by_id"
-    t.integer  "stockit_id"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
-    t.integer  "test_status_id"
-    t.integer  "voltage_id"
-    t.integer  "frequency_id"
+  create_table "electricals", id: :serial, force: :cascade do |t|
+    t.string "brand"
+    t.string "model"
+    t.string "serial_number"
+    t.integer "country_id"
+    t.string "standard"
+    t.string "power"
+    t.string "system_or_region"
+    t.date "tested_on"
+    t.integer "updated_by_id"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "test_status_id"
+    t.integer "voltage_id"
+    t.integer "frequency_id"
   end
 
-  create_table "gogovan_orders", force: :cascade do |t|
-    t.integer  "booking_id"
-    t.string   "status"
+  create_table "gogovan_orders", id: :serial, force: :cascade do |t|
+    t.integer "booking_id"
+    t.string "status"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.float    "price"
-    t.string   "driver_name"
-    t.string   "driver_mobile"
-    t.string   "driver_license"
-    t.string   "ggv_uuid"
+    t.float "price"
+    t.string "driver_name"
+    t.string "driver_mobile"
+    t.string "driver_license"
+    t.string "ggv_uuid"
     t.datetime "completed_at"
+    t.index ["ggv_uuid"], name: "index_gogovan_orders_on_ggv_uuid", unique: true
   end
 
-  add_index "gogovan_orders", ["ggv_uuid"], name: "index_gogovan_orders_on_ggv_uuid", unique: true, using: :btree
-
-  create_table "gogovan_transports", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "gogovan_transports", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "disabled",   default: false
+    t.boolean "disabled", default: false
   end
 
-  create_table "goodcity_requests", force: :cascade do |t|
-    t.integer  "quantity"
-    t.integer  "package_type_id"
-    t.integer  "order_id"
-    t.text     "description"
-    t.integer  "created_by_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+  create_table "goodcity_requests", id: :serial, force: :cascade do |t|
+    t.integer "quantity"
+    t.integer "package_type_id"
+    t.integer "order_id"
+    t.text "description"
+    t.integer "created_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_goodcity_requests_on_created_by_id"
+    t.index ["order_id"], name: "index_goodcity_requests_on_order_id"
+    t.index ["package_type_id"], name: "index_goodcity_requests_on_package_type_id"
   end
 
-  add_index "goodcity_requests", ["created_by_id"], name: "index_goodcity_requests_on_created_by_id", using: :btree
-  add_index "goodcity_requests", ["order_id"], name: "index_goodcity_requests_on_order_id", using: :btree
-  add_index "goodcity_requests", ["package_type_id"], name: "index_goodcity_requests_on_package_type_id", using: :btree
-
-  create_table "goodcity_settings", force: :cascade do |t|
+  create_table "goodcity_settings", id: :serial, force: :cascade do |t|
     t.string "key"
     t.string "value"
     t.string "description"
+    t.index ["key"], name: "index_goodcity_settings_on_key"
   end
 
-  add_index "goodcity_settings", ["key"], name: "index_goodcity_settings_on_key", using: :btree
-
-  create_table "holidays", force: :cascade do |t|
+  create_table "holidays", id: :serial, force: :cascade do |t|
     t.datetime "holiday"
-    t.integer  "year"
-    t.string   "name"
+    t.integer "year"
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "identity_types", force: :cascade do |t|
-    t.string   "identifier"
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "identity_types", id: :serial, force: :cascade do |t|
+    t.string "identifier"
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "images", force: :cascade do |t|
-    t.string   "cloudinary_id"
-    t.boolean  "favourite",      default: false
-    t.integer  "item_id"
+  create_table "images", id: :serial, force: :cascade do |t|
+    t.string "cloudinary_id"
+    t.boolean "favourite", default: false
+    t.integer "item_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.integer  "angle",          default: 0
-    t.integer  "imageable_id"
-    t.string   "imageable_type"
+    t.integer "angle", default: 0
+    t.integer "imageable_id"
+    t.string "imageable_type"
+    t.index ["imageable_id", "imageable_type"], name: "index_images_on_imageable_id_and_imageable_type"
   end
 
-  add_index "images", ["imageable_id", "imageable_type"], name: "index_images_on_imageable_id_and_imageable_type", using: :btree
-
-  create_table "inventory_numbers", force: :cascade do |t|
+  create_table "inventory_numbers", id: :serial, force: :cascade do |t|
     t.string "code"
   end
 
-  create_table "items", force: :cascade do |t|
-    t.text     "donor_description"
-    t.string   "state"
-    t.integer  "offer_id",            null: false
-    t.integer  "package_type_id"
-    t.integer  "rejection_reason_id"
-    t.string   "reject_reason"
+  create_table "items", id: :serial, force: :cascade do |t|
+    t.text "donor_description"
+    t.string "state"
+    t.integer "offer_id", null: false
+    t.integer "package_type_id"
+    t.integer "rejection_reason_id"
+    t.string "reject_reason"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "donor_condition_id"
+    t.integer "donor_condition_id"
     t.datetime "deleted_at"
-    t.text     "rejection_comments"
+    t.text "rejection_comments"
+    t.index ["donor_condition_id"], name: "index_items_on_donor_condition_id"
+    t.index ["offer_id"], name: "index_items_on_offer_id"
+    t.index ["package_type_id"], name: "index_items_on_package_type_id"
+    t.index ["rejection_reason_id"], name: "index_items_on_rejection_reason_id"
   end
 
-  add_index "items", ["donor_condition_id"], name: "index_items_on_donor_condition_id", using: :btree
-  add_index "items", ["offer_id"], name: "index_items_on_offer_id", using: :btree
-  add_index "items", ["package_type_id"], name: "index_items_on_package_type_id", using: :btree
-  add_index "items", ["rejection_reason_id"], name: "index_items_on_rejection_reason_id", using: :btree
+  create_table "locations", id: :serial, force: :cascade do |t|
+    t.string "building"
+    t.string "area"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["area"], name: "index_locations_on_area", using: :gin
+    t.index ["building"], name: "index_locations_on_building", using: :gin
+    t.index ["stockit_id"], name: "index_locations_on_stockit_id"
+  end
 
-  create_table "locations", force: :cascade do |t|
-    t.string   "building"
-    t.string   "area"
-    t.integer  "stockit_id"
+  create_table "lookups", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "key"
+    t.string "label_en"
+    t.string "label_zh_tw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "label_en"], name: "index_lookups_on_name_and_label_en"
+    t.index ["name", "label_zh_tw"], name: "index_lookups_on_name_and_label_zh_tw"
+    t.index ["name"], name: "index_lookups_on_name"
+  end
+
+  create_table "medicals", id: :serial, force: :cascade do |t|
+    t.string "serial_number"
+    t.string "model"
+    t.string "brand"
+    t.integer "country_id"
+    t.integer "updated_by_id"
+    t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "locations", ["area"], name: "index_locations_on_area", using: :gin
-  add_index "locations", ["building"], name: "index_locations_on_building", using: :gin
-  add_index "locations", ["stockit_id"], name: "index_locations_on_stockit_id", using: :btree
-
-  create_table "lookups", force: :cascade do |t|
-    t.string   "name"
-    t.string   "key"
-    t.string   "label_en"
-    t.string   "label_zh_tw"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
-
-  add_index "lookups", ["name", "label_en"], name: "index_lookups_on_name_and_label_en", using: :btree
-  add_index "lookups", ["name", "label_zh_tw"], name: "index_lookups_on_name_and_label_zh_tw", using: :btree
-  add_index "lookups", ["name"], name: "index_lookups_on_name", using: :btree
-
-  create_table "medicals", force: :cascade do |t|
-    t.string   "serial_number"
-    t.string   "model"
-    t.string   "brand"
-    t.integer  "country_id"
-    t.integer  "updated_by_id"
-    t.integer  "stockit_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-  end
-
-  create_table "messages", force: :cascade do |t|
-    t.text     "body"
-    t.integer  "sender_id"
-    t.boolean  "is_private",       default: false
+  create_table "messages", id: :serial, force: :cascade do |t|
+    t.text "body"
+    t.integer "sender_id"
+    t.boolean "is_private", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.string   "messageable_type"
-    t.integer  "messageable_id"
-    t.jsonb    "lookup",           default: {}
+    t.string "messageable_type"
+    t.integer "messageable_id"
+    t.jsonb "lookup", default: {}
+    t.index ["body"], name: "messages_body_search_idx", using: :gin
+    t.index ["lookup"], name: "index_messages_on_lookup", using: :gin
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
-  add_index "messages", ["body"], name: "messages_body_search_idx", using: :gin
-  add_index "messages", ["lookup"], name: "index_messages_on_lookup", using: :gin
-  add_index "messages", ["sender_id"], name: "index_messages_on_sender_id", using: :btree
-
-  create_table "offers", force: :cascade do |t|
-    t.string   "language"
-    t.string   "state"
-    t.string   "origin"
-    t.boolean  "stairs"
-    t.boolean  "parking"
-    t.string   "estimated_size"
-    t.text     "notes"
-    t.integer  "created_by_id"
+  create_table "offers", id: :serial, force: :cascade do |t|
+    t.string "language"
+    t.string "state"
+    t.string "origin"
+    t.boolean "stairs"
+    t.boolean "parking"
+    t.string "estimated_size"
+    t.text "notes"
+    t.integer "created_by_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.datetime "submitted_at"
-    t.integer  "reviewed_by_id"
+    t.integer "reviewed_by_id"
     t.datetime "reviewed_at"
-    t.integer  "gogovan_transport_id"
-    t.integer  "crossroads_transport_id"
+    t.integer "gogovan_transport_id"
+    t.integer "crossroads_transport_id"
     t.datetime "review_completed_at"
     t.datetime "received_at"
-    t.string   "delivered_by",            limit: 30
-    t.integer  "closed_by_id"
+    t.string "delivered_by", limit: 30
+    t.integer "closed_by_id"
     t.datetime "cancelled_at"
-    t.integer  "received_by_id"
+    t.integer "received_by_id"
     t.datetime "start_receiving_at"
-    t.integer  "cancellation_reason_id"
-    t.string   "cancel_reason"
+    t.integer "cancellation_reason_id"
+    t.string "cancel_reason"
     t.datetime "inactive_at"
-    t.boolean  "saleable",                           default: false
-    t.integer  "company_id"
+    t.boolean "saleable", default: false
+    t.integer "company_id"
+    t.index ["cancellation_reason_id"], name: "index_offers_on_cancellation_reason_id"
+    t.index ["closed_by_id"], name: "index_offers_on_closed_by_id"
+    t.index ["company_id"], name: "index_offers_on_company_id"
+    t.index ["created_by_id"], name: "index_offers_on_created_by_id"
+    t.index ["crossroads_transport_id"], name: "index_offers_on_crossroads_transport_id"
+    t.index ["gogovan_transport_id"], name: "index_offers_on_gogovan_transport_id"
+    t.index ["notes"], name: "offers_notes_search_idx", using: :gin
+    t.index ["received_by_id"], name: "index_offers_on_received_by_id"
+    t.index ["reviewed_by_id"], name: "index_offers_on_reviewed_by_id"
+    t.index ["state"], name: "index_offers_on_state"
   end
 
-  add_index "offers", ["cancellation_reason_id"], name: "index_offers_on_cancellation_reason_id", using: :btree
-  add_index "offers", ["closed_by_id"], name: "index_offers_on_closed_by_id", using: :btree
-  add_index "offers", ["company_id"], name: "index_offers_on_company_id", using: :btree
-  add_index "offers", ["created_by_id"], name: "index_offers_on_created_by_id", using: :btree
-  add_index "offers", ["crossroads_transport_id"], name: "index_offers_on_crossroads_transport_id", using: :btree
-  add_index "offers", ["gogovan_transport_id"], name: "index_offers_on_gogovan_transport_id", using: :btree
-  add_index "offers", ["notes"], name: "offers_notes_search_idx", using: :gin
-  add_index "offers", ["received_by_id"], name: "index_offers_on_received_by_id", using: :btree
-  add_index "offers", ["reviewed_by_id"], name: "index_offers_on_reviewed_by_id", using: :btree
-  add_index "offers", ["state"], name: "index_offers_on_state", using: :btree
-
-  create_table "offers_packages", force: :cascade do |t|
+  create_table "offers_packages", id: :serial, force: :cascade do |t|
     t.integer "package_id"
     t.integer "offer_id"
   end
 
-  create_table "order_transports", force: :cascade do |t|
+  create_table "order_transports", id: :serial, force: :cascade do |t|
     t.datetime "scheduled_at"
-    t.string   "timeslot"
-    t.string   "transport_type"
-    t.integer  "contact_id"
-    t.integer  "gogovan_order_id"
-    t.integer  "order_id"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.boolean  "need_english",         default: false
-    t.boolean  "need_cart",            default: false
-    t.boolean  "need_carry",           default: false
-    t.boolean  "need_over_6ft",        default: false
-    t.integer  "gogovan_transport_id"
-    t.string   "remove_net"
+    t.string "timeslot"
+    t.string "transport_type"
+    t.integer "contact_id"
+    t.integer "gogovan_order_id"
+    t.integer "order_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "need_english", default: false
+    t.boolean "need_cart", default: false
+    t.boolean "need_carry", default: false
+    t.boolean "need_over_6ft", default: false
+    t.integer "gogovan_transport_id"
+    t.string "remove_net"
+    t.index ["contact_id"], name: "index_order_transports_on_contact_id"
+    t.index ["gogovan_order_id"], name: "index_order_transports_on_gogovan_order_id"
+    t.index ["gogovan_transport_id"], name: "index_order_transports_on_gogovan_transport_id"
+    t.index ["order_id"], name: "index_order_transports_on_order_id"
+    t.index ["scheduled_at"], name: "index_order_transports_on_scheduled_at"
   end
 
-  add_index "order_transports", ["contact_id"], name: "index_order_transports_on_contact_id", using: :btree
-  add_index "order_transports", ["gogovan_order_id"], name: "index_order_transports_on_gogovan_order_id", using: :btree
-  add_index "order_transports", ["gogovan_transport_id"], name: "index_order_transports_on_gogovan_transport_id", using: :btree
-  add_index "order_transports", ["order_id"], name: "index_order_transports_on_order_id", using: :btree
-  add_index "order_transports", ["scheduled_at"], name: "index_order_transports_on_scheduled_at", using: :btree
-
-  create_table "orders", force: :cascade do |t|
-    t.string   "status"
-    t.string   "code"
-    t.string   "detail_type"
-    t.integer  "detail_id"
-    t.integer  "stockit_contact_id"
-    t.integer  "stockit_organisation_id"
-    t.integer  "stockit_id"
+  create_table "orders", id: :serial, force: :cascade do |t|
+    t.string "status"
+    t.string "code"
+    t.string "detail_type"
+    t.integer "detail_id"
+    t.integer "stockit_contact_id"
+    t.integer "stockit_organisation_id"
+    t.integer "stockit_id"
     t.datetime "created_at"
-    t.datetime "updated_at",                              null: false
-    t.text     "description"
-    t.integer  "stockit_activity_id"
-    t.integer  "country_id"
-    t.integer  "created_by_id"
-    t.integer  "processed_by_id"
-    t.integer  "organisation_id"
-    t.string   "state"
-    t.text     "purpose_description"
+    t.datetime "updated_at", null: false
+    t.text "description"
+    t.integer "stockit_activity_id"
+    t.integer "country_id"
+    t.integer "created_by_id"
+    t.integer "processed_by_id"
+    t.integer "organisation_id"
+    t.string "state"
+    t.text "purpose_description"
     t.datetime "processed_at"
-    t.integer  "process_completed_by_id"
+    t.integer "process_completed_by_id"
     t.datetime "process_completed_at"
     t.datetime "cancelled_at"
-    t.integer  "cancelled_by_id"
+    t.integer "cancelled_by_id"
     t.datetime "closed_at"
-    t.integer  "closed_by_id"
+    t.integer "closed_by_id"
     t.datetime "dispatch_started_at"
-    t.integer  "dispatch_started_by_id"
-    t.integer  "submitted_by_id"
+    t.integer "dispatch_started_by_id"
+    t.integer "submitted_by_id"
     t.datetime "submitted_at"
-    t.integer  "people_helped",           default: 0
-    t.integer  "beneficiary_id"
-    t.integer  "address_id"
-    t.integer  "district_id"
-    t.text     "cancel_reason"
-    t.integer  "booking_type_id"
-    t.string   "staff_note",              default: ""
-    t.integer  "cancellation_reason_id"
-    t.boolean  "continuous",              default: false
-    t.date     "shipment_date"
+    t.integer "people_helped", default: 0
+    t.integer "beneficiary_id"
+    t.integer "address_id"
+    t.integer "district_id"
+    t.text "cancel_reason"
+    t.integer "booking_type_id"
+    t.string "staff_note", default: ""
+    t.integer "cancellation_reason_id"
+    t.boolean "continuous", default: false
+    t.date "shipment_date"
+    t.index ["address_id"], name: "index_orders_on_address_id"
+    t.index ["beneficiary_id"], name: "index_orders_on_beneficiary_id"
+    t.index ["cancelled_by_id"], name: "index_orders_on_cancelled_by_id"
+    t.index ["closed_by_id"], name: "index_orders_on_closed_by_id"
+    t.index ["code"], name: "orders_code_idx", using: :gin
+    t.index ["country_id"], name: "index_orders_on_country_id"
+    t.index ["created_by_id"], name: "index_orders_on_created_by_id"
+    t.index ["detail_id", "detail_type"], name: "index_orders_on_detail_id_and_detail_type"
+    t.index ["detail_id"], name: "index_orders_on_detail_id"
+    t.index ["dispatch_started_by_id"], name: "index_orders_on_dispatch_started_by_id"
+    t.index ["organisation_id"], name: "index_orders_on_organisation_id"
+    t.index ["process_completed_by_id"], name: "index_orders_on_process_completed_by_id"
+    t.index ["processed_by_id"], name: "index_orders_on_processed_by_id"
+    t.index ["shipment_date"], name: "index_orders_on_shipment_date"
+    t.index ["state"], name: "index_orders_on_state"
+    t.index ["stockit_activity_id"], name: "index_orders_on_stockit_activity_id"
+    t.index ["stockit_contact_id"], name: "index_orders_on_stockit_contact_id"
+    t.index ["stockit_organisation_id"], name: "index_orders_on_stockit_organisation_id"
+    t.index ["submitted_by_id"], name: "index_orders_on_submitted_by_id"
   end
 
-  add_index "orders", ["address_id"], name: "index_orders_on_address_id", using: :btree
-  add_index "orders", ["beneficiary_id"], name: "index_orders_on_beneficiary_id", using: :btree
-  add_index "orders", ["cancelled_by_id"], name: "index_orders_on_cancelled_by_id", using: :btree
-  add_index "orders", ["closed_by_id"], name: "index_orders_on_closed_by_id", using: :btree
-  add_index "orders", ["code"], name: "orders_code_idx", using: :gin
-  add_index "orders", ["country_id"], name: "index_orders_on_country_id", using: :btree
-  add_index "orders", ["created_by_id"], name: "index_orders_on_created_by_id", using: :btree
-  add_index "orders", ["detail_id", "detail_type"], name: "index_orders_on_detail_id_and_detail_type", using: :btree
-  add_index "orders", ["detail_id"], name: "index_orders_on_detail_id", using: :btree
-  add_index "orders", ["dispatch_started_by_id"], name: "index_orders_on_dispatch_started_by_id", using: :btree
-  add_index "orders", ["organisation_id"], name: "index_orders_on_organisation_id", using: :btree
-  add_index "orders", ["process_completed_by_id"], name: "index_orders_on_process_completed_by_id", using: :btree
-  add_index "orders", ["processed_by_id"], name: "index_orders_on_processed_by_id", using: :btree
-  add_index "orders", ["shipment_date"], name: "index_orders_on_shipment_date", using: :btree
-  add_index "orders", ["state"], name: "index_orders_on_state", using: :btree
-  add_index "orders", ["stockit_activity_id"], name: "index_orders_on_stockit_activity_id", using: :btree
-  add_index "orders", ["stockit_contact_id"], name: "index_orders_on_stockit_contact_id", using: :btree
-  add_index "orders", ["stockit_organisation_id"], name: "index_orders_on_stockit_organisation_id", using: :btree
-  add_index "orders", ["submitted_by_id"], name: "index_orders_on_submitted_by_id", using: :btree
-
-  create_table "orders_packages", force: :cascade do |t|
-    t.integer  "package_id"
-    t.integer  "order_id"
-    t.string   "state"
-    t.integer  "quantity"
-    t.integer  "updated_by_id"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+  create_table "orders_packages", id: :serial, force: :cascade do |t|
+    t.integer "package_id"
+    t.integer "order_id"
+    t.string "state"
+    t.integer "quantity"
+    t.integer "updated_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "sent_on"
-    t.integer  "dispatched_quantity", default: 0
+    t.integer "dispatched_quantity", default: 0
     t.integer "shipping_number"
+    t.index ["order_id", "package_id"], name: "index_orders_packages_on_order_id_and_package_id"
+    t.index ["order_id"], name: "index_orders_packages_on_order_id"
+    t.index ["package_id", "order_id"], name: "index_orders_packages_on_package_id_and_order_id"
+    t.index ["package_id"], name: "index_orders_packages_on_package_id"
+    t.index ["updated_by_id"], name: "index_orders_packages_on_updated_by_id"
   end
 
-  add_index "orders_packages", ["order_id", "package_id"], name: "index_orders_packages_on_order_id_and_package_id", using: :btree
-  add_index "orders_packages", ["order_id"], name: "index_orders_packages_on_order_id", using: :btree
-  add_index "orders_packages", ["package_id", "order_id"], name: "index_orders_packages_on_package_id_and_order_id", using: :btree
-  add_index "orders_packages", ["package_id"], name: "index_orders_packages_on_package_id", using: :btree
-  add_index "orders_packages", ["updated_by_id"], name: "index_orders_packages_on_updated_by_id", using: :btree
-
-  create_table "orders_process_checklists", force: :cascade do |t|
+  create_table "orders_process_checklists", id: :serial, force: :cascade do |t|
     t.integer "order_id"
     t.integer "process_checklist_id"
+    t.index ["order_id"], name: "index_orders_process_checklists_on_order_id"
+    t.index ["process_checklist_id"], name: "index_orders_process_checklists_on_process_checklist_id"
   end
 
-  add_index "orders_process_checklists", ["order_id"], name: "index_orders_process_checklists_on_order_id", using: :btree
-  add_index "orders_process_checklists", ["process_checklist_id"], name: "index_orders_process_checklists_on_process_checklist_id", using: :btree
-
-  create_table "orders_purposes", force: :cascade do |t|
+  create_table "orders_purposes", id: :serial, force: :cascade do |t|
     t.integer "order_id"
     t.integer "purpose_id"
+    t.index ["order_id"], name: "index_orders_purposes_on_order_id"
+    t.index ["purpose_id"], name: "index_orders_purposes_on_purpose_id"
   end
 
-  add_index "orders_purposes", ["order_id"], name: "index_orders_purposes_on_order_id", using: :btree
-  add_index "orders_purposes", ["purpose_id"], name: "index_orders_purposes_on_purpose_id", using: :btree
-
-  create_table "organisation_types", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.string   "category_en"
-    t.string   "category_zh_tw"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-  end
-
-  create_table "organisations", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.integer  "organisation_type_id"
-    t.text     "description_en"
-    t.text     "description_zh_tw"
-    t.string   "registration"
-    t.string   "website"
-    t.integer  "country_id"
-    t.integer  "district_id"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
-    t.string   "gih3_id"
-  end
-
-  add_index "organisations", ["country_id"], name: "index_organisations_on_country_id", using: :btree
-  add_index "organisations", ["district_id"], name: "index_organisations_on_district_id", using: :btree
-  add_index "organisations", ["name_en"], name: "index_organisations_on_name_en", using: :btree
-  add_index "organisations", ["name_zh_tw"], name: "index_organisations_on_name_zh_tw", using: :btree
-  add_index "organisations", ["organisation_type_id"], name: "index_organisations_on_organisation_type_id", using: :btree
-
-  create_table "organisations_users", force: :cascade do |t|
-    t.integer  "organisation_id"
-    t.integer  "user_id"
-    t.string   "position"
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
-    t.string   "preferred_contact_number"
-    t.string   "status",                   default: "pending"
-  end
-
-  add_index "organisations_users", ["organisation_id"], name: "index_organisations_users_on_organisation_id", using: :btree
-  add_index "organisations_users", ["user_id"], name: "index_organisations_users_on_user_id", using: :btree
-
-  create_table "package_categories", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.integer  "parent_id"
+  create_table "organisation_types", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.string "category_en"
+    t.string "category_zh_tw"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "package_categories", ["parent_id"], name: "index_package_categories_on_parent_id", using: :btree
-
-  create_table "package_categories_package_types", force: :cascade do |t|
-    t.integer  "package_type_id"
-    t.integer  "package_category_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+  create_table "organisations", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.integer "organisation_type_id"
+    t.text "description_en"
+    t.text "description_zh_tw"
+    t.string "registration"
+    t.string "website"
+    t.integer "country_id"
+    t.integer "district_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "gih3_id"
+    t.index ["country_id"], name: "index_organisations_on_country_id"
+    t.index ["district_id"], name: "index_organisations_on_district_id"
+    t.index ["name_en"], name: "index_organisations_on_name_en"
+    t.index ["name_zh_tw"], name: "index_organisations_on_name_zh_tw"
+    t.index ["organisation_type_id"], name: "index_organisations_on_organisation_type_id"
   end
 
-  add_index "package_categories_package_types", ["package_category_id"], name: "index_package_categories_package_types_on_package_category_id", using: :btree
-  add_index "package_categories_package_types", ["package_type_id"], name: "index_package_categories_package_types_on_package_type_id", using: :btree
-
-  create_table "package_sets", force: :cascade do |t|
-    t.integer  "package_type_id"
-    t.text     "description"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+  create_table "organisations_users", id: :serial, force: :cascade do |t|
+    t.integer "organisation_id"
+    t.integer "user_id"
+    t.string "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "preferred_contact_number"
+    t.string "status", default: "pending"
+    t.index ["organisation_id"], name: "index_organisations_users_on_organisation_id"
+    t.index ["user_id"], name: "index_organisations_users_on_user_id"
   end
 
-  add_index "package_sets", ["package_type_id"], name: "index_package_sets_on_package_type_id", using: :btree
-
-  create_table "package_types", force: :cascade do |t|
-    t.string   "code"
-    t.string   "name_en"
-    t.string   "name_zh_tw"
-    t.string   "other_terms_en"
-    t.string   "other_terms_zh_tw"
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
-    t.boolean  "visible_in_selects",      default: false
-    t.integer  "stockit_id"
-    t.integer  "location_id"
-    t.boolean  "allow_requests",          default: true
-    t.boolean  "allow_stock",             default: false
-    t.boolean  "allow_pieces",            default: false
-    t.string   "subform"
-    t.boolean  "allow_box",               default: false
-    t.boolean  "allow_pallet",            default: false
-    t.decimal  "default_value_hk_dollar"
-    t.boolean  "allow_expiry_date",       default: false
+  create_table "package_categories", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.integer "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_package_categories_on_parent_id"
   end
 
-  add_index "package_types", ["allow_requests"], name: "index_package_types_on_allow_requests", using: :btree
-  add_index "package_types", ["location_id"], name: "index_package_types_on_location_id", using: :btree
-  add_index "package_types", ["name_en"], name: "package_types_name_en_search_idx", using: :gin
-  add_index "package_types", ["name_zh_tw"], name: "package_types_name_zh_tw_search_idx", using: :gin
-  add_index "package_types", ["stockit_id"], name: "index_package_types_on_stockit_id", using: :btree
-  add_index "package_types", ["visible_in_selects"], name: "index_package_types_on_visible_in_selects", using: :btree
+  create_table "package_categories_package_types", id: :serial, force: :cascade do |t|
+    t.integer "package_type_id"
+    t.integer "package_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["package_category_id"], name: "index_package_categories_package_types_on_package_category_id"
+    t.index ["package_type_id"], name: "index_package_categories_package_types_on_package_type_id"
+  end
 
-  create_table "packages", force: :cascade do |t|
-    t.integer  "length"
-    t.integer  "width"
-    t.integer  "height"
-    t.text     "notes"
-    t.integer  "item_id"
-    t.string   "state"
+  create_table "package_sets", id: :serial, force: :cascade do |t|
+    t.integer "package_type_id"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["package_type_id"], name: "index_package_sets_on_package_type_id"
+  end
+
+  create_table "package_types", id: :serial, force: :cascade do |t|
+    t.string "code"
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.string "other_terms_en"
+    t.string "other_terms_zh_tw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "visible_in_selects", default: false
+    t.integer "stockit_id"
+    t.integer "location_id"
+    t.boolean "allow_requests", default: true
+    t.boolean "allow_stock", default: false
+    t.boolean "allow_pieces", default: false
+    t.string "subform"
+    t.boolean "allow_box", default: false
+    t.boolean "allow_pallet", default: false
+    t.boolean "allow_expiry_date", default: false
+    t.decimal "default_value_hk_dollar"
+    t.index ["allow_requests"], name: "index_package_types_on_allow_requests"
+    t.index ["location_id"], name: "index_package_types_on_location_id"
+    t.index ["name_en"], name: "package_types_name_en_search_idx", using: :gin
+    t.index ["name_zh_tw"], name: "package_types_name_zh_tw_search_idx", using: :gin
+    t.index ["stockit_id"], name: "index_package_types_on_stockit_id"
+    t.index ["visible_in_selects"], name: "index_package_types_on_visible_in_selects"
+  end
+
+  create_table "packages", id: :serial, force: :cascade do |t|
+    t.integer "length"
+    t.integer "width"
+    t.integer "height"
+    t.text "notes"
+    t.integer "item_id"
+    t.string "state"
     t.datetime "received_at"
     t.datetime "rejected_at"
-    t.integer  "package_type_id"
+    t.integer "package_type_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.integer  "offer_id",                 default: 0
-    t.string   "inventory_number"
-    t.integer  "location_id"
-    t.string   "designation_name"
-    t.integer  "donor_condition_id"
-    t.string   "grade"
-    t.integer  "box_id"
-    t.integer  "pallet_id"
-    t.integer  "stockit_id"
-    t.integer  "order_id"
-    t.date     "stockit_sent_on"
-    t.date     "stockit_designated_on"
-    t.integer  "stockit_designated_by_id"
-    t.integer  "stockit_sent_by_id"
-    t.integer  "favourite_image_id"
-    t.date     "stockit_moved_on"
-    t.integer  "stockit_moved_by_id"
-    t.boolean  "saleable"
-    t.string   "case_number"
-    t.boolean  "allow_web_publish"
-    t.integer  "received_quantity"
-    t.integer  "weight"
-    t.integer  "pieces"
-    t.integer  "detail_id"
-    t.string   "detail_type"
-    t.integer  "storage_type_id"
-    t.integer  "available_quantity",       default: 0
-    t.integer  "on_hand_quantity",         default: 0
-    t.integer  "designated_quantity",      default: 0
-    t.integer  "dispatched_quantity",      default: 0
-    t.date     "expiry_date"
-    t.decimal  "value_hk_dollar"
-    t.integer  "package_set_id"
-    t.integer  "restriction_id"
-    t.text     "comment"
+    t.integer "offer_id", default: 0
+    t.string "inventory_number"
+    t.integer "location_id"
+    t.string "designation_name"
+    t.integer "donor_condition_id"
+    t.string "grade"
+    t.integer "box_id"
+    t.integer "pallet_id"
+    t.integer "stockit_id"
+    t.integer "order_id"
+    t.date "stockit_sent_on"
+    t.date "stockit_designated_on"
+    t.integer "stockit_designated_by_id"
+    t.integer "stockit_sent_by_id"
+    t.integer "favourite_image_id"
+    t.date "stockit_moved_on"
+    t.integer "stockit_moved_by_id"
+    t.boolean "saleable"
+    t.string "case_number"
+    t.boolean "allow_web_publish"
+    t.integer "received_quantity"
+    t.integer "weight"
+    t.integer "pieces"
+    t.integer "detail_id"
+    t.string "detail_type"
+    t.integer "storage_type_id"
+    t.integer "available_quantity", default: 0
+    t.integer "on_hand_quantity", default: 0
+    t.integer "designated_quantity", default: 0
+    t.integer "dispatched_quantity", default: 0
+    t.date "expiry_date"
+    t.decimal "value_hk_dollar"
+    t.integer "package_set_id"
+    t.integer "restriction_id"
+    t.text "comment"
+    t.index ["allow_web_publish"], name: "index_packages_on_allow_web_publish"
+    t.index ["available_quantity"], name: "index_packages_on_available_quantity"
+    t.index ["box_id"], name: "index_packages_on_box_id"
+    t.index ["case_number"], name: "index_packages_on_case_number", using: :gin
+    t.index ["designated_quantity"], name: "index_packages_on_designated_quantity"
+    t.index ["designation_name"], name: "index_packages_on_designation_name", using: :gin
+    t.index ["detail_type", "detail_id"], name: "index_packages_on_detail_type_and_detail_id"
+    t.index ["dispatched_quantity"], name: "index_packages_on_dispatched_quantity"
+    t.index ["donor_condition_id"], name: "index_packages_on_donor_condition_id"
+    t.index ["inventory_number"], name: "index_packages_on_inventory_number"
+    t.index ["inventory_number"], name: "inventory_numbers_search_idx", using: :gin
+    t.index ["item_id"], name: "index_packages_on_item_id"
+    t.index ["location_id"], name: "index_packages_on_location_id"
+    t.index ["notes"], name: "index_packages_on_notes", using: :gin
+    t.index ["offer_id"], name: "index_packages_on_offer_id"
+    t.index ["on_hand_quantity"], name: "index_packages_on_on_hand_quantity"
+    t.index ["order_id"], name: "index_packages_on_order_id"
+    t.index ["package_set_id"], name: "index_packages_on_package_set_id"
+    t.index ["package_type_id"], name: "index_packages_on_package_type_id"
+    t.index ["pallet_id"], name: "index_packages_on_pallet_id"
+    t.index ["state"], name: "index_packages_on_state", using: :gin
+    t.index ["stockit_designated_by_id"], name: "index_packages_on_stockit_designated_by_id"
+    t.index ["stockit_id"], name: "index_packages_on_stockit_id"
+    t.index ["stockit_moved_by_id"], name: "index_packages_on_stockit_moved_by_id"
+    t.index ["stockit_sent_by_id"], name: "index_packages_on_stockit_sent_by_id"
+    t.index ["storage_type_id"], name: "index_packages_on_storage_type_id"
   end
 
-  add_index "packages", ["allow_web_publish"], name: "index_packages_on_allow_web_publish", using: :btree
-  add_index "packages", ["available_quantity"], name: "index_packages_on_available_quantity", using: :btree
-  add_index "packages", ["box_id"], name: "index_packages_on_box_id", using: :btree
-  add_index "packages", ["case_number"], name: "index_packages_on_case_number", using: :gin
-  add_index "packages", ["designated_quantity"], name: "index_packages_on_designated_quantity", using: :btree
-  add_index "packages", ["designation_name"], name: "index_packages_on_designation_name", using: :gin
-  add_index "packages", ["detail_type", "detail_id"], name: "index_packages_on_detail_type_and_detail_id", using: :btree
-  add_index "packages", ["dispatched_quantity"], name: "index_packages_on_dispatched_quantity", using: :btree
-  add_index "packages", ["donor_condition_id"], name: "index_packages_on_donor_condition_id", using: :btree
-  add_index "packages", ["inventory_number"], name: "index_packages_on_inventory_number", using: :btree
-  add_index "packages", ["inventory_number"], name: "inventory_numbers_search_idx", using: :gin
-  add_index "packages", ["item_id"], name: "index_packages_on_item_id", using: :btree
-  add_index "packages", ["location_id"], name: "index_packages_on_location_id", using: :btree
-  add_index "packages", ["notes"], name: "index_packages_on_notes", using: :gin
-  add_index "packages", ["offer_id"], name: "index_packages_on_offer_id", using: :btree
-  add_index "packages", ["on_hand_quantity"], name: "index_packages_on_on_hand_quantity", using: :btree
-  add_index "packages", ["order_id"], name: "index_packages_on_order_id", using: :btree
-  add_index "packages", ["package_set_id"], name: "index_packages_on_package_set_id", using: :btree
-  add_index "packages", ["package_type_id"], name: "index_packages_on_package_type_id", using: :btree
-  add_index "packages", ["pallet_id"], name: "index_packages_on_pallet_id", using: :btree
-  add_index "packages", ["state"], name: "index_packages_on_state", using: :gin
-  add_index "packages", ["stockit_designated_by_id"], name: "index_packages_on_stockit_designated_by_id", using: :btree
-  add_index "packages", ["stockit_id"], name: "index_packages_on_stockit_id", using: :btree
-  add_index "packages", ["stockit_moved_by_id"], name: "index_packages_on_stockit_moved_by_id", using: :btree
-  add_index "packages", ["stockit_sent_by_id"], name: "index_packages_on_stockit_sent_by_id", using: :btree
-  add_index "packages", ["storage_type_id"], name: "index_packages_on_storage_type_id", using: :btree
-
-  create_table "packages_inventories", force: :cascade do |t|
-    t.integer  "package_id",  null: false
-    t.integer  "location_id", null: false
-    t.integer  "user_id",     null: false
-    t.string   "action",      null: false
-    t.string   "source_type"
-    t.integer  "source_id"
-    t.integer  "quantity",    null: false
+  create_table "packages_inventories", id: :serial, force: :cascade do |t|
+    t.integer "package_id", null: false
+    t.integer "location_id", null: false
+    t.integer "user_id", null: false
+    t.string "action", null: false
+    t.string "source_type"
+    t.integer "source_id"
+    t.integer "quantity", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "description"
+    t.text "description"
+    t.index ["action"], name: "index_packages_inventories_on_action"
+    t.index ["created_at"], name: "index_packages_inventories_on_created_at"
+    t.index ["location_id"], name: "index_packages_inventories_on_location_id"
+    t.index ["package_id", "source_type"], name: "index_packages_inventories_on_package_id_and_source_type"
+    t.index ["package_id"], name: "index_packages_inventories_on_package_id"
+    t.index ["source_id", "source_type"], name: "index_packages_inventories_on_source_id_and_source_type"
+    t.index ["source_id"], name: "index_packages_inventories_on_source_id"
+    t.index ["source_type", "package_id"], name: "index_packages_inventories_on_source_type_and_package_id"
+    t.index ["source_type", "source_id"], name: "index_packages_inventories_on_source_type_and_source_id"
+    t.index ["source_type"], name: "index_packages_inventories_on_source_type"
+    t.index ["user_id"], name: "index_packages_inventories_on_user_id"
   end
 
-  add_index "packages_inventories", ["action"], name: "index_packages_inventories_on_action", using: :btree
-  add_index "packages_inventories", ["created_at"], name: "index_packages_inventories_on_created_at", using: :btree
-  add_index "packages_inventories", ["location_id"], name: "index_packages_inventories_on_location_id", using: :btree
-  add_index "packages_inventories", ["package_id", "source_type"], name: "index_packages_inventories_on_package_id_and_source_type", using: :btree
-  add_index "packages_inventories", ["package_id"], name: "index_packages_inventories_on_package_id", using: :btree
-  add_index "packages_inventories", ["source_id", "source_type"], name: "index_packages_inventories_on_source_id_and_source_type", using: :btree
-  add_index "packages_inventories", ["source_id"], name: "index_packages_inventories_on_source_id", using: :btree
-  add_index "packages_inventories", ["source_type", "package_id"], name: "index_packages_inventories_on_source_type_and_package_id", using: :btree
-  add_index "packages_inventories", ["source_type", "source_id"], name: "index_packages_inventories_on_source_type_and_source_id", using: :btree
-  add_index "packages_inventories", ["source_type"], name: "index_packages_inventories_on_source_type", using: :btree
-  add_index "packages_inventories", ["user_id"], name: "index_packages_inventories_on_user_id", using: :btree
-
-  create_table "packages_locations", force: :cascade do |t|
-    t.integer  "package_id"
-    t.integer  "location_id"
-    t.integer  "quantity"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "reference_to_orders_package"
-  end
-
-  add_index "packages_locations", ["location_id", "package_id"], name: "index_packages_locations_on_location_id_and_package_id", using: :btree
-  add_index "packages_locations", ["location_id"], name: "index_packages_locations_on_location_id", using: :btree
-  add_index "packages_locations", ["package_id", "location_id"], name: "index_packages_locations_on_package_id_and_location_id", using: :btree
-  add_index "packages_locations", ["package_id"], name: "index_packages_locations_on_package_id", using: :btree
-  add_index "packages_locations", ["reference_to_orders_package"], name: "index_packages_locations_on_reference_to_orders_package", using: :btree
-
-  create_table "pallets", force: :cascade do |t|
-    t.string   "pallet_number"
-    t.string   "description"
-    t.text     "comments"
-    t.integer  "stockit_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-  end
-
-  create_table "permissions", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "printers", force: :cascade do |t|
-    t.boolean  "active"
-    t.integer  "location_id"
-    t.string   "name"
-    t.string   "host"
-    t.string   "port"
-    t.string   "username"
-    t.string   "password"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
-
-  create_table "printers_users", force: :cascade do |t|
-    t.integer "printer_id"
-    t.integer "user_id"
-    t.string  "tag"
-  end
-
-  create_table "process_checklists", force: :cascade do |t|
-    t.string  "text_en"
-    t.string  "text_zh_tw"
-    t.integer "booking_type_id"
-  end
-
-  add_index "process_checklists", ["booking_type_id"], name: "index_process_checklists_on_booking_type_id", using: :btree
-
-  create_table "purposes", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "packages_locations", id: :serial, force: :cascade do |t|
+    t.integer "package_id"
+    t.integer "location_id"
+    t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "identifier"
+    t.integer "reference_to_orders_package"
+    t.index ["location_id", "package_id"], name: "index_packages_locations_on_location_id_and_package_id"
+    t.index ["location_id"], name: "index_packages_locations_on_location_id"
+    t.index ["package_id", "location_id"], name: "index_packages_locations_on_package_id_and_location_id"
+    t.index ["package_id"], name: "index_packages_locations_on_package_id"
+    t.index ["reference_to_orders_package"], name: "index_packages_locations_on_reference_to_orders_package"
   end
 
-  create_table "rejection_reasons", force: :cascade do |t|
-    t.string   "name_en"
+  create_table "pallets", id: :serial, force: :cascade do |t|
+    t.string "pallet_number"
+    t.string "description"
+    t.text "comments"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "permissions", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name_zh_tw"
   end
 
-  create_table "requested_packages", force: :cascade do |t|
+  create_table "printers", id: :serial, force: :cascade do |t|
+    t.boolean "active"
+    t.integer "location_id"
+    t.string "name"
+    t.string "host"
+    t.string "port"
+    t.string "username"
+    t.string "password"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "printers_users", id: :serial, force: :cascade do |t|
+    t.integer "printer_id"
+    t.integer "user_id"
+    t.string "tag"
+  end
+
+  create_table "process_checklists", id: :serial, force: :cascade do |t|
+    t.string "text_en"
+    t.string "text_zh_tw"
+    t.integer "booking_type_id"
+    t.index ["booking_type_id"], name: "index_process_checklists_on_booking_type_id"
+  end
+
+  create_table "purposes", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "identifier"
+  end
+
+  create_table "rejection_reasons", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "name_zh_tw"
+  end
+
+  create_table "requested_packages", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "package_id"
     t.boolean "is_available"
-    t.integer "quantity",     default: 1
+    t.integer "quantity", default: 1
+    t.index ["package_id", "user_id"], name: "index_requested_packages_on_package_id_and_user_id", unique: true
+    t.index ["package_id"], name: "index_requested_packages_on_package_id"
+    t.index ["user_id", "package_id"], name: "index_requested_packages_on_user_id_and_package_id", unique: true
+    t.index ["user_id"], name: "index_requested_packages_on_user_id"
   end
 
-  add_index "requested_packages", ["package_id", "user_id"], name: "index_requested_packages_on_package_id_and_user_id", unique: true, using: :btree
-  add_index "requested_packages", ["package_id"], name: "index_requested_packages_on_package_id", using: :btree
-  add_index "requested_packages", ["user_id", "package_id"], name: "index_requested_packages_on_user_id_and_package_id", unique: true, using: :btree
-  add_index "requested_packages", ["user_id"], name: "index_requested_packages_on_user_id", using: :btree
-
-  create_table "restrictions", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "restrictions", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "role_permissions", force: :cascade do |t|
-    t.integer  "role_id"
-    t.integer  "permission_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-  end
-
-  add_index "role_permissions", ["permission_id"], name: "index_role_permissions_on_permission_id", using: :btree
-  add_index "role_permissions", ["role_id"], name: "index_role_permissions_on_role_id", using: :btree
-
-  create_table "roles", force: :cascade do |t|
-    t.string   "name"
+  create_table "role_permissions", id: :serial, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "permission_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer  "level"
+    t.index ["permission_id"], name: "index_role_permissions_on_permission_id"
+    t.index ["role_id"], name: "index_role_permissions_on_role_id"
   end
 
-  add_index "roles", ["level"], name: "index_roles_on_level", using: :btree
+  create_table "roles", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "level"
+    t.index ["level"], name: "index_roles_on_level"
+  end
 
-  create_table "schedules", force: :cascade do |t|
-    t.string   "resource"
-    t.integer  "slot"
-    t.string   "slot_name"
-    t.string   "zone"
+  create_table "schedules", id: :serial, force: :cascade do |t|
+    t.string "resource"
+    t.integer "slot"
+    t.string "slot_name"
+    t.string "zone"
     t.datetime "scheduled_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "stockit_activities", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "stockit_id"
+  create_table "stockit_activities", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "stockit_contacts", force: :cascade do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "mobile_phone_number"
-    t.string   "phone_number"
-    t.integer  "stockit_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-  end
-
-  add_index "stockit_contacts", ["first_name"], name: "st_contacts_first_name_idx", using: :gin
-  add_index "stockit_contacts", ["last_name"], name: "st_contacts_last_name_idx", using: :gin
-  add_index "stockit_contacts", ["mobile_phone_number"], name: "st_contacts_mobile_phone_number_idx", using: :gin
-  add_index "stockit_contacts", ["phone_number"], name: "st_contacts_phone_number_idx", using: :gin
-
-  create_table "stockit_local_orders", force: :cascade do |t|
-    t.string   "client_name"
-    t.string   "hkid_number"
-    t.string   "reference_number"
-    t.integer  "stockit_id"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
-    t.text     "purpose_of_goods"
-  end
-
-  add_index "stockit_local_orders", ["client_name"], name: "st_local_orders_client_name_idx", using: :gin
-
-  create_table "stockit_organisations", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "stockit_id"
+  create_table "stockit_contacts", id: :serial, force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "mobile_phone_number"
+    t.string "phone_number"
+    t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["first_name"], name: "st_contacts_first_name_idx", using: :gin
+    t.index ["last_name"], name: "st_contacts_last_name_idx", using: :gin
+    t.index ["mobile_phone_number"], name: "st_contacts_mobile_phone_number_idx", using: :gin
+    t.index ["phone_number"], name: "st_contacts_phone_number_idx", using: :gin
   end
 
-  add_index "stockit_organisations", ["name"], name: "st_organisations_name_idx", using: :gin
-
-  create_table "stocktake_revisions", force: :cascade do |t|
-    t.integer  "stocktake_id",                        null: false
-    t.integer  "package_id",                          null: false
-    t.integer  "quantity",        default: 0,         null: false
-    t.string   "state",           default: "pending", null: false
-    t.boolean  "dirty",           default: false,     null: false
-    t.string   "warning"
-    t.integer  "created_by_id"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.integer  "processed_delta", default: 0
+  create_table "stockit_local_orders", id: :serial, force: :cascade do |t|
+    t.string "client_name"
+    t.string "hkid_number"
+    t.string "reference_number"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "purpose_of_goods"
+    t.index ["client_name"], name: "st_local_orders_client_name_idx", using: :gin
   end
 
-  add_index "stocktake_revisions", ["package_id", "stocktake_id"], name: "index_stocktake_revisions_on_package_id_and_stocktake_id", unique: true, using: :btree
-  add_index "stocktake_revisions", ["package_id"], name: "index_stocktake_revisions_on_package_id", using: :btree
-  add_index "stocktake_revisions", ["stocktake_id", "package_id"], name: "index_stocktake_revisions_on_stocktake_id_and_package_id", unique: true, using: :btree
-  add_index "stocktake_revisions", ["stocktake_id"], name: "index_stocktake_revisions_on_stocktake_id", using: :btree
-
-  create_table "stocktakes", force: :cascade do |t|
-    t.string   "name",                           null: false
-    t.string   "state",         default: "open"
-    t.string   "comment"
-    t.integer  "created_by_id"
-    t.integer  "location_id",                    null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+  create_table "stockit_organisations", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "stockit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "st_organisations_name_idx", using: :gin
   end
 
-  add_index "stocktakes", ["location_id"], name: "index_stocktakes_on_location_id", using: :btree
-  add_index "stocktakes", ["name"], name: "index_stocktakes_on_name", unique: true, using: :btree
-
-  create_table "storage_types", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.integer  "max_unit_quantity"
+  create_table "stocktake_revisions", id: :serial, force: :cascade do |t|
+    t.integer "stocktake_id", null: false
+    t.integer "package_id", null: false
+    t.integer "quantity", default: 0, null: false
+    t.string "state", default: "pending", null: false
+    t.boolean "dirty", default: false, null: false
+    t.string "warning"
+    t.integer "created_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "processed_delta", default: 0
+    t.index ["package_id", "stocktake_id"], name: "index_stocktake_revisions_on_package_id_and_stocktake_id", unique: true
+    t.index ["package_id"], name: "index_stocktake_revisions_on_package_id"
+    t.index ["stocktake_id", "package_id"], name: "index_stocktake_revisions_on_stocktake_id_and_package_id", unique: true
+    t.index ["stocktake_id"], name: "index_stocktake_revisions_on_stocktake_id"
   end
 
-  create_table "subpackage_types", force: :cascade do |t|
-    t.integer  "package_type_id"
-    t.integer  "subpackage_type_id"
-    t.boolean  "is_default",         default: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+  create_table "stocktakes", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "state", default: "open"
+    t.string "comment"
+    t.integer "created_by_id"
+    t.integer "location_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_stocktakes_on_location_id"
+    t.index ["name"], name: "index_stocktakes_on_name", unique: true
   end
 
-  add_index "subpackage_types", ["package_type_id", "package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id", using: :btree
-  add_index "subpackage_types", ["package_type_id"], name: "index_subpackage_types_on_package_type_id", using: :btree
-  add_index "subpackage_types", ["subpackage_type_id"], name: "index_subpackage_types_on_subpackage_type_id", using: :btree
+  create_table "storage_types", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "max_unit_quantity"
+  end
 
-  create_table "subscriptions", force: :cascade do |t|
+  create_table "subpackage_types", id: :serial, force: :cascade do |t|
+    t.integer "package_type_id"
+    t.integer "subpackage_type_id"
+    t.boolean "is_default", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["package_type_id", "package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
+    t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id"
+    t.index ["subpackage_type_id"], name: "index_subpackage_types_on_subpackage_type_id"
+  end
+
+  create_table "subscriptions", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "message_id"
-    t.string  "state"
-    t.string  "subscribable_type"
+    t.string "state"
+    t.string "subscribable_type"
     t.integer "subscribable_id"
+    t.index ["message_id"], name: "index_subscriptions_on_message_id"
+    t.index ["state"], name: "index_subscriptions_on_state"
+    t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
-  add_index "subscriptions", ["message_id"], name: "index_subscriptions_on_message_id", using: :btree
-  add_index "subscriptions", ["state"], name: "index_subscriptions_on_state", using: :btree
-  add_index "subscriptions", ["user_id"], name: "index_subscriptions_on_user_id", using: :btree
-
-  create_table "territories", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "territories", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "timeslots", force: :cascade do |t|
-    t.string   "name_en"
-    t.string   "name_zh_tw"
+  create_table "timeslots", id: :serial, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_zh_tw"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "user_roles", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "role_id"
+  create_table "user_roles", id: :serial, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "role_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "expires_at"
+    t.index ["role_id"], name: "index_user_roles_on_role_id"
+    t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
-  add_index "user_roles", ["role_id"], name: "index_user_roles_on_role_id", using: :btree
-  add_index "user_roles", ["user_id"], name: "index_user_roles_on_user_id", using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "mobile"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "image_id"
+    t.integer "image_id"
     t.datetime "last_connected"
     t.datetime "last_disconnected"
-    t.boolean  "disabled",             default: false
-    t.string   "email"
-    t.string   "title"
+    t.boolean "disabled", default: false
+    t.string "email"
+    t.string "title"
     t.datetime "sms_reminder_sent_at"
-    t.boolean  "is_mobile_verified",   default: false
-    t.boolean  "is_email_verified",    default: false
-    t.boolean  "receive_email",        default: false
-    t.string   "other_phone"
-    t.integer  "printer_id"
-    t.string   "preferred_language"
+    t.boolean "is_mobile_verified", default: false
+    t.boolean "is_email_verified", default: false
+    t.boolean "receive_email", default: false
+    t.string "other_phone"
+    t.string "preferred_language"
+    t.index ["image_id"], name: "index_users_on_image_id"
+    t.index ["mobile"], name: "index_users_on_mobile"
+    t.index ["sms_reminder_sent_at"], name: "index_users_on_sms_reminder_sent_at"
   end
 
-  add_index "users", ["image_id"], name: "index_users_on_image_id", using: :btree
-  add_index "users", ["mobile"], name: "index_users_on_mobile", using: :btree
-  add_index "users", ["sms_reminder_sent_at"], name: "index_users_on_sms_reminder_sent_at", using: :btree
-
-  create_table "valuation_matrices", force: :cascade do |t|
-    t.integer  "donor_condition_id", null: false
-    t.string   "grade",              null: false
-    t.decimal  "multiplier",         null: false
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+  create_table "valuation_matrices", id: :serial, force: :cascade do |t|
+    t.integer "donor_condition_id", null: false
+    t.string "grade", null: false
+    t.decimal "multiplier", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "versions", force: :cascade do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
-    t.string   "whodunnit"
-    t.jsonb    "object"
-    t.jsonb    "object_changes"
-    t.integer  "related_id"
-    t.string   "related_type"
+  create_table "versions", id: :serial, force: :cascade do |t|
+    t.string "item_type", null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.jsonb "object_changes"
+    t.integer "related_id"
+    t.string "related_type"
     t.datetime "created_at"
+    t.index ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))"
+    t.index ["created_at"], name: "index_versions_on_created_at"
+    t.index ["event"], name: "index_versions_on_event"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["item_type"], name: "index_versions_on_item_type"
+    t.index ["related_type", "related_id"], name: "index_versions_on_related_type_and_related_id"
+    t.index ["related_type"], name: "index_versions_on_related_type"
+    t.index ["whodunnit"], name: "index_versions_on_whodunnit"
   end
-
-  add_index "versions", ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))", using: :btree
-  add_index "versions", ["created_at"], name: "index_versions_on_created_at", using: :btree
-  add_index "versions", ["event"], name: "index_versions_on_event", using: :btree
-  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
-  add_index "versions", ["item_type"], name: "index_versions_on_item_type", using: :btree
-  add_index "versions", ["related_type", "related_id"], name: "index_versions_on_related_type_and_related_id", using: :btree
-  add_index "versions", ["related_type"], name: "index_versions_on_related_type", using: :btree
-  add_index "versions", ["whodunnit"], name: "index_versions_on_whodunnit", using: :btree
 
   add_foreign_key "addresses", "districts", name: "addresses_district_id_fk"
   add_foreign_key "auth_tokens", "users", name: "auth_tokens_user_id_fk"
@@ -1171,6 +1126,5 @@ ActiveRecord::Schema.define(version: 2020_10_06_145926) do
   add_foreign_key "user_roles", "roles", name: "user_roles_role_id_fk"
   add_foreign_key "user_roles", "users", name: "user_roles_user_id_fk"
   add_foreign_key "users", "images", name: "users_image_id_fk"
-  add_foreign_key "users", "printers"
   add_foreign_key "valuation_matrices", "donor_conditions"
 end

--- a/lib/goodcity/errors.rb
+++ b/lib/goodcity/errors.rb
@@ -96,6 +96,8 @@ module Goodcity
   DuplicateRecordError            = factory(BaseError, 'errors.duplicate_error', status: 409)
   InvalidParamsError              = factory(BaseError, 'errors.invalid_params', status: 422)
   NotFoundError                   = factory(BaseError, 'errors.not_found', status: 404)
+  ForeignKeyMismatchError         = factory(BaseError, 'errors.foreign_key_mismatch_violation', status: 409)
+  ForeignKeyDeletionError         = factory(BaseError, 'errors.foreign_key_delete_violation', status: 409)
 
   AccessDeniedError               = factory(AccessError, 'errors.forbidden', status: 403)
   UnauthorizedError               = factory(AccessError, 'warden.unauthorized', status: 401)

--- a/spec/controllers/api/v1/api_controller_spec.rb
+++ b/spec/controllers/api/v1/api_controller_spec.rb
@@ -11,12 +11,31 @@ RSpec.describe Api::V1::ApiController, type: :controller do
       end
     end
 
-    # TODO: Fix tests for 4XX status
-    # it do
-    #   get :index
-    #   expect(response.status).to eq(404)
-    #   expect(subject).to eql( {"error"=>"Oh noes !"} )
-    # end
+    it do
+      get :index
+      expect(response.status).to eq(404)
+      expect(subject).to eql( {"error"=>"Oh noes !"} )
+    end
+  end
+
+  context "handling PG::ForeignKeyViolation exceptions" do
+    controller do
+      def index
+        raise PG::ForeignKeyViolation
+      end
+    end
+
+    it do
+      get :index, format: 'json'
+      expect(response.status).to eq(409)
+      expect(subject['error']).to eq('A broken entity relationship has occurred')
+    end
+
+    it do
+      delete :index, format: 'json'
+      expect(response.status).to eq(409)
+      expect(subject['error']).to eq('Another entity is dependent on the record you are trying to delete')
+    end
   end
 
   context "handling CanCan::AccessDenied exceptions" do
@@ -26,11 +45,10 @@ RSpec.describe Api::V1::ApiController, type: :controller do
       end
     end
 
-    # TODO: Fix tests for 4XX status
-    # it do
-    #   get :index, format: 'json'
-    #   expect(response.status).to eq(403)
-    # end
+    it do
+      get :index, format: 'json'
+      expect(response.status).to eq(403)
+    end
   end
 
   context "handling Apipie::ParamInvalid exceptions" do

--- a/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slot_presets_controller_spec.rb
@@ -9,11 +9,10 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
 
   describe "GET /appointment_slot_presets" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "prevents reading default slots", :show_in_doc do
-      #   get :index
-      #   expect(response.status).to eq(401)
-      # end
+      it "prevents reading default slots", :show_in_doc do
+        get :index
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as Supervisor' do
@@ -43,16 +42,15 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
 
   describe "POST /appointment_slot_presets" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies creation of a default appointment slot" do
-      #   post :create, appointment_slot_preset: payload
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies creation of a default appointment slot" do
+        post :create, params: { appointment_slot_preset: payload }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in without permissions' do
       before { generate_and_set_token(no_permission_user) }
-      # TODO: Fix tests for 4XX status
+
       it "denies creation of a default appointment slot" do
         post :create, params: { appointment_slot_preset: payload }
         expect(response.status).to eq(403)
@@ -90,11 +88,10 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
 
   describe "PUT /appointment_slot_presets/1" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies update of an appointment slot preset" do
-      #   put :update, id: appt_slot.id, appointment_slot_preset: payload
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies update of an appointment slot preset" do
+        put :update, params: { id: appt_slot.id, appointment_slot_preset: payload }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as a user without can_manage_settings permission' do
@@ -126,11 +123,10 @@ RSpec.describe Api::V1::AppointmentSlotPresetsController, type: :controller do
 
   describe "DELETE /appointment_slot_presets/1" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies destruction of an appointment slot preset" do
-      #   delete :destroy, params: { id: appt_slot.id }
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies destruction of an appointment slot preset" do
+        delete :destroy, params: { id: appt_slot.id }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as a user without can_manage_settings permission' do

--- a/spec/controllers/api/v1/appointment_slots_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slots_controller_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe Api::V1::AppointmentSlotsController, type: :controller do
 
   describe "GET /appointment_slots" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "prevents reading slots", :show_in_doc do
-      #   get :index
-      #   expect(response.status).to eq(401)
-      # end
+      it "prevents reading slots", :show_in_doc do
+        get :index
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as Supervisor' do
@@ -182,11 +181,10 @@ RSpec.describe Api::V1::AppointmentSlotsController, type: :controller do
     let!(:payload) { {quota: 5, timestamp: now.to_s} }
 
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies creation of an appointment slot" do
-      #   post :create, appointment_slot: payload
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies creation of an appointment slot" do
+        post :create, params: { appointment_slot: payload }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in without permissions' do
@@ -221,11 +219,10 @@ RSpec.describe Api::V1::AppointmentSlotsController, type: :controller do
     let!(:appt_slot) { FactoryBot.create :appointment_slot, timestamp: now, quota: 10 }
 
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies update of an appointment slot" do
-      #   put :update, params: { id: appt_slot.id, appointment_slot: {quota: 5 } }
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies update of an appointment slot" do
+        put :update, params: { id: appt_slot.id, appointment_slot: {quota: 5 } }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as a user without can_manage_settings permission' do
@@ -256,11 +253,10 @@ RSpec.describe Api::V1::AppointmentSlotsController, type: :controller do
     let!(:appt_slot) { FactoryBot.create :appointment_slot, timestamp: now, quota: 10 }
 
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies destruction of an appointment slot" do
-      #   delete :destroy, id: appt_slot.id
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies destruction of an appointment slot" do
+        delete :destroy, params: { id: appt_slot.id }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as a user without can_manage_settings permission' do

--- a/spec/controllers/api/v1/beneficiaries_controller_spec.rb
+++ b/spec/controllers/api/v1/beneficiaries_controller_spec.rb
@@ -11,11 +11,10 @@ RSpec.describe Api::V1::BeneficiariesController, type: :controller do
 
   describe "GET beneficiaries" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "prevents reading beneficiaries", :show_in_doc do
-      #   get :index
-      #   expect(response.status).to eq(401)
-      # end
+      it "prevents reading beneficiaries", :show_in_doc do
+        get :index
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as Supervisor' do
@@ -76,11 +75,10 @@ RSpec.describe Api::V1::BeneficiariesController, type: :controller do
 
   describe "POST /beneficiaries" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies creation of a beneficiary" do
-      #   post :create, params: { beneficiary: payload }
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies creation of a beneficiary" do
+        post :create, params: { beneficiary: payload }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as Charity user' do
@@ -106,11 +104,10 @@ RSpec.describe Api::V1::BeneficiariesController, type: :controller do
 
   describe "PUT /beneficiaries/1" do
     context 'When not logged in' do
-      # TODO: Fix tests for 4XX status
-      # it "denies update of a beneficiary" do
-      #   put :update, params: { id: beneficiary.id, beneficiary: payload }
-      #   expect(response.status).to eq(401)
-      # end
+      it "denies update of a beneficiary" do
+        put :update, params: { id: beneficiary.id, beneficiary: payload }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'When logged in as a user without can_manage_orders permission' do

--- a/spec/controllers/api/v1/goodcity_settings_controller_spec.rb
+++ b/spec/controllers/api/v1/goodcity_settings_controller_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
 
   describe "POST /goodicty_settings" do
     context "as a guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   post :create, params: { goodcity_setting: goodcity_setting_params }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        post :create, params: { goodcity_setting: goodcity_setting_params }
+        expect(response.status).to eq(401)
+      end
     end
 
     context "as a user without 'can_manage_settings' permission" do
@@ -51,11 +50,10 @@ RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
     end
 
     context "as a guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   put :update, params: { id: goodcity_setting.id, goodcity_setting: goodcity_setting_params }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        put :update, params: { id: goodcity_setting.id, goodcity_setting: goodcity_setting_params }
+        expect(response.status).to eq(401)
+      end
     end
 
     context "as a user without 'can_manage_settings' permission" do
@@ -84,11 +82,10 @@ RSpec.describe Api::V1::GoodcitySettingsController, type: :controller do
     end
 
     context "as a guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   delete :destroy, params: { id: goodcity_setting.id, goodcity_setting: goodcity_setting_params }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        delete :destroy, params: { id: goodcity_setting.id, goodcity_setting: goodcity_setting_params }
+        expect(response.status).to eq(401)
+      end
     end
 
     context "as a user without 'can_manage_settings' permission" do

--- a/spec/controllers/api/v1/package_sets_controller_spec.rb
+++ b/spec/controllers/api/v1/package_sets_controller_spec.rb
@@ -42,11 +42,10 @@ RSpec.describe Api::V1::PackageSetsController, type: :controller do
     end
 
     describe "as guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns a 401 " do
-      #   get :show, params: { id: package_set.id}
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns a 401 " do
+        get :show, params: { id: package_set.id}
+        expect(response.status).to eq(401)
+      end
     end
   end
 
@@ -84,11 +83,10 @@ RSpec.describe Api::V1::PackageSetsController, type: :controller do
     end
 
     describe "as guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns a 401 " do
-      #   post :create, params: post_body
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns a 401 " do
+        post :create, params: post_body
+        expect(response.status).to eq(401)
+      end
     end
   end
 
@@ -121,11 +119,10 @@ RSpec.describe Api::V1::PackageSetsController, type: :controller do
     end
 
     describe "as guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns a 401 " do
-      #   put :update, params: { id: package_set.id, package_set: params }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns a 401 " do
+        put :update, params: { id: package_set.id, package_set: params }
+        expect(response.status).to eq(401)
+      end
     end
   end
 
@@ -166,11 +163,10 @@ RSpec.describe Api::V1::PackageSetsController, type: :controller do
     end
 
     describe "as guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns a 401 " do
-      #   delete :destroy, params: { id: package_set.id }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns a 401 " do
+        delete :destroy, params: { id: package_set.id }
+        expect(response.status).to eq(401)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/process_checklists_controller_spec.rb
+++ b/spec/controllers/api/v1/process_checklists_controller_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe Api::V1::ProcessChecklistsController, type: :controller do
     end
 
     describe 'as an anonymous user' do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401", :show_in_doc do
-      #   get :index
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401", :show_in_doc do
+        get :index
+        expect(response.status).to eq(401)
+      end
     end
 
     describe 'as a user without the ability' do

--- a/spec/controllers/api/v1/requested_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/requested_packages_controller_spec.rb
@@ -23,11 +23,10 @@ RSpec.describe Api::V1::RequestedPackagesController, type: :controller do
 
   describe "GET requested_pacakges" do
     context "as a guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   get :index
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        get :index
+        expect(response.status).to eq(401)
+      end
     end
 
     user_types.each do |user_type|
@@ -107,17 +106,16 @@ RSpec.describe Api::V1::RequestedPackagesController, type: :controller do
 
   describe "PUT /requested_package/:id" do
     context 'if invalid user' do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   put :update, params: { id: create(:requested_package).id }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        put :update, params: { id: create(:requested_package).id }
+        expect(response.status).to eq(401)
+      end
 
-      # it "returns 403 for invalid login" do
-      #   create(:user)
-      #   put :update, params: { id: create(:requested_package).id }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 403 for invalid login" do
+        create(:user)
+        put :update, params: { id: create(:requested_package).id }
+        expect(response.status).to eq(401)
+      end
     end
 
     context 'if valid user' do
@@ -158,11 +156,10 @@ RSpec.describe Api::V1::RequestedPackagesController, type: :controller do
 
   describe "DELETE /requested_package/:id" do
     context "as a guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   delete :destroy, params: { id: create(:requested_package).id }
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        delete :destroy, params: { id: create(:requested_package).id }
+        expect(response.status).to eq(401)
+      end
     end
 
     user_types.each do |user_type|
@@ -194,11 +191,10 @@ RSpec.describe Api::V1::RequestedPackagesController, type: :controller do
 
   describe "Checkout process" do
     context "as a guest" do
-      # TODO: Fix tests for 4XX status
-      # it "returns 401" do
-      #   post :checkout
-      #   expect(response.status).to eq(401)
-      # end
+      it "returns 401" do
+        post :checkout
+        expect(response.status).to eq(401)
+      end
     end
 
     user_types.each do |user_type|

--- a/spec/controllers/api/v2/ability_spec.rb
+++ b/spec/controllers/api/v2/ability_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V2::Ability do
       subject { Api::V2::Ability.new(user) }
 
       it "takes the permissions from all roles" do
-        expect(subject.user_permissions).to match([
+        expect(subject.user_permissions).to match_array([
           "permission_a1",
           "permission_a2",
           "permission_b1",
@@ -37,7 +37,7 @@ RSpec.describe Api::V2::Ability do
       subject { Api::V2::Ability.new(user, role: role_a) }
 
       it "only takes the permissions from the mentioned role" do
-        expect(subject.user_permissions).to match([
+        expect(subject.user_permissions).to match_array([
           "permission_a1",
           "permission_a2",
         ])

--- a/spec/controllers/api/v2/ability_spec.rb
+++ b/spec/controllers/api/v2/ability_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::Ability do
+  let(:user) { create :user }
+  let(:role_a) { create :role, name: 'Role A', level: 15 }
+  let(:role_b) { create :role, name: 'Role B', level: 10 }
+  let(:permission_a1) { create :permission, name: 'permission_a1' }
+  let(:permission_a2) { create :permission, name: 'permission_a2' }
+  let(:permission_b1) { create :permission, name: 'permission_b1' }
+  let(:permission_b2) { create :permission, name: 'permission_b2' }
+
+  before do
+    create :role_permission, role: role_a, permission: permission_a1
+    create :role_permission, role: role_a, permission: permission_a2
+    create :role_permission, role: role_b, permission: permission_b1
+    create :role_permission, role: role_b, permission: permission_b2
+
+    role_a.grant(user)
+    role_b.grant(user)
+  end
+
+  describe "Permission resolution" do
+    context "as a user with no specified role" do
+      subject { Api::V2::Ability.new(user) }
+
+      it "takes the permissions from all roles" do
+        expect(subject.user_permissions).to match([
+          "permission_a1",
+          "permission_a2",
+          "permission_b1",
+          "permission_b2"
+        ])
+      end
+    end
+
+    context "as a user with a specified role" do
+      subject { Api::V2::Ability.new(user, role: role_a) }
+
+      it "only takes the permissions from the mentioned role" do
+        expect(subject.user_permissions).to match([
+          "permission_a1",
+          "permission_a2",
+        ])
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v2/api_controller_spec.rb
+++ b/spec/controllers/api/v2/api_controller_spec.rb
@@ -69,13 +69,13 @@ RSpec.describe Api::V2::ApiController, type: :controller do
       end
     end
 
-    it do
+    it 'handles broken foreign key with an appropriate message' do
       get :index, format: 'json'
       expect(response.status).to eq(409)
       expect(subject['error']).to eq('A broken entity relationship has occurred')
     end
 
-    it do
+    it 'handles broken foreign key during a deletion with an appropriate message'do
       delete :index, format: 'json'
       expect(response.status).to eq(409)
       expect(subject['error']).to eq('Another entity is dependent on the record you are trying to delete')

--- a/spec/models/beneficiary_spec.rb
+++ b/spec/models/beneficiary_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe Beneficiary, type: :model do
     it { is_expected.to belong_to :created_by }
   end
 
+  describe "Lifecycle" do
+    context "on destruction" do
+      let(:order) { create :order }
+      let(:beneficiary) { order.beneficiary }
+
+      it "clears its own beneficiary_id from orders" do
+        expect {
+          beneficiary.destroy!
+        }.to change {
+          order.reload.beneficiary_id
+        }.from(beneficiary.id).to(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Changes

- orders.beneficiary_id nulled before beneficiary is deleted
- restored some commented tests
- api v2 role specification: empty role defaults to all role behaviour
- added a default error message for all foreign key related issue
- prevent frontend from setting `stockit_organisation_id` as it caused broken foreign keys