### PR TITLE
GCW-3401- Modifying a user's email to an email which is already in use should fail

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -57,7 +57,11 @@ module Api
 
       def update
         @user.update_attributes(user_params)
-        render json: @user, serializer: serializer
+        if @user.valid?
+          render json: @user, serializer: serializer
+        else
+          render_error(@user.errors.full_messages.join(". "))
+        end
       end
 
       def recent_users


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3401

### What does this PR do?

This PR catches error thrown while updating user and send it in response.