### PR TITLE
FIX: Offers.send_message without donor

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -287,7 +287,7 @@ class Offer < ApplicationRecord
   end
 
   def send_message(body, user)
-    messages.create(body: body, sender: user) unless body.blank?
+    messages.create(body: body, sender: user, recipient: created_by) unless body.blank? || user.blank? || created_by.blank?
   end
 
   def assign_reviewer(reviewer)

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Offer, type: :model do
 
   before { allow_any_instance_of(PushService).to receive(:notify) }
   let(:offer) { create :offer }
+  let(:offer_with_no_donor) { create :offer, created_by: nil }
 
   it_behaves_like "paranoid"
 
@@ -245,8 +246,9 @@ RSpec.describe Offer, type: :model do
       offer.send_message(nil, user)
     end
     it 'should not send a message if the offer has no donor' do
-      expect(offer).not_to receive(:messages)
-      offer.send_message(nil, user)
+      expect(offer_with_no_donor.created_by).to eq(nil)
+      expect(offer_with_no_donor).not_to receive(:messages)
+      offer_with_no_donor.send_message("test", user)
     end
   end
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Offer, type: :model do
   describe "#send_message" do
     let(:user) { create :user }
     it 'should send message to donor' do
-      expect(offer).to receive_message_chain(:messages, :create).with({body: "test message", sender: user})
+      expect(offer).to receive_message_chain(:messages, :create).with({body: "test message", sender: user, recipient: offer.created_by})
       offer.send_message("test message", user)
     end
     it 'should not send message to donor if message is empty' do
@@ -241,6 +241,10 @@ RSpec.describe Offer, type: :model do
       offer.send_message("", user)
     end
     it 'should not send message to donor if message is nil' do
+      expect(offer).not_to receive(:messages)
+      offer.send_message(nil, user)
+    end
+    it 'should not send a message if the offer has no donor' do
       expect(offer).not_to receive(:messages)
       offer.send_message(nil, user)
     end


### PR DESCRIPTION
Calling `send_message` on an Offer will not do anything if a donor is not present.