### PR TITLE
GCW-3444 ADD: Stocktake counter caches

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class ApiController < ApplicationController
+      include ParamReader
+
       skip_before_action :validate_token, only: [:error]
 
       resource_description do
@@ -75,15 +77,6 @@ module Api
         return DEFAULT_SEARCH_COUNT if @per_page < 1
         return MAX_SEARCH_COUNT if @per_page > MAX_SEARCH_COUNT
         @per_page
-      end
-
-      def array_param(key)
-        params.fetch(key, "").strip.split(",")
-      end
-
-      def bool_param(key, default)
-        return default if params[key].nil?
-        params[key].to_s == "true"
       end
 
       def time_epoch_param(key)

--- a/app/controllers/api/v1/requested_packages_controller.rb
+++ b/app/controllers/api/v1/requested_packages_controller.rb
@@ -84,10 +84,6 @@ module Api
       def checkout_order
         Order.find_by(id: params[:order_id]) if params[:order_id].present?
       end
-
-      def bool_param(key)
-        params[key].to_s == "true"
-      end
     end
   end
 end

--- a/app/controllers/api/v1/stocktakes_controller.rb
+++ b/app/controllers/api/v1/stocktakes_controller.rb
@@ -80,11 +80,6 @@ module Api
       def serializer
         Api::V1::StocktakeSerializer
       end
-
-      def bool_param(key, default_val)
-        return default_val unless params.include?(key)
-        params[key].to_s == "true"
-      end
     end
   end
 end

--- a/app/controllers/api/v1/stocktakes_controller.rb
+++ b/app/controllers/api/v1/stocktakes_controller.rb
@@ -14,12 +14,22 @@ module Api
 
       api :GET, "/v1/stocktakes", "List all stocktakes"
       def index
-        render json: @stocktakes, each_serializer: serializer, include_packages_locations: true
+        render(
+          json: @stocktakes,
+          each_serializer: serializer,
+          include_packages_locations: true,
+          include_revisions: bool_param(:include_revisions, true)
+        )
       end
 
       api :GET, "/v1/stocktakes/:id", "Get a stocktake by id"
       def show
-        render json: @stocktake, serializer: serializer, include_packages_locations: true
+        render(
+          json: @stocktake,
+          serializer: serializer,
+          include_packages_locations: true,
+          include_revisions: bool_param(:include_revisions, true)
+        )
       end
 
       api :POST, "/v1/stocktakes", "Create a stocktake"
@@ -69,6 +79,11 @@ module Api
 
       def serializer
         Api::V1::StocktakeSerializer
+      end
+
+      def bool_param(key, default_val)
+        return default_val unless params.include?(key)
+        params[key].to_s == "true"
       end
     end
   end

--- a/app/controllers/concerns/param_reader.rb
+++ b/app/controllers/concerns/param_reader.rb
@@ -1,0 +1,12 @@
+module ParamReader
+  extend ActiveSupport::Concern
+
+  def bool_param(key, default_val = false)
+    return default_val unless params.include?(key)
+    params[key].to_s == "true"
+  end
+
+  def array_param(key)
+    params.fetch(key, "").strip.split(",")
+  end
+end

--- a/app/models/concerns/watcher.rb
+++ b/app/models/concerns/watcher.rb
@@ -2,19 +2,17 @@ module Watcher
   extend ActiveSupport::Concern
 
   included do
-    @@watcher_enabled = true
+    thread_mattr_accessor :watcher_enabled
+
+    self.watcher_enabled = true
 
     class << self
-      def watcher_enabled?
-        @@watcher_enabled 
-      end
-
       def watch(model_klasses, on: [:create, :update, :destroy, :touch], timing: :after)
         klass = self
         [model_klasses].flatten.uniq.each do |model_kass|
           on.each do |event|
             model_kass.set_callback event, timing, ->(rec) {
-              if klass.watcher_enabled?
+              if klass.watcher_enabled
                 yield(rec, event)
               end
             }
@@ -23,10 +21,10 @@ module Watcher
       end
 
       def watcher_off
-        @@watcher_enabled = false
+        self.watcher_enabled = false
         yield
       ensure
-        @@watcher_enabled = true
+        self.watcher_enabled = true
       end
     end
   end

--- a/app/models/concerns/watcher.rb
+++ b/app/models/concerns/watcher.rb
@@ -1,3 +1,22 @@
+# Watcher concern
+#
+# Uses model hooks internally to detect changes on one more more models (and call the ruby block)
+# It is useful when listening to a change on another model, as we don't want to modify that model class with extra hooks
+#
+# e.g
+#
+# class ModelA
+#  ...
+# end
+#
+# class ModelB
+#   include Watcher
+#
+#   watch ModelA do |record|
+#     // do something, maybe update model B
+#   end
+# end
+#
 module Watcher
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/watcher.rb
+++ b/app/models/concerns/watcher.rb
@@ -1,12 +1,32 @@
 module Watcher
   extend ActiveSupport::Concern
 
-  class_methods do
-    def watch(model_klasses, on: [:create, :update, :destroy, :touch], timing: :after)
-      [model_klasses].flatten.uniq.each do |model_kass|
-        on.each do |event|
-          model_kass.set_callback event, timing, ->(rec) { yield(rec, event) }
+  included do
+    @@watcher_enabled = true
+
+    class << self
+      def watcher_enabled?
+        @@watcher_enabled 
+      end
+
+      def watch(model_klasses, on: [:create, :update, :destroy, :touch], timing: :after)
+        klass = self
+        [model_klasses].flatten.uniq.each do |model_kass|
+          on.each do |event|
+            model_kass.set_callback event, timing, ->(rec) {
+              if klass.watcher_enabled?
+                yield(rec, event)
+              end
+            }
+          end
         end
+      end
+
+      def watcher_off
+        @@watcher_enabled = false
+        yield
+      ensure
+        @@watcher_enabled = true
       end
     end
   end

--- a/app/models/stocktake.rb
+++ b/app/models/stocktake.rb
@@ -65,6 +65,9 @@ class Stocktake < ApplicationRecord
       .pluck(:package_id)
 
     Stocktake.watcher_off do
+      # We disable the watch module during this operation to
+      # avoid automatically recomputing counter caches on revision creation
+
       ActiveRecord::Base.transaction do
         package_ids.map do |pid|
           StocktakeRevision.find_or_create_by(package_id: pid, stocktake_id: id) do |revision|

--- a/app/models/stocktake.rb
+++ b/app/models/stocktake.rb
@@ -1,4 +1,5 @@
 class Stocktake < ApplicationRecord
+  include Watcher
   include StocktakeProcessor
   include PushUpdatesMinimal
 
@@ -40,6 +41,14 @@ class Stocktake < ApplicationRecord
   end
 
   # ---------------------
+  # Computed Properties
+  # ---------------------
+
+  watch [StocktakeRevision] do |rev|
+    rev.stocktake.compute_counters! if rev.stocktake.open?
+  end
+
+  # ---------------------
   # Methdos
   # ---------------------
 
@@ -55,15 +64,43 @@ class Stocktake < ApplicationRecord
       .having('SUM(quantity) > 0')
       .pluck(:package_id)
 
-    ActiveRecord::Base.transaction do
-      package_ids.map do |pid|
-        StocktakeRevision.find_or_create_by(package_id: pid, stocktake_id: id) do |revision|
-          revision.quantity       = 0
-          revision.dirty          = true
-          revision.state          = 'pending'
-          revision.created_by_id  = User.current_user&.id || User.system_user.id
+    Stocktake.watcher_off do
+      ActiveRecord::Base.transaction do
+        package_ids.map do |pid|
+          StocktakeRevision.find_or_create_by(package_id: pid, stocktake_id: id) do |revision|
+            revision.quantity       = 0
+            revision.dirty          = true
+            revision.state          = 'pending'
+            revision.created_by_id  = User.current_user&.id || User.system_user.id
+          end
         end
+
+        compute_counters!
       end
     end
+  end
+
+  def clear_counters!
+    self.counts = 0
+    self.gains = 0
+    self.losses = 0
+    self.warnings = 0
+  end
+
+  def compute_counters!
+    clear_counters!
+
+    StocktakeRevision.where(stocktake_id: id).each do |rev|
+      if rev.dirty
+        self.warnings += 1
+      else
+        delta = rev.computed_diff
+        self.losses += 1    if delta < 0
+        self.gains  += 1    if delta > 0
+        self.warnings += 1  if rev.warning.present?
+        self.counts += 1 
+      end
+    end
+    self.save!
   end
 end

--- a/app/serializers/api/v1/stocktake_serializer.rb
+++ b/app/serializers/api/v1/stocktake_serializer.rb
@@ -7,7 +7,12 @@ module Api
       has_one   :location, serializer: LocationSerializer
       has_one   :created_by, serializer: UserSerializer, root: :user, user_summary: true
       
-      attributes :id, :name, :location_id, :created_by_id, :state, :comment, :created_at, :updated_at
+      attributes :id, :name, :location_id, :created_by_id, :state, :comment, :created_at, :updated_at, :gains, :losses, :counts, :warnings
+
+      def include_stocktake_revisions?
+        return true unless @options.include?(:include_revisions)
+        @options[:include_revisions]
+      end
     end
   end
 end

--- a/db/migrate/20210112024003_add_counter_caches_to_stocktakes.rb
+++ b/db/migrate/20210112024003_add_counter_caches_to_stocktakes.rb
@@ -1,0 +1,8 @@
+class AddCounterCachesToStocktakes < ActiveRecord::Migration[5.2]
+  def change
+    add_column    :stocktakes, :counts ,    :integer, default: 0
+    add_column    :stocktakes, :gains,      :integer, default: 0
+    add_column    :stocktakes, :losses,     :integer, default: 0
+    add_column    :stocktakes, :warnings,   :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_021558) do
+ActiveRecord::Schema.define(version: 2021_01_12_024003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -937,6 +937,10 @@ ActiveRecord::Schema.define(version: 2021_01_06_021558) do
     t.integer "location_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "counts", default: 0
+    t.integer "gains", default: 0
+    t.integer "losses", default: 0
+    t.integer "warnings", default: 0
     t.index ["location_id"], name: "index_stocktakes_on_location_id"
     t.index ["name"], name: "index_stocktakes_on_name", unique: true
   end

--- a/spec/controllers/api/v1/stocktakes_controller_spec.rb
+++ b/spec/controllers/api/v1/stocktakes_controller_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Api::V1::StocktakesController, type: :controller do
         expect(parsed_body["stocktakes"].length).to eq(1)
         expect(parsed_body["stocktakes"].first["id"]).to eq(stocktake.id)
       end
+
+      it "includes stocktake revisions" do
+        get :index
+        expect(parsed_body["stocktake_revisions"].length).to eq(3)
+      end
+
+      context "with ?include_revisions set to false" do
+        it "does not include stocktake revisions" do
+          get :index, params: { include_revisions: false }
+          expect(parsed_body["stocktake_revisions"]).to be_nil
+        end
+      end
     end
   end
 
@@ -66,6 +78,18 @@ RSpec.describe Api::V1::StocktakesController, type: :controller do
       it "returns the requested stocktake" do
         get :show, params: { id: stocktake.id }
         expect(parsed_body["stocktake"]["id"]).to eq(stocktake.id)
+      end
+
+      it "includes stocktake revisions" do
+        get :show, params: { id: stocktake.id }
+        expect(parsed_body["stocktake_revisions"].length).to eq(3)
+      end
+
+      context "with ?include_revisions set to false" do
+        it "does not include stocktake revisions" do
+          get :show, params: { id: stocktake.id, include_revisions: false }
+          expect(parsed_body["stocktake_revisions"]).to be_nil
+        end
       end
     end
   end

--- a/spec/models/concerns/watcher_spec.rb
+++ b/spec/models/concerns/watcher_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe Watcher do
+
+  class Sample
+    include Watcher
+
+    @@calls = 0
+
+    class << self
+      def calls; @@calls; end
+      def inc;  @@calls += 1; end
+    end
+
+    watch([Package]) do
+      Sample.inc
+    end
+  end
+
+  it "triggers when the watched Model receives changes" do
+    expect {
+      create(:package)
+    }.to change {
+      Sample.calls
+    }.by(1)
+  end
+
+  describe "Disabling the watcher" do
+    it "doesn't trigger on changes made in a #watcher_off block" do
+      expect {
+        Sample.watcher_off do 
+          create(:package)
+        end
+      }.not_to change(Sample, :calls)
+    end
+  end
+end

--- a/spec/models/stocktake_spec.rb
+++ b/spec/models/stocktake_spec.rb
@@ -11,6 +11,85 @@ RSpec.describe Stocktake, type: :model do
     it { is_expected.to have_db_column(:name).of_type(:string) }
     it { is_expected.to have_db_column(:state).of_type(:string) }
     it { is_expected.to have_db_column(:comment).of_type(:string) }
+    it { is_expected.to have_db_column(:counts).of_type(:integer) }
+    it { is_expected.to have_db_column(:gains).of_type(:integer) }
+    it { is_expected.to have_db_column(:losses).of_type(:integer) }
+    it { is_expected.to have_db_column(:warnings).of_type(:integer) }
+  end
+
+  describe 'Counter caches' do
+    let(:location) { create(:location) }
+    let(:package) { create(:package, received_quantity: 5) }
+    let(:stocktake) { create(:stocktake, location: location) }
+  
+    before { initialize_inventory(package, location: location) }
+
+    before do
+      stocktake.compute_counters!
+    end
+
+    it "adds to the gains counter if a revision has a quantity greater than the packages on_hand_quantity" do
+      expect {
+        create :stocktake_revision, stocktake: stocktake, package: package, quantity: 6
+      }.to change(stocktake, :gains).from(0).to(1)
+
+      expect(stocktake.losses).to eq(0)
+      expect(stocktake.warnings).to eq(0)
+    end
+
+    it "adds to the counts counter if a revision has a quantity greater than the packages on_hand_quantity" do
+      expect {
+        create :stocktake_revision, stocktake: stocktake, package: package, quantity: 6
+      }.to change(stocktake, :counts).from(0).to(1)
+
+      expect(stocktake.losses).to eq(0)
+      expect(stocktake.warnings).to eq(0)
+    end
+
+    it "adds to the losses counter if a revision has a quantity lower than the packages on_hand_quantity" do
+      expect {
+        create :stocktake_revision, stocktake: stocktake, package: package, quantity: 4
+      }.to change(stocktake, :losses).from(0).to(1)
+
+      expect(stocktake.gains).to eq(0)
+      expect(stocktake.warnings).to eq(0)
+    end
+
+    it "adds to the counts counter if a revision has a quantity lower than the packages on_hand_quantity" do
+      expect {
+        create :stocktake_revision, stocktake: stocktake, package: package, quantity: 4
+      }.to change(stocktake, :counts).from(0).to(1)
+
+      expect(stocktake.gains).to eq(0)
+      expect(stocktake.warnings).to eq(0)
+    end
+
+    it "adds to the warning counter if the revision is dirty" do
+      expect {
+        create :stocktake_revision, stocktake: stocktake, package: package, quantity: 5, dirty: true
+      }.to change(stocktake, :warnings).from(0).to(1)
+    end
+
+    it "doesnt add to the counts if the revision is dirty" do
+      expect {
+        create :stocktake_revision, stocktake: stocktake, package: package, quantity: 5, dirty: true
+      }.not_to change(stocktake, :counts)
+    end
+
+    it "removes a count if it a revision is changed to be marked as dirty" do
+      revision = create(:stocktake_revision, stocktake: stocktake, package: package, quantity: 6)
+      expect(stocktake.reload.gains).to eq(1)
+      revision.update!(dirty: true)
+      expect(stocktake.reload.gains).to eq(0)
+    end
+
+    it "can be disabled by turning off the watcher module" do
+      expect {
+        Stocktake.watcher_off do
+          create :stocktake_revision, stocktake: stocktake, package: package, quantity: 6
+        end
+      }.not_to change(stocktake, :gains)
+    end
   end
 
   describe 'Populating revisions' do
@@ -37,6 +116,21 @@ RSpec.describe Stocktake, type: :model do
       expect(stocktake.revisions.map(&:dirty).uniq).to eq([true])
       expect(stocktake.revisions.map(&:quantity).uniq).to eq([0])
       expect(stocktake.revisions.map(&:state).uniq).to eq(['pending'])
+    end
+
+    it "initializes the counter caches" do
+      stocktake.populate_revisions!
+      stocktake.reload
+
+      expect(stocktake.counts).to eq(0)
+      expect(stocktake.gains).to eq(0)
+      expect(stocktake.losses).to eq(0)
+      expect(stocktake.warnings).to eq(3)
+    end
+
+    it "turns off computed properties during process" do
+      expect(Stocktake).to receive(:watcher_off).once
+      stocktake.populate_revisions!
     end
 
     it "doesn't modify an existing revision for a package" do

--- a/spec/serializers/api/v1/stocktake_serializer_spec.rb
+++ b/spec/serializers/api/v1/stocktake_serializer_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::StocktakeSerializer do
 
+  let(:options) { {} }
   let(:package) { create(:package, :with_inventory_record, received_quantity: 10) }
   let(:record) { build(:stocktake) }
-  let(:serializer) { Api::V1::StocktakeSerializer.new(record).as_json }
+  let(:serializer) { Api::V1::StocktakeSerializer.new(record, options).as_json }
   let(:json) { JSON.parse( serializer.to_json ) }
   let(:revision) { create(:stocktake_revision, stocktake: record, package: package, quantity: 12) }
 
@@ -22,5 +23,15 @@ describe Api::V1::StocktakeSerializer do
     expect(json['stocktake_revisions'][0]['id']).to eq(revision.id)
     expect(json['packages'].length).to eq(1)
     expect(json['packages'][0]['id']).to eq(revision.package.id)
+  end
+
+  describe "Option" do
+    describe ":include_revisions" do
+      let(:options) { { include_revisions: false } }
+
+      it "excludes revisions if set to false" do
+        expect(json['stocktake_revisions']).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Stocktakes now have the following counter caches : 

- `gains`
- `losses`
- `counts`
- `warnings`

Those were previously computed on the frontend from the list of stocktake revisions.

Which also means that we can now fetch the stocktakes _without_ their revisions, for faster load time on the main page. We're now doing that thanks to an `?include_revisions` query param.