### PR TITLE
GCW-2626 Cancelling an orders_package doesn't zero the quantity

### DIFF
--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -96,7 +96,6 @@ class OrdersPackage < ApplicationRecord
       if orders_package.designated? && orders_package.dispatched_quantity.positive?
         raise Goodcity::InvalidStateError.new(I18n.t('orders_package.cancel_requires_undispatch'))
       end
-      orders_package.quantity   = 0
       orders_package.updated_by = User.current_user
     end
 

--- a/spec/models/orders_package_spec.rb
+++ b/spec/models/orders_package_spec.rb
@@ -112,6 +112,20 @@ RSpec.describe OrdersPackage, type: :model do
         }.to change(orders_package, :state).to('designated')
       end
     end
+
+    describe '#cancel' do
+      it 'changes state from requested to designated' do
+        expect{
+          orders_package.cancel
+        }.to change(orders_package, :state).to('cancelled')
+      end
+
+      it 'does not change the quantity' do
+        expect{
+          orders_package.cancel
+        }.not_to change(orders_package, :quantity)
+      end
+    end
   end
 
   describe "#for_order" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2626

### What does this PR do?

Removes a line which set the orders_package quantity to 0
