### PR TITLE
GCW-3497- Add permissions to access order transport in closed and cancelled state

### DIFF
--- a/app/controllers/api/v1/ability.rb
+++ b/app/controllers/api/v1/ability.rb
@@ -257,7 +257,7 @@ module Api
         can :create, OrderTransport
         if can_manage_order_transport?
           can %i[create index show], OrderTransport
-          can [:update], OrderTransport, order: { state: %w[draft submitted processing awaiting_dispatch] }
+          can [:update], OrderTransport, order: { state: %w[draft submitted processing awaiting_dispatch closed cancelled] }
         else
           can [:index, :show], OrderTransport, OrderTransport.user_orders(@user_id) do |transport|
             transport.order.created_by_id == @user_id

--- a/spec/controllers/api/v1/order_transport_controller_spec.rb
+++ b/spec/controllers/api/v1/order_transport_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Api::V1::OrderTransportsController, type: :controller do
       end
     end
 
-    context 'if an update is made on cancelled order by stock administrator' do
+    context 'if an update is made on cancelled order by supervisor' do
       before { generate_and_set_token(supervisor) }
       it 'does not allow to perform the operation' do
         order_transport = create(:order_transport, order: cancelled_order, timeslot: '2PM-3PM')

--- a/spec/controllers/api/v1/order_transport_controller_spec.rb
+++ b/spec/controllers/api/v1/order_transport_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::OrderTransportsController, type: :controller do
   let(:charity_user) { create :user, :charity, :with_can_manage_orders_permission }
+  let(:supervisor) { create(:user, :with_supervisor_role)}
+  let(:stock_administrator) { create(:user, :with_stock_administrator_role, :with_can_manage_order_transport_permission )}
   let(:order) { create :order, :with_state_submitted, created_by: charity_user }
   let(:cancelled_order) { create(:order, :with_state_cancelled, created_by: charity_user) }
   let(:order_transport) { create(:order_transport, order: order) }
@@ -14,7 +16,7 @@ RSpec.describe Api::V1::OrderTransportsController, type: :controller do
   end
 
   describe 'PUT order_transports/1' do
-    it 'updates the order_transport' do
+    it 'updates the order_transport with valid order state' do
       put :update, params: { id: order_transport.id,
                              order_transport: { scheduled_at: '2020-05-11T16:30:00+08:00',
                                                 timeslot: '16:30', order_id: order.id } }
@@ -24,15 +26,40 @@ RSpec.describe Api::V1::OrderTransportsController, type: :controller do
       expect(parsed_body['order_transport']['scheduled_at'].to_date).to eq('2020-05-11T16:30:00+08:00'.to_date)
     end
 
-    context 'if an update is made on cancelled order' do
+    context 'if an update is made on cancelled order by charity user' do
       it 'does not allow to perform the operation' do
         order_transport = create(:order_transport, order: cancelled_order, timeslot: '2PM-3PM')
         put :update, params: { id: order_transport.id,
                                order_transport: { timeslot: '16:30',
                                                   order_id: cancelled_order.id } }
+
         order_transport.reload
         expect(response).to have_http_status(:forbidden)
         expect(order_transport.timeslot).to eq('2PM-3PM')
+      end
+    end
+
+    context 'if an update is made on cancelled order by stock administrator' do
+      before { generate_and_set_token(stock_administrator) }
+      it 'allows to perform the operation' do
+        order_transport = create(:order_transport, order: cancelled_order, timeslot: '2PM-3PM')
+        put :update, params: { id: order_transport.id, order_transport: { timeslot: '16:30', scheduled_at: '2021-03-03T16:30:00+08:00', order_id: cancelled_order.id } }
+
+        order_transport.reload
+        expect(response).to have_http_status(:success)
+        expect(parsed_body['order_transport']['timeslot']).to eq('16:30')
+        expect(parsed_body['order_transport']['scheduled_at'].to_date).to eq('2021-03-03T16:30:00+08:00'.to_date)
+      end
+    end
+
+    context 'if an update is made on cancelled order by stock administrator' do
+      before { generate_and_set_token(supervisor) }
+      it 'does not allow to perform the operation' do
+        order_transport = create(:order_transport, order: cancelled_order, timeslot: '2PM-3PM')
+        put :update, params: { id: order_transport.id, order_transport: { timeslot: '15:30', order_id: cancelled_order.id } }
+
+        order_transport.reload
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3497

### What does this PR do?

FEATURE: Error message shows '[object Object]' when attempting to edit Transport Type on closed order fix