### PR TITLE
GCW-3519 - Fix ordering issue when users are searched with last_name

### DIFF
--- a/app/models/concerns/fuzzy_search.rb
+++ b/app/models/concerns/fuzzy_search.rb
@@ -94,15 +94,14 @@ module FuzzySearch
       similarities = search_prop_names.reduce({}) do |sims, f|
         sims[f] = self.model.sanitize_sql_for_conditions(["SIMILARITY(#{f}, ?)", search_text])
         sims
-      end 
+      end
 
-      select_list = similarities.values + ["#{table_name}.*"]
+      select_list = ["GREATEST(#{similarities.values.join(',')}) as max_tolerance"] + ["#{table_name}.*"]
       conditions  = similarities.map { |f, s| "#{s} >= #{search_configuration[f][:threshold]}" }
-      ordering    = similarities.values.map { |s| "#{s} DESC" }
 
       select(Arel.sql(select_list.join(',')))
         .where(Arel.sql(conditions.join(' OR ')))
-        .order(Arel.sql(ordering.join(',')))
+        .order(Arel.sql('max_tolerance DESC'))
         .distinct
     }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -121,8 +121,12 @@ describe User, :type => :model do
       charity_users.each { |u| sample_role.grant(u) }
     end
 
-    it "will return users according to searchText" do
+    it "will return users based on firstname from search text" do
       expect(User.search(charity_users.first.first_name)).to include(charity_users.first)
+    end
+
+    it "will return users based on lastname from search text" do
+      expect(User.search(charity_users.first.last_name)).to include(charity_users.first)
     end
 
     it "will return users based on email from search text" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3519

### What does this PR do?

When Users are searched with last_name, show matched results at top of the list
