### PR TITLE
GCW-3376 Fix User Charity Search

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -22,7 +22,7 @@ module Api
       def index
         @users = @users.except_stockit_user
         return search_user_and_render_json if params[:searchText].present?
-        
+
         @users = @users.with_roles(params[:roles]) if params[:roles].present?
         @users = @users.where(id: ids_param) if ids_param.present?
         render json: @users, each_serializer: serializer
@@ -88,14 +88,15 @@ module Api
 
       def search_user_and_render_json
         records = @users.limit(25)
-        records = records.search(params['searchText'])               if params['searchText'].present?
-        records = records.with_roles(params['role_name'])            if params['role_name'].present?
+        records = records.search(params['searchText']) if params['searchText'].present?
+        records = records.search_by_role(params['role_name']) if params['role_name'].present?
+
         data = ActiveModel::ArraySerializer.new(records,
           each_serializer: Api::V1::UserDetailsSerializer,
           include_user_roles: true,
-          root: "users"
+          root: 'users'
         ).as_json
-        render json: { "meta": {"search": params["searchText"] } }.merge(data)
+        render json: { 'meta': { 'search': params['searchText'] } }.merge(data)
       end
 
       def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,14 @@ class User < ApplicationRecord
       .order("orders.id DESC").limit(5)
   end
 
+  def self.search_by_role(name)
+    if name == 'Charity'
+      joins(:organisations_users).where(organisations_users: { status: [OrganisationsUser::ACTIVE_STATUS] })
+    else
+      with_roles(name)
+    end
+  end
+
   def allowed_login?(app_name)
     if [DONOR_APP, BROWSE_APP].include?(app_name)
       return true

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     it "is tolerant to typos" do
       get :index, params: { searchText: "jannne"  }
       expect(response.status).to eq(200)
-      expect(parsed_body['users'].count).to eq(2)
+      expect(parsed_body['users'].count).to eq(3)
 
       ids = parsed_body['users'].map { |u| u['id'] }
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
-  describe "GET searched user" do    
+  describe "GET searched user" do
     let(:role_1) { create(:role, name: "Role 1", level: 1) }
     let(:role_2) { create(:role, name: "Role 2", level: 5) }
 
@@ -64,8 +64,9 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     let(:user_3) { create(:user, :charity, first_name: "John", last_name: 'Doe') }
     let(:user_4) { create(:user, :charity, first_name: "Foo", last_name: 'Bar') }
     let(:user_5) { create(:user, :charity, first_name: "Stephen", last_name: 'K') }
+    let(:user_6) { create(:user, first_name: 'Jango', last_name: 'Charlie') }
 
-    let(:supervisor) { create :user, :with_can_read_or_modify_user_permission, role_name: 'Supervisor' }
+    let(:supervisor) { create :user, :with_can_read_or_modify_user_permission, role_name: 'Supervisor', first_name: 'Jane', last_name: 'Brown' }
 
     before do
       User.destroy_all # Ensure no lingering users exist
@@ -138,6 +139,22 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       get :index, params: { searchText: "jneo"  }
       expect(response.status).to eq(200)
       expect(parsed_body['users'].count).to eq(0)
+    end
+
+    context 'when search scope is restricted for charity users' do
+      it 'returns charity users' do
+        get :index, params: { searchText: 'jannne', role_name: 'Charity' }
+        expect(response.status).to eq(200)
+        expect(parsed_body['users'].count).to eq(2)
+      end
+    end
+
+    context 'when search scope is not restricted to any roles' do
+      it 'returns users matching the searchText' do
+        get :index, params: { searchText: 'jan' }
+        expect(response.status).to eq(200)
+        expect(parsed_body['users'].count).to eq(3)
+      end
     end
   end
 


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3376

### What does this PR do?
Fix the search of charity users - Instead of searching on the basis of role name, performs search on the approved or pending organisation status

