### PR TITLE
GCW-3403-Adding Missing actions on history tab

### DIFF
--- a/app/serializers/api/v1/orders_package_serializer.rb
+++ b/app/serializers/api/v1/orders_package_serializer.rb
@@ -3,8 +3,9 @@ module Api::V1
     embed :ids, include: true
     attributes :id, :package_id, :order_id, :state, :quantity,
                :dispatched_quantity, :sent_on, :designation_id,
-               :item_id, :created_at, :allowed_actions, :shipping_number
+               :item_id, :created_at, :allowed_actions, :shipping_number, :updated_by_id
 
+    has_one  :updated_by, serializer: UserSummarySerializer, root: :user               
     has_one :package, serializer: PackageSerializer
     has_one :order, serializer: OrderShallowSerializer, root: 'designation'
 

--- a/spec/serializers/api/v1/orders_package_serializer_spec.rb
+++ b/spec/serializers/api/v1/orders_package_serializer_spec.rb
@@ -16,6 +16,7 @@ describe Api::V1::OrdersPackageSerializer do
     expect(record['id']).to eq(orders_package.id)
     expect(record['package_id']).to eq(orders_package.package_id)
     expect(record['order_id']).to eq(orders_package.order_id)
+    expect(record['updated_by_id']).to eq(orders_package.updated_by_id)
     expect(record['state']).to eq(orders_package.state)
     expect(record['quantity']).to eq(orders_package.quantity)
     expect(record['dispatched_quantity']).to eq(orders_package.dispatched_quantity)


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3403

### What does this PR do?

This PR adds `updated_by` field in `orders_pacakge` serializer.
