### PR TITLE
Performance improvement: stocktake counters

### DIFF
--- a/spec/models/concerns/stocktake_processor_spec.rb
+++ b/spec/models/concerns/stocktake_processor_spec.rb
@@ -99,6 +99,11 @@ context StocktakeProcessor do
       expect { subject.process_stocktake(stocktake)  }.to raise_error(Goodcity::InvalidStateError).with_message('Some quantity revisions require a re-count')
     end
 
+    it 'calls computed_counters! only once' do
+      expect_any_instance_of(Stocktake).to receive(:compute_counters!).and_call_original
+      subject.process_stocktake(Stocktake.find(stocktake.id))
+    end
+
     describe 'when an error occurs' do
       before do
         # This quantity designated, therefore cannot be reduced in the inventory

--- a/spec/models/concerns/stocktake_processor_spec.rb
+++ b/spec/models/concerns/stocktake_processor_spec.rb
@@ -100,7 +100,7 @@ context StocktakeProcessor do
     end
 
     it 'calls computed_counters! only once' do
-      expect_any_instance_of(Stocktake).to receive(:compute_counters!).and_call_original
+      expect_any_instance_of(Stocktake).to receive(:compute_counters!).once.and_call_original
       subject.process_stocktake(Stocktake.find(stocktake.id))
     end
 

--- a/spec/models/stocktake_spec.rb
+++ b/spec/models/stocktake_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Stocktake, type: :model do
     let(:location) { create(:location) }
     let(:package) { create(:package, received_quantity: 5) }
     let(:stocktake) { create(:stocktake, location: location) }
-  
+
     before { initialize_inventory(package, location: location) }
 
     before do
@@ -81,6 +81,12 @@ RSpec.describe Stocktake, type: :model do
       expect(stocktake.reload.gains).to eq(1)
       revision.update!(dirty: true)
       expect(stocktake.reload.gains).to eq(0)
+    end
+
+    it "doesnt modify counters if ran within a without_auto_counters block" do
+      expect {
+        Stocktake.without_auto_counters { create :stocktake_revision, stocktake: stocktake, package: package, quantity: 6 }
+      }.not_to change(stocktake, :gains)
     end
   end
 


### PR DESCRIPTION
:zap: 

- Disable auto-recount of counter caches during stocktake processing
- The counters will be re-counted only once at the end of the entire
process

