### PR TITLE
GCW-3377 Remove charity user check from user search

### DIFF
--- a/app/controllers/api/v1/organisations_users_controller.rb
+++ b/app/controllers/api/v1/organisations_users_controller.rb
@@ -1,9 +1,8 @@
 module Api
   module V1
     class OrganisationsUsersController < Api::V1::ApiController
-      authorize_resource :organisations_user, parent: false, except: [:status_list]
+      authorize_resource :organisations_user, parent: false
       load_resource :organisations_user, only: [:show, :update]
-      skip_authorization_check only: [:status_list]
 
       resource_description do
         short "Get Organisations Users."
@@ -46,11 +45,6 @@ module Api
 
       def show
         render json: @organisations_user, serializer: serializer
-      end
-
-      api :GET, '/v1/organisations_user/status_list', 'Get a list of available status for user'
-      def status_list
-        render json: { status: OrganisationsUser.all_status }, status: 200
       end
 
       private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -88,8 +88,7 @@ module Api
 
       def search_user_and_render_json
         records = @users.limit(25)
-        records = records.search(params['searchText']) if params['searchText'].present?
-        records = records.search_by_role(params['role_name']) if params['role_name'].present?
+        records = records.filter_users(params)
 
         data = ActiveModel::ArraySerializer.new(records,
           each_serializer: Api::V1::UserDetailsSerializer,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,12 +171,15 @@ class User < ApplicationRecord
       .order("orders.id DESC").limit(5)
   end
 
-  def self.search_by_role(name)
-    if name == 'Charity'
-      joins(:organisations_users).where(organisations_users: { status: [OrganisationsUser::ACTIVE_STATUS] })
-    else
-      with_roles(name)
-    end
+  def self.filter_users(opts)
+    res = search(opts['searchText']) if opts['searchText'].present?
+    res = res.by_organisation_status(opts['organisation_status'].split(',')) if opts['organisation_status'].present?
+    res = res.with_roles(opts['role_name']) if opts['role_name'].present?
+    res
+  end
+
+  def self.by_organisation_status(status_list)
+    joins(:organisations_users).where(organisations_users: { status: status_list })
   end
 
   def allowed_login?(app_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,7 @@ class User < ApplicationRecord
   scope :active, -> { where(disabled: false) }
   scope :exclude_user, ->(id) { where.not(id: id) }
   scope :with_roles, ->(role_names) { where(roles: { name: role_names }).joins(:active_roles) }
+  scope :with_organisation_status, ->(status_list) { joins(:organisations_users).where(organisations_users: { status: status_list }) }
 
   # --------------------
   # Methods
@@ -173,13 +174,9 @@ class User < ApplicationRecord
 
   def self.filter_users(opts)
     res = search(opts['searchText']) if opts['searchText'].present?
-    res = res.by_organisation_status(opts['organisation_status'].split(',')) if opts['organisation_status'].present?
+    res = res.with_organisation_status(opts['organisation_status'].split(',')) if opts['organisation_status'].present?
     res = res.with_roles(opts['role_name']) if opts['role_name'].present?
     res
-  end
-
-  def self.by_organisation_status(status_list)
-    joins(:organisations_users).where(organisations_users: { status: status_list })
   end
 
   def allowed_login?(app_name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,11 +124,7 @@ Rails.application.routes.draw do
       resources :holidays, only: [:index, :create, :destroy, :update]
       resources :orders_packages
       resources :packages_locations, only: [:index, :show]
-      resources :organisations_users, only: [:create, :index, :update, :show] do
-        collection do
-          get :status_list
-        end
-      end
+      resources :organisations_users, only: [:create, :index, :update, :show]
       resources :gc_organisations do
         get 'names', on: :collection
         member do

--- a/spec/controllers/api/v1/organisations_user_controller_spec.rb
+++ b/spec/controllers/api/v1/organisations_user_controller_spec.rb
@@ -734,18 +734,6 @@ RSpec.describe Api::V1::OrganisationsUsersController, type: :controller do
           end
         end
       end
-
-      describe '/GET all_status' do
-        it 'returns 200' do
-          get :status_list
-          expect(response).to have_http_status(:success)
-        end
-
-        it 'returns all status' do
-          get :status_list
-          expect(parsed_body['status']).to match_array(OrganisationsUser.all_status)
-        end
-      end
     end
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       expect(parsed_body['users'].count).to eq(0)
     end
 
-    context 'when search scope is restricted for charity users' do
+    context 'when search scope is restricted for organisation_status' do
       it 'returns charity users' do
-        get :index, params: { searchText: 'jannne', role_name: 'Charity' }
+        get :index, params: { searchText: 'jannne', organisation_status: 'pending,approved' }
         expect(response.status).to eq(200)
         expect(parsed_body['users'].count).to eq(2)
       end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
   end
 
-  describe "GET searched user" do
+  describe "GET searched user", focus: true do
     let(:role_1) { create(:role, name: "Role 1", level: 1) }
     let(:role_2) { create(:role, name: "Role 2", level: 5) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -458,4 +458,40 @@ describe User, :type => :model do
       end
     end
   end
+
+  describe '.by_organisation_status' do
+    let(:role_1) { create(:role, name: "Role 1", level: 1) }
+    let(:role_2) { create(:role, name: "Role 2", level: 5) }
+
+    let(:user_1) { create(:user, :charity) }
+    let(:user_2) { create(:user, :charity) }
+    let(:user_3) { create(:user, :charity) }
+    let(:user_4) { create(:user, :charity) }
+    let(:user_5) { create(:user, :charity) }
+    let(:user_6) { create(:user) }
+
+    before do
+      User.destroy_all # Ensure no lingering users exist
+
+      role_1.grant(user_1)
+      role_2.grant(user_2)
+      role_1.grant(user_3)
+      role_1.grant(user_4)
+      role_2.grant(user_5)
+      role_2.grant(user_6)
+
+      user_5.organisations_users.first.update(status: 'expired')
+      user_4.organisations_users.first.update(status: 'denied')
+    end
+
+    it 'search users by organisation status' do
+      users = User.by_organisation_status(%w[pending approved])
+      expect(users.count).to eq(3)
+      expect(users).to match_array([user_1, user_2, user_3])
+
+      users = User.by_organisation_status(%w[expired denied])
+      expect(users.count).to eq(2)
+      expect(users).to match_array([user_4, user_5])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -459,7 +459,7 @@ describe User, :type => :model do
     end
   end
 
-  describe '.by_organisation_status' do
+  describe '.with_organisation_status' do
     let(:role_1) { create(:role, name: "Role 1", level: 1) }
     let(:role_2) { create(:role, name: "Role 2", level: 5) }
 
@@ -485,11 +485,11 @@ describe User, :type => :model do
     end
 
     it 'search users by organisation status' do
-      users = User.by_organisation_status(%w[pending approved])
+      users = User.with_organisation_status(%w[pending approved])
       expect(users.count).to eq(3)
       expect(users).to match_array([user_1, user_2, user_3])
 
-      users = User.by_organisation_status(%w[expired denied])
+      users = User.with_organisation_status(%w[expired denied])
       expect(users.count).to eq(2)
       expect(users).to match_array([user_4, user_5])
     end


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3377

### What does this PR do?
Removes the charity user role check on user search, and search user based on `organisations_users` status attribute