### PR TITLE
GCW 3475 Adding carryouts and other to offer filter

### DIFF
--- a/app/models/concerns/order_filtering.rb
+++ b/app/models/concerns/order_filtering.rb
@@ -114,8 +114,12 @@ module OrderFiltering
       "lower(detail_type) LIKE 'shipment'"
     end
 
+    def carry_out_sql
+      "lower(detail_type) LIKE 'carryout'"
+    end
+
     def other_sql
-      "lower(detail_type) NOT IN ('goodcity', 'shipment', 'stockitlocalorder')"
+      "lower(detail_type) NOT IN ('goodcity', 'shipment', 'carryout')"
     end
 
     # HELPERS

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -236,11 +236,12 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
           expect(parsed_body["meta"]["search"]).to eql("iphone")
         end
 
-        ["appointment", "online_orders", "shipment", "other"].each do |type|
+        ["appointment", "online_orders", "shipment", "carry_out", "other"].each do |type|
           it "can return a single order of type #{type}" do
             create :appointment, :with_state_submitted, description: "IPhone 100s"
             create :online_order, :awaiting_dispatch, description: "IPhone 100s", order_transport: ggv_transport
             create :order, :with_state_processing, description: "IPhone 100s", detail_type: "Shipment", code: "S1234"
+            create :order, :with_state_processing, description: "IPhone 100s", detail_type: "CarryOut", code: "C2234"
             create :order, :with_state_processing, description: "IPhone 100s", detail_type: "other" , code: "2345"
 
             get :index, params: { searchText: "iphone", type: type }
@@ -250,6 +251,14 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
             expect(parsed_body["meta"]["search"]).to eql("iphone")
           end
         end
+
+        # it "does not return valid order type when type is other" do
+        #   create :online_order, :awaiting_dispatch, description: "Testing", order_transport: ggv_transport
+        #   get :index, params: { type: "other" }
+        #   expect(response.status).to eq(200)
+        #   expect(parsed_body["designations"].count).to eq(0)
+        #   expect(parsed_body["meta"]["total_pages"]).to eql(0)
+        # end
 
         it "returns records with multiple specified types" do
           create :appointment, :with_state_submitted, description: "IPhone 100s", order_transport: order_transport

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -252,13 +252,13 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
           end
         end
 
-        # it "does not return valid order type when type is other" do
-        #   create :online_order, :awaiting_dispatch, description: "Testing", order_transport: ggv_transport
-        #   get :index, params: { type: "other" }
-        #   expect(response.status).to eq(200)
-        #   expect(parsed_body["designations"].count).to eq(0)
-        #   expect(parsed_body["meta"]["total_pages"]).to eql(0)
-        # end
+        it "does not return valid order type when type is other" do
+          create :online_order, :awaiting_dispatch, description: "Testing", order_transport: ggv_transport
+          get :index, params: { type: "other" }
+          expect(response.status).to eq(200)
+          expect(parsed_body["designations"].count).to eq(0)
+          expect(parsed_body["meta"]["total_pages"]).to eql(0)
+        end
 
         it "returns records with multiple specified types" do
           create :appointment, :with_state_submitted, description: "IPhone 100s", order_transport: order_transport

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -264,22 +264,17 @@ RSpec.describe Api::V1::OrdersController, type: :controller do
         end
 
         context "when order_type is other" do
-          it "returns response with order having invalid detail_type" do
+          before do
             create :order, :with_state_processing, detail_type: "other" , code: "2345"
             create :order, :with_state_processing, detail_type: "xyz" , code: "23845"
+          end
+
+          it "returns response with order having invalid detail_type" do
             get :index, params: { type: "other" }
             order_types = parsed_body["designations"].map { |res| res["detail_type"] }
             expect(response.status).to eq(200)
             expect(order_types.uniq).to match_array(["other", "xyz"])
             expect(parsed_body["designations"].count).to eq(2)
-          end
-
-          it 'response will not have order with valid detail_type' do
-            create :online_order, :awaiting_dispatch, description: "Testing", order_transport: ggv_transport
-            get :index, params: { type: "other" }
-            expect(response.status).to eq(200)
-            expect(parsed_body["designations"].count).to eq(0)
-            expect(parsed_body["meta"]["total_pages"]).to eql(0)
           end
         end
 


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3475

### What does this PR do?

FEATURE: STOCK: user can filter orders of type "carry out" or "other"