### PR TITLE
GCW-3576- Add otp-auth-key recycling for signup pages

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,6 +130,7 @@ class User < ApplicationRecord
     mobile = user_params["mobile"].presence
     email = user_params["email"].presence
     user = find_user_by_mobile_or_email(mobile, email)
+    AuthenticationService.otp_auth_key_for(user, refresh: true) if user.present?
     user ||= new(user_params)
     user.preferred_language = I18n.locale
     user.request_from_browse = (app_name == BROWSE_APP)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -236,6 +236,24 @@ describe User, :type => :model do
         end
       end
     end
+
+    context "when user is present" do
+      it "should recycle otp_auth_key" do
+        user = create(:user, mobile: mobile, email: "abc@example.com")
+        expect(AuthenticationService).to receive(:otp_auth_key_for).with(user,refresh: true)
+        User.creation_with_auth(user_attributes, BROWSE_APP)
+      end
+    end
+
+    context "when user is not present" do
+      it "should not recycle otp_auth_key" do
+        new_user = build(:user)
+        allow(new_user).to receive(:send_verification_pin)
+        expect(User).to receive(:new).with(user_attributes).and_return(new_user)
+        expect(AuthenticationService).not_to receive(:otp_auth_key_for)
+        User.creation_with_auth(user_attributes, BROWSE_APP)
+      end
+    end
   end
 
   describe "#send_verification_pin" do


### PR DESCRIPTION
### Ticket Link: 
 
 https://jira.crossroads.org.hk/browse/GCW-3576?focusedCommentId=46565&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-46565

### What does this PR do?

Recycling otp_auth_key in signup endpoint if user is present.