### PR TITLE
Fixed GET package-types response

### DIFF
--- a/app/controllers/api/v1/package_types_controller.rb
+++ b/app/controllers/api/v1/package_types_controller.rb
@@ -16,7 +16,7 @@ module Api
       def index
         return stock_codes if params['stock'].present?
         @package_types = @package_types.find(params[:ids].split(",")) if params[:ids].present?
-        render json: @package_types.visible, each_serializer: serializer
+        render json: @package_types, each_serializer: serializer
       end
 
       def stock_codes

--- a/spec/controllers/api/v1/package_types_controller_spec.rb
+++ b/spec/controllers/api/v1/package_types_controller_spec.rb
@@ -6,11 +6,28 @@ RSpec.describe Api::V1::PackageTypesController, type: :controller do
   describe "GET package_types" do
     before { generate_and_set_token(user) }
 
-    it "returns 200", show_in_doc: true  do
-      create_list :package_type, 3
+    it "returns all package_types", show_in_doc: true  do
+      create_list :base_package_type, 3
+
       get :index
+
       expect(response.status).to eq(200)
       expect(response.body).to include("package_types")
+      expect(JSON.parse(response.body)["package_types"].count).to eq(3)
+    end
+
+    it "returns all stock enabled package_types" do
+      stock_package_types = create_list :base_package_type, 3, allow_stock: true
+      package_type = create :base_package_type
+
+      get :index, params: { stock: true }, format: 'json'
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["codes"].count).to eq(3)
+
+      package_type_codes = JSON.parse(response.body)["codes"].map{|code| code["code"]}
+      expect(package_type_codes).to match_array(stock_package_types.map &:code)
+      expect(package_type_codes).to_not include(package_type.code)
     end
   end
 end

--- a/spec/factories/package_types.rb
+++ b/spec/factories/package_types.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     visible_in_selects { true }
     initialize_with    { PackageType.find_or_initialize_by(code: code) }
     association        :location
+    allow_stock        { false }
 
     trait :allow_expiry_date do
       allow_expiry_date { true }


### PR DESCRIPTION
Fixed GET package-types response.
Removed filter of `allow_stock` from the package-types response.

Slack Conversation: https://crossroads-hk.slack.com/archives/GBJAFNVFB/p1605076241204500