### PR TITLE
GCW-3403 - Adding version in orders_package model for missing actions on history tab 

### DIFF
--- a/app/controllers/api/v1/packages_controller.rb
+++ b/app/controllers/api/v1/packages_controller.rb
@@ -361,7 +361,8 @@ module Api
       api :GET, '/v1/packages/:id/versions', "List all versions associated with package"
       def versions
         subform_versions = @package.detail&.versions || []
-        all_versions = @package.versions + subform_versions
+        orders_package_versions = @package.orders_packages.reduce([]) { |op_versions, op| op_versions.concat(op.versions) }
+        all_versions = @package.versions + subform_versions + orders_package_versions
         render json: all_versions, each_serializer: version_serializer, root: "versions"
       end
 

--- a/app/models/orders_package.rb
+++ b/app/models/orders_package.rb
@@ -1,5 +1,5 @@
 class OrdersPackage < ApplicationRecord
-
+  has_paper_trail versions: { class_name: "Version" }
   include OrdersPackageActions
   include HookControls
   include Watcher

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -807,7 +807,7 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
   with_versioning do
     describe "GET package/1/versions" do
       let(:electrical) { create :electrical }
-      let(:package) { create :package, detail: electrical }
+      let(:package) { create :package, :dispatched, detail: electrical}
 
       before do
         generate_and_set_token(user)
@@ -819,17 +819,21 @@ RSpec.describe Api::V1::PackagesController, type: :controller do
       end
 
       it "returns versions of packages" do
-        # FAIL
         get :versions, params: { id: package.id }
-        expect(parsed_body['versions'].size).to eq(package.versions.size + electrical.versions.size)
+        expect(parsed_body['versions'].size).to eq(package.versions.size + electrical.versions.size + package.orders_packages.first.versions.size)
         expect(parsed_body["versions"].first["id"]).to eq(package.versions.first.id)
       end
 
       it "returns versions of detail along with package versions" do
-        # FAIL
         get :versions, params: { id: package.id }
         expect(parsed_body["versions"].map { |version| version["id"] }).to include(electrical.versions.first.id)
       end
+
+      it "returns versions of orders_package along with package & details versions" do
+        get :versions, params: { id: package.id }
+        expect(parsed_body["versions"].map { |version| version["id"] }).to include(package.orders_packages.first.versions.first.id)
+      end
+
     end
   end
 


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3403

### What does this PR do?

This PR adds `version` in orders_package to generate versioning of designate action for Item history page.