### PR TITLE
GCW-3382-whodunnit is setting null on update.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
   include AppMatcher
 
   check_authorization
-
+  before_action :set_paper_trail_whodunnit
   # User.current is required to be set for OffersController.before_filter
   before_action :set_locale, :set_device_id, :current_user
   helper_method :current_user


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3382

### What does this PR do?

This PR fixes the issue of `whodunnit` is setting null on update. `before_action :set_paper_trail_whodunnit` adds the `whodunnit` .