### PR TITLE
FIX: Prevent closing an order which has designated orders_packages

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -241,6 +241,10 @@ class Order < ApplicationRecord
     end
 
     before_transition on: :close do |order|
+      if order.orders_packages.designated.count.positive?
+        raise Goodcity::InvalidStateError.new(I18n.t('order.cannot_close_with_undispatched_packages'))
+      end
+
       if order.dispatching?
         order.closed_at = Time.now
         order.closed_by = User.current_user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,8 @@ en:
     invalid_qty: "Invalid quantity"
     cancel_requires_undispatch: "Unable to cancel during dispatch, please undispatch and try again"
     exceed_dispatch_quantity: "You cannot dispatch more than were ordered."
+  order:
+    cannot_close_with_undispatched_packages: "All packages must be dispatched before closing an order"
   stocktakes:
     invalid_state: Cannot process a closed or cancelled Stocktake
     dirty_revisions: Some quantity revisions require a re-count

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -134,6 +134,8 @@ zh-tw:
     invalid_qty: "Invalid quantity"
     cancel_requires_undispatch: "Unable to cancel during dispatch, please undispatch and try again"
     exceed_dispatch_quantity: "You cannot dispatch more than were ordered."
+  order:
+    cannot_close_with_undispatched_packages: "All packages must be dispatched before closing an order"
   stocktakes:
     invalid_state: Cannot process a closed or cancelled Stocktake
     dirty_revisions: Some quantity revisions require a re-count

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -620,12 +620,12 @@ ActiveRecord::Schema.define(version: 2020_11_05_105317) do
     t.boolean "allow_pallet", default: false
     t.boolean "allow_expiry_date", default: false
     t.decimal "default_value_hk_dollar"
-    t.text "description_en"
-    t.text "description_zh_tw"
     t.integer "length"
     t.integer "width"
     t.integer "height"
     t.string "department"
+    t.text "description_en"
+    t.text "description_zh_tw"
     t.index ["allow_requests"], name: "index_package_types_on_allow_requests"
     t.index ["location_id"], name: "index_package_types_on_location_id"
     t.index ["name_en"], name: "package_types_name_en_search_idx", using: :gin
@@ -639,7 +639,6 @@ ActiveRecord::Schema.define(version: 2020_11_05_105317) do
     t.integer "width"
     t.integer "height"
     t.text "notes", null: false
-    t.text "notes_zh_tw"
     t.integer "item_id"
     t.string "state"
     t.datetime "received_at"
@@ -685,6 +684,7 @@ ActiveRecord::Schema.define(version: 2020_11_05_105317) do
     t.integer "package_set_id"
     t.integer "restriction_id"
     t.text "comment"
+    t.text "notes_zh_tw"
     t.index ["allow_web_publish"], name: "index_packages_on_allow_web_publish"
     t.index ["available_quantity"], name: "index_packages_on_available_quantity"
     t.index ["box_id"], name: "index_packages_on_box_id"
@@ -933,8 +933,8 @@ ActiveRecord::Schema.define(version: 2020_11_05_105317) do
     t.boolean "is_default", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["package_type_id", "package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
     t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id"
+    t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
     t.index ["subpackage_type_id"], name: "index_subpackage_types_on_subpackage_type_id"
   end
 


### PR DESCRIPTION
This was a frontend verification up until now. Which was bypassed when an order had more than 20 elements because pagination would not load all the records locally to find out whether all the orders_packages were actually in the right state