### PR TITLE
GCW-3489: Remove watcher toggle

### DIFF
--- a/app/models/concerns/watcher.rb
+++ b/app/models/concerns/watcher.rb
@@ -21,29 +21,14 @@ module Watcher
   extend ActiveSupport::Concern
 
   included do
-    thread_mattr_accessor :watcher_enabled
-
-    self.watcher_enabled = true
-
     class << self
       def watch(model_klasses, on: [:create, :update, :destroy, :touch], timing: :after)
         klass = self
         [model_klasses].flatten.uniq.each do |model_kass|
           on.each do |event|
-            model_kass.set_callback event, timing, ->(rec) {
-              if klass.watcher_enabled
-                yield(rec, event)
-              end
-            }
+            model_kass.set_callback event, timing, ->(rec) { yield(rec, event) }
           end
         end
-      end
-
-      def watcher_off
-        self.watcher_enabled = false
-        yield
-      ensure
-        self.watcher_enabled = true
       end
     end
   end

--- a/app/models/concerns/watcher.rb
+++ b/app/models/concerns/watcher.rb
@@ -23,7 +23,6 @@ module Watcher
   included do
     class << self
       def watch(model_klasses, on: [:create, :update, :destroy, :touch], timing: :after)
-        klass = self
         [model_klasses].flatten.uniq.each do |model_kass|
           on.each do |event|
             model_kass.set_callback event, timing, ->(rec) { yield(rec, event) }

--- a/app/models/stocktake.rb
+++ b/app/models/stocktake.rb
@@ -66,7 +66,7 @@ class Stocktake < ApplicationRecord
 
     ActiveRecord::Base.connection.execute <<-SQL
       INSERT INTO stocktake_revisions (package_id, stocktake_id, quantity, dirty, state, created_by_id, created_at, updated_at)
-        SELECT pinv.package_id, #{stocktake_id}, #{quantity}, #{dirty}, #{state}, #{created_by_id}, NOW(), NOW()
+        SELECT pinv.package_id, #{stocktake_id}, #{quantity}, #{dirty}, '#{state}', #{created_by_id}, NOW(), NOW()
         FROM packages_inventories AS pinv
         WHERE location_id = #{location_id} AND package_id NOT IN (
           SELECT package_id FROM stocktake_revisions WHERE stocktake_id = #{stocktake_id} 

--- a/app/models/stocktake.rb
+++ b/app/models/stocktake.rb
@@ -66,7 +66,7 @@ class Stocktake < ApplicationRecord
       quantity: 0,
     }
 
-    ActiveRecord::Base.connection.execute <<-SQL
+    sql = ActiveRecord::Base.sanitize_sql <<-SQL
       INSERT INTO stocktake_revisions (package_id, created_at, updated_at, #{attrs.keys.join(',')})
         SELECT pinv.package_id, NOW(), NOW(), #{attrs.values.join(',')}
         FROM packages_inventories AS pinv
@@ -76,6 +76,8 @@ class Stocktake < ApplicationRecord
         GROUP BY package_id
         HAVING SUM(quantity) > 0
     SQL
+
+    ActiveRecord::Base.connection.execute(sql)
 
     compute_counters!
   end

--- a/spec/models/concerns/watcher_spec.rb
+++ b/spec/models/concerns/watcher_spec.rb
@@ -24,14 +24,4 @@ describe Watcher do
       Sample.calls
     }.by(1)
   end
-
-  describe "Disabling the watcher" do
-    it "doesn't trigger on changes made in a #watcher_off block" do
-      expect {
-        Sample.watcher_off do 
-          create(:package)
-        end
-      }.not_to change(Sample, :calls)
-    end
-  end
 end

--- a/spec/models/stocktake_spec.rb
+++ b/spec/models/stocktake_spec.rb
@@ -82,14 +82,6 @@ RSpec.describe Stocktake, type: :model do
       revision.update!(dirty: true)
       expect(stocktake.reload.gains).to eq(0)
     end
-
-    it "can be disabled by turning off the watcher module" do
-      expect {
-        Stocktake.watcher_off do
-          create :stocktake_revision, stocktake: stocktake, package: package, quantity: 6
-        end
-      }.not_to change(stocktake, :gains)
-    end
   end
 
   describe 'Populating revisions' do

--- a/spec/models/stocktake_spec.rb
+++ b/spec/models/stocktake_spec.rb
@@ -128,11 +128,6 @@ RSpec.describe Stocktake, type: :model do
       expect(stocktake.warnings).to eq(3)
     end
 
-    it "turns off computed properties during process" do
-      expect(Stocktake).to receive(:watcher_off).once
-      stocktake.populate_revisions!
-    end
-
     it "doesn't modify an existing revision for a package" do
       create(:stocktake_revision, package: packages.first, stocktake: stocktake, quantity: 5, dirty: false, state: 'processed')
 


### PR DESCRIPTION
Stocktake revision population code now uses a single query, that allows:

- the removal of callback toggle on Watcher, that was causing the bug
- improved performance as it's all done in a single query now

Note: I would advise against using `thread_mattr_accessor` for the time being as it clearly hasn't been working as intented