### PR TITLE
GCW-3476-Some orders have more than one transport type

### DIFF
--- a/db/migrate/20210118111336_add_unique_constraints_to_order_on_transport.rb
+++ b/db/migrate/20210118111336_add_unique_constraints_to_order_on_transport.rb
@@ -1,0 +1,6 @@
+class AddUniqueConstraintsToOrderOnTransport < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :order_transports, :order_id
+    add_index :order_transports, :order_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2021_01_12_024003) do
+=======
+ActiveRecord::Schema.define(version: 2021_01_18_111336) do
+>>>>>>> migration added for orders_transport order_id uniqueness
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "btree_gin"
+  enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "addresses", id: :serial, force: :cascade do |t|
-    t.string "flat"
-    t.string "building"
-    t.string "street"
+    t.string "flat", limit: 255
+    t.string "building", limit: 255
+    t.string "street", limit: 255
     t.integer "district_id"
     t.integer "addressable_id"
-    t.string "addressable_type"
-    t.string "address_type"
+    t.string "addressable_type", limit: 255
+    t.string "address_type", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -48,7 +51,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
 
   create_table "auth_tokens", id: :serial, force: :cascade do |t|
     t.datetime "otp_code_expiry"
-    t.string "otp_secret_key"
+    t.string "otp_secret_key", limit: 255
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -76,7 +79,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "identifier"
-    t.index ["name_en", "name_zh_tw"], name: "index_booking_types_on_name_en_and_name_zh_tw", unique: true
+    t.index ["identifier"], name: "index_booking_types_on_identifier"
   end
 
   create_table "boxes", id: :serial, force: :cascade do |t|
@@ -160,8 +163,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "contacts", id: :serial, force: :cascade do |t|
-    t.string "name"
-    t.string "mobile"
+    t.string "name", limit: 255
+    t.string "mobile", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -175,8 +178,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "crossroads_transports", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cost"
@@ -188,7 +191,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.integer "offer_id"
     t.integer "contact_id"
     t.integer "schedule_id"
-    t.string "delivery_type"
+    t.string "delivery_type", limit: 255
     t.datetime "start"
     t.datetime "finish"
     t.datetime "created_at"
@@ -202,8 +205,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "districts", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.integer "territory_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -213,8 +216,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "donor_conditions", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "visible_to_donor", default: true, null: false
@@ -239,7 +242,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
 
   create_table "gogovan_orders", id: :serial, force: :cascade do |t|
     t.integer "booking_id"
-    t.string "status"
+    t.string "status", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -253,8 +256,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "gogovan_transports", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "disabled", default: false
@@ -283,7 +286,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   create_table "holidays", id: :serial, force: :cascade do |t|
     t.datetime "holiday"
     t.integer "year"
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -297,7 +300,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "images", id: :serial, force: :cascade do |t|
-    t.string "cloudinary_id"
+    t.string "cloudinary_id", limit: 255
     t.boolean "favourite", default: false
     t.integer "item_id"
     t.datetime "created_at"
@@ -315,11 +318,11 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
 
   create_table "items", id: :serial, force: :cascade do |t|
     t.text "donor_description"
-    t.string "state"
+    t.string "state", limit: 255
     t.integer "offer_id", null: false
     t.integer "package_type_id"
     t.integer "rejection_reason_id"
-    t.string "reject_reason"
+    t.string "reject_reason", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "donor_condition_id"
@@ -336,8 +339,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.string "area"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["area"], name: "index_locations_on_area", using: :gin
-    t.index ["building"], name: "index_locations_on_building", using: :gin
   end
 
   create_table "lookups", id: :serial, force: :cascade do |t|
@@ -373,18 +374,17 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.integer "messageable_id"
     t.jsonb "lookup", default: {}
     t.integer "recipient_id"
-    t.index ["body"], name: "messages_body_search_idx", using: :gin
     t.index ["lookup"], name: "index_messages_on_lookup", using: :gin
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
   create_table "offers", id: :serial, force: :cascade do |t|
-    t.string "language"
-    t.string "state"
-    t.string "origin"
+    t.string "language", limit: 255
+    t.string "state", limit: 255
+    t.string "origin", limit: 255
     t.boolean "stairs"
     t.boolean "parking"
-    t.string "estimated_size"
+    t.string "estimated_size", limit: 255
     t.text "notes"
     t.integer "created_by_id"
     t.datetime "created_at"
@@ -413,7 +413,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.index ["created_by_id"], name: "index_offers_on_created_by_id"
     t.index ["crossroads_transport_id"], name: "index_offers_on_crossroads_transport_id"
     t.index ["gogovan_transport_id"], name: "index_offers_on_gogovan_transport_id"
-    t.index ["notes"], name: "offers_notes_search_idx", using: :gin
     t.index ["received_by_id"], name: "index_offers_on_received_by_id"
     t.index ["reviewed_by_id"], name: "index_offers_on_reviewed_by_id"
     t.index ["state"], name: "index_offers_on_state"
@@ -442,7 +441,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.index ["contact_id"], name: "index_order_transports_on_contact_id"
     t.index ["gogovan_order_id"], name: "index_order_transports_on_gogovan_order_id"
     t.index ["gogovan_transport_id"], name: "index_order_transports_on_gogovan_transport_id"
-    t.index ["order_id"], name: "index_order_transports_on_order_id"
+    t.index ["order_id"], name: "index_order_transports_on_order_id", unique: true
     t.index ["scheduled_at"], name: "index_order_transports_on_scheduled_at"
   end
 
@@ -487,7 +486,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.index ["beneficiary_id"], name: "index_orders_on_beneficiary_id"
     t.index ["cancelled_by_id"], name: "index_orders_on_cancelled_by_id"
     t.index ["closed_by_id"], name: "index_orders_on_closed_by_id"
-    t.index ["code"], name: "orders_code_idx", using: :gin
     t.index ["country_id"], name: "index_orders_on_country_id"
     t.index ["created_by_id"], name: "index_orders_on_created_by_id"
     t.index ["detail_id", "detail_type"], name: "index_orders_on_detail_id_and_detail_type"
@@ -614,23 +612,23 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.boolean "visible_in_selects", default: false
     t.integer "location_id"
     t.boolean "allow_requests", default: true
-    t.boolean "allow_stock", default: false
     t.boolean "allow_pieces", default: false
+    t.boolean "allow_stock", default: false
     t.string "subform"
     t.boolean "allow_box", default: false
     t.boolean "allow_pallet", default: false
-    t.boolean "allow_expiry_date", default: false
     t.decimal "default_value_hk_dollar"
+    t.boolean "allow_expiry_date", default: false
+    t.text "description_en"
+    t.text "description_zh_tw"
     t.integer "length"
     t.integer "width"
     t.integer "height"
     t.string "department"
-    t.text "description_en"
-    t.text "description_zh_tw"
     t.index ["allow_requests"], name: "index_package_types_on_allow_requests"
+    t.index ["description_en"], name: "index_package_types_on_description_en"
+    t.index ["description_zh_tw"], name: "index_package_types_on_description_zh_tw"
     t.index ["location_id"], name: "index_package_types_on_location_id"
-    t.index ["name_en"], name: "package_types_name_en_search_idx", using: :gin
-    t.index ["name_zh_tw"], name: "package_types_name_zh_tw_search_idx", using: :gin
     t.index ["visible_in_selects"], name: "index_package_types_on_visible_in_selects"
   end
 
@@ -640,7 +638,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.integer "height"
     t.text "notes", null: false
     t.integer "item_id"
-    t.string "state"
+    t.string "state", limit: 255
     t.datetime "received_at"
     t.datetime "rejected_at"
     t.integer "package_type_id"
@@ -672,12 +670,12 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.integer "detail_id"
     t.string "detail_type"
     t.integer "storage_type_id"
+    t.decimal "value_hk_dollar"
     t.integer "available_quantity", default: 0
     t.integer "on_hand_quantity", default: 0
     t.integer "designated_quantity", default: 0
     t.integer "dispatched_quantity", default: 0
     t.date "expiry_date"
-    t.decimal "value_hk_dollar"
     t.integer "package_set_id"
     t.integer "restriction_id"
     t.text "comment"
@@ -687,24 +685,19 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.index ["allow_web_publish"], name: "index_packages_on_allow_web_publish"
     t.index ["available_quantity"], name: "index_packages_on_available_quantity"
     t.index ["box_id"], name: "index_packages_on_box_id"
-    t.index ["case_number"], name: "index_packages_on_case_number", using: :gin
     t.index ["designated_quantity"], name: "index_packages_on_designated_quantity"
-    t.index ["designation_name"], name: "index_packages_on_designation_name", using: :gin
     t.index ["detail_type", "detail_id"], name: "index_packages_on_detail_type_and_detail_id"
     t.index ["dispatched_quantity"], name: "index_packages_on_dispatched_quantity"
     t.index ["donor_condition_id"], name: "index_packages_on_donor_condition_id"
     t.index ["inventory_number"], name: "index_packages_on_inventory_number"
-    t.index ["inventory_number"], name: "inventory_numbers_search_idx", using: :gin
     t.index ["item_id"], name: "index_packages_on_item_id"
     t.index ["location_id"], name: "index_packages_on_location_id"
-    t.index ["notes"], name: "index_packages_on_notes", using: :gin
     t.index ["offer_id"], name: "index_packages_on_offer_id"
     t.index ["on_hand_quantity"], name: "index_packages_on_on_hand_quantity"
     t.index ["order_id"], name: "index_packages_on_order_id"
     t.index ["package_set_id"], name: "index_packages_on_package_set_id"
     t.index ["package_type_id"], name: "index_packages_on_package_type_id"
     t.index ["pallet_id"], name: "index_packages_on_pallet_id"
-    t.index ["state"], name: "index_packages_on_state", using: :gin
     t.index ["stockit_designated_by_id"], name: "index_packages_on_stockit_designated_by_id"
     t.index ["stockit_moved_by_id"], name: "index_packages_on_stockit_moved_by_id"
     t.index ["stockit_sent_by_id"], name: "index_packages_on_stockit_sent_by_id"
@@ -758,7 +751,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "permissions", id: :serial, force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -803,10 +796,10 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "rejection_reasons", id: :serial, force: :cascade do |t|
-    t.string "name_en"
+    t.string "name_en", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "name_zh_tw"
+    t.string "name_zh_tw", limit: 255
   end
 
   create_table "requested_packages", id: :serial, force: :cascade do |t|
@@ -845,10 +838,10 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "schedules", id: :serial, force: :cascade do |t|
-    t.string "resource"
+    t.string "resource", limit: 255
     t.integer "slot"
-    t.string "slot_name"
-    t.string "zone"
+    t.string "slot_name", limit: 255
+    t.string "zone", limit: 255
     t.datetime "scheduled_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -867,6 +860,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.text "notes_zh_tw"
     t.index ["created_by_id"], name: "index_shareables_on_created_by_id"
     t.index ["expires_at"], name: "index_shareables_on_expires_at"
+    t.index ["public_uid"], name: "index_shareables_on_public_uid"
     t.index ["resource_id", "resource_type"], name: "index_shareables_on_resource_id_and_resource_type", unique: true
     t.index ["resource_type", "resource_id"], name: "index_shareables_on_resource_type_and_resource_id", unique: true
     t.index ["resource_type"], name: "index_shareables_on_resource_type"
@@ -887,10 +881,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["first_name"], name: "st_contacts_first_name_idx", using: :gin
-    t.index ["last_name"], name: "st_contacts_last_name_idx", using: :gin
-    t.index ["mobile_phone_number"], name: "st_contacts_mobile_phone_number_idx", using: :gin
-    t.index ["phone_number"], name: "st_contacts_phone_number_idx", using: :gin
   end
 
   create_table "stockit_local_orders", id: :serial, force: :cascade do |t|
@@ -901,7 +891,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "purpose_of_goods"
-    t.index ["client_name"], name: "st_local_orders_client_name_idx", using: :gin
   end
 
   create_table "stockit_organisations", id: :serial, force: :cascade do |t|
@@ -909,7 +898,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "st_organisations_name_idx", using: :gin
   end
 
   create_table "stocktake_revisions", id: :serial, force: :cascade do |t|
@@ -958,15 +946,15 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
     t.boolean "is_default", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["package_type_id", "package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
     t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id"
-    t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
     t.index ["subpackage_type_id"], name: "index_subpackage_types_on_subpackage_type_id"
   end
 
   create_table "subscriptions", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "message_id"
-    t.string "state"
+    t.string "state", limit: 255
     t.string "subscribable_type"
     t.integer "subscribable_id"
     t.index ["message_id"], name: "index_subscriptions_on_message_id"
@@ -975,15 +963,15 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "territories", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "timeslots", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -1011,9 +999,9 @@ ActiveRecord::Schema.define(version: 2021_01_12_024003) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
-    t.string "mobile"
+    t.string "first_name", limit: 255
+    t.string "last_name", limit: 255
+    t.string "mobile", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "image_id"

--- a/spec/controllers/api/v1/appointment_slots_controller_spec.rb
+++ b/spec/controllers/api/v1/appointment_slots_controller_spec.rb
@@ -70,14 +70,13 @@ RSpec.describe Api::V1::AppointmentSlotsController, type: :controller do
       end
 
       it 'specifies the number of remaining slots (/calendar)' do
-        appointment_order = FactoryBot.create(:order, booking_type: appointment_type)
         FactoryBot.create :appointment_slot, timestamp: DateTime.parse('29th Oct 2018 10:30:00+08:00'), quota: 5 # Monday
         FactoryBot.create :appointment_slot, timestamp: DateTime.parse('30th Oct 2018 10:30:00+08:00'), quota: 5 # Tuesday
         FactoryBot.create :appointment_slot, timestamp: DateTime.parse('30th Oct 2018 14:00:00+08:00'), quota: 5 # Tuesday
 
-        (1..5).each { |i| FactoryBot.create :order_transport, scheduled_at: Date.parse('29-10-2018'), timeslot: '10:30AM-11:30PM', order: appointment_order }
-        (1..3).each { |i| FactoryBot.create :order_transport, scheduled_at: Date.parse('30-10-2018'), timeslot: '10:30AM-11:30PM', order: appointment_order }
-        (1..5).each { |i| FactoryBot.create :order_transport, scheduled_at: Date.parse('30-10-2018'), timeslot: '2PM-3PM', order: appointment_order }
+        (1..5).each { |i| FactoryBot.create :order_transport, scheduled_at: Date.parse('29-10-2018'), timeslot: '10:30AM-11:30PM', order: FactoryBot.create(:order, booking_type: appointment_type) }
+        (1..3).each { |i| FactoryBot.create :order_transport, scheduled_at: Date.parse('30-10-2018'), timeslot: '10:30AM-11:30PM', order: FactoryBot.create(:order, booking_type: appointment_type) }
+        (1..5).each { |i| FactoryBot.create :order_transport, scheduled_at: Date.parse('30-10-2018'), timeslot: '2PM-3PM', order: FactoryBot.create(:order, booking_type: appointment_type) }
 
         get :calendar, params: { from: '2018-10-29', to: '2018-10-30' }
         results = parsed_body['appointment_calendar_dates']

--- a/spec/models/order_transport_spec.rb
+++ b/spec/models/order_transport_spec.rb
@@ -116,4 +116,19 @@ RSpec.describe OrderTransport, type: :model do
       expect(order_transport2.pickup?).to be_falsey
     end
   end
+
+  describe "Unique to order" do
+    let!(:order) { create(:order, :with_state_submitted) }
+    let!(:order2) { create(:order, :with_state_submitted) }
+    let!(:order_transport) { create(:order_transport, transport_type: "self", order_id: order.id) }
+    let (:order_transport2) { create(:order_transport, transport_type: "self") }
+
+    it "should throw uniqeness error if order_transport is assigned to same order" do
+      expect { order_transport2.update(order_id: order.id) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "should not throw uniqeness error if order_transport is assigned to new order" do
+      expect(order_transport2.update(order_id: order2.id)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3476

### What does this PR do?

This PR adds a `unique` constraint for `order_id` on the `orders_transport` table and added specs to test this feature.



