### PR TITLE
Fix Validation Error on order designation

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -440,6 +440,7 @@ class Package < ApplicationRecord
 
   def validate_package_type
     return unless box_or_pallet?
+    return unless package_type_id_changed?
 
     count = PackagesInventory.packages_contained_in(self).count
     errors.add(:error, I18n.t('box_pallet.errors.cannot_change_type')) if count.positive?

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -1639,6 +1639,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
             order = create(:order, :with_state_submitted)
             put :designate, params: { id: box.id, quantity: 1, order_id: order.id }
             expect(response.status).to eq(200)
+            expect(box.reload.designated_quantity).to eq(1)
           end
         end
       end

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -1630,6 +1630,17 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
             expect(package1.on_hand_boxed_quantity).to eq(5)
           end
         end
+
+        context 'when designating a box/pallet to order' do
+          it 'should designate to the order' do
+            put :add_remove_item, params: params
+            expect(package1.reload.on_hand_boxed_quantity).to eq(5)
+
+            order = create(:order, :with_state_submitted)
+            put :designate, params: { id: box.id, quantity: 1, order_id: order.id }
+            expect(response.status).to eq(200)
+          end
+        end
       end
 
       context 'remove item from container' do


### PR DESCRIPTION
On designating a box or pallet to the order, a validation error pops up `Cannot change type of a box with items. Please remove the items and try again`

This will fix the scenario