### PR TITLE
GCW 3201 Adding shareable id to notification payload

### DIFF
--- a/app/serializers/api/v1/notification_serializer.rb
+++ b/app/serializers/api/v1/notification_serializer.rb
@@ -5,7 +5,7 @@ module Api::V1
 
     def shareable_public_id
       if object.messageable_type == 'Offer'
-        Shareable.find_by(resource_id: object.messageable_id,resource_type: 'Offer').try(:public_uid)
+        Shareable.find_by(resource_id: object.messageable_id, resource_type: 'Offer').try(:public_uid)
       end
     end
 

--- a/app/serializers/api/v1/notification_serializer.rb
+++ b/app/serializers/api/v1/notification_serializer.rb
@@ -4,8 +4,8 @@ module Api::V1
     attributes :shareable_public_id
 
     def shareable_public_id
-      if object.messageable_type == "Offer"
-        Shareable.find_by(resource_id: object.messageable_id).try(:public_uid)
+      if object.messageable_type == 'Offer'
+        Shareable.find_by(resource_id: object.messageable_id,resource_type: 'Offer').try(:public_uid)
       end
     end
 

--- a/app/serializers/api/v1/notification_serializer.rb
+++ b/app/serializers/api/v1/notification_serializer.rb
@@ -1,6 +1,13 @@
 module Api::V1
   class NotificationSerializer < MessageSerializer
     attributes :unread_count
+    attributes :shareable_public_id
+
+    def shareable_public_id
+      if object.messageable_type == "Offer"
+        Shareable.find_by(resource_id: object.messageable_id).try(:public_uid)
+      end
+    end
 
     def unread_count
       record = Message.select("count(subscriptions.state)")

--- a/spec/serializers/api/v1/notification_serializer_spec.rb
+++ b/spec/serializers/api/v1/notification_serializer_spec.rb
@@ -3,10 +3,12 @@ require "rails_helper"
 describe Api::V1::NotificationSerializer do
 
   let(:user) { create(:user) }
+  let(:offer)  { create(:offer) }
+  let(:shareable) { create :shareable, resource: offer }
   let(:package) { create :package }
-  let(:message) { create :message, messageable: package, is_private: true }
-  let(:message2) { create :message, messageable: package, is_private: true }
-  let(:serializer) { Api::V1::NotificationSerializer.new(message, root: "message").as_json }
+  let(:message) { create :message, messageable: offer, is_private: true }
+  let(:message2) { create :message, messageable: offer, is_private: true }
+  let(:serializer) { Api::V1::NotificationSerializer.new(message, root: "message").as_json
   let(:json) { JSON.parse(serializer.to_json) }
 
   before do
@@ -22,5 +24,6 @@ describe Api::V1::NotificationSerializer do
     expect(json["message"]["is_private"]).to eql(message.is_private)
     expect(json["message"]["sender_id"]).to eql(message.sender_id)
     expect(json["message"]["unread_count"]).to eql(2)
+    expect(json["message"]["shareable_public_id"]).to eql(shareable.public_uid)
   end
 end

--- a/spec/serializers/api/v1/notification_serializer_spec.rb
+++ b/spec/serializers/api/v1/notification_serializer_spec.rb
@@ -4,11 +4,11 @@ describe Api::V1::NotificationSerializer do
 
   let(:user) { create(:user) }
   let(:offer)  { create(:offer) }
-  let(:shareable) { create :shareable, resource: offer }
+  let!(:shareable) { create :shareable, resource: offer }
   let(:package) { create :package }
   let(:message) { create :message, messageable: offer, is_private: true }
   let(:message2) { create :message, messageable: offer, is_private: true }
-  let(:serializer) { Api::V1::NotificationSerializer.new(message, root: "message").as_json
+  let(:serializer) { Api::V1::NotificationSerializer.new(message, root: "message").as_json }
   let(:json) { JSON.parse(serializer.to_json) }
 
   before do


### PR DESCRIPTION
GCW 3201 Adding shareable id to notification payload to add uid for the route of offer messages from notification in the browse app