### PR TITLE
Stocktakes: move processing to Sidekiq

### DIFF
--- a/app/controllers/api/v1/stocktake_revisions_controller.rb
+++ b/app/controllers/api/v1/stocktake_revisions_controller.rb
@@ -12,7 +12,6 @@ module Api
         error 500, "Internal Server Error"
       end
 
-
       api :POST, "/v1/stocktake_revisions", "Create a stocktake revision"
       def create
         stocktake = Stocktake.find(stocktake_revision_params['stocktake_id'])

--- a/app/jobs/stocktake_job.rb
+++ b/app/jobs/stocktake_job.rb
@@ -1,0 +1,13 @@
+class StocktakeJob < ActiveJob::Base
+  queue_as :high
+
+  def perform(stocktake_id)
+    Stocktake.locked(stocktake_id) do
+      stocktake = Stocktake.find(stocktake_id)
+
+      if stocktake&.awaiting_process?
+        Stocktake.process_stocktake(stocktake)
+      end
+    end
+  end
+end

--- a/app/models/stocktake_revision.rb
+++ b/app/models/stocktake_revision.rb
@@ -50,7 +50,7 @@ class StocktakeRevision < ApplicationRecord
   # ---------------------
 
   def validate_open_stocktake
-    return if self.stocktake.open?
+    return if self.stocktake&.open?
 
     if self.new_record? || self.quantity_changed?
       errors.add(:base, Goodcity::InvalidStateError.new(I18n.t('stocktakes.cannot_edit_revision')))

--- a/app/models/stocktake_revision.rb
+++ b/app/models/stocktake_revision.rb
@@ -8,6 +8,8 @@ class StocktakeRevision < ApplicationRecord
 
   before_save :unset_dirty_and_warning
 
+  validate :validate_open_stocktake, on: [:create, :update]
+
   # ---------------------
   # Live updates
   # ---------------------
@@ -46,6 +48,14 @@ class StocktakeRevision < ApplicationRecord
   # ---------------------
   # Hook methods
   # ---------------------
+
+  def validate_open_stocktake
+    return if self.stocktake.open?
+
+    if self.new_record? || self.quantity_changed?
+      errors.add(:base, Goodcity::InvalidStateError.new(I18n.t('stocktakes.cannot_edit_revision')))
+    end
+  end
 
   def unset_dirty_and_warning
     self.dirty    = false unless self.dirty_changed?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,7 @@ en:
     cancel_requires_undispatch: "Unable to cancel during dispatch, please undispatch and try again"
     exceed_dispatch_quantity: "You cannot dispatch more than were ordered."
   stocktakes:
+    cannot_edit_revision: Revisions can only be edited on open stocktakes
     invalid_state: Cannot process a closed or cancelled Stocktake
     dirty_revisions: Some quantity revisions require a re-count
   organisations_user_builder:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -144,6 +144,7 @@ zh-tw:
     cancel_requires_undispatch: "Unable to cancel during dispatch, please undispatch and try again"
     exceed_dispatch_quantity: "You cannot dispatch more than were ordered."
   stocktakes:
+    cannot_edit_revision: Revisions can only be edited on open stocktakes
     invalid_state: Cannot process a closed or cancelled Stocktake
     dirty_revisions: Some quantity revisions require a re-count
   organisations_user_builder:

--- a/spec/jobs/stocktake_job_spec.rb
+++ b/spec/jobs/stocktake_job_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe StocktakeJob, :type => :job do
+  let(:location) { create(:location) }
+  let(:stocktake) { create(:stocktake, location: location) }
+  let(:package_1) { create(:package, received_quantity: 10) }
+  let(:package_2) { create(:package, received_quantity: 10) }
+  let(:package_3) { create(:package, received_quantity: 10) }
+
+  before do
+    touch(stocktake)
+    initialize_inventory(package_1, package_2, package_3, location: location)
+    create(:stocktake_revision, package: package_1, stocktake: stocktake, quantity: 12)  # we counted more
+    create(:stocktake_revision, package: package_2, stocktake: stocktake, quantity: 8)   # we counted less
+    create(:stocktake_revision, package: package_3, stocktake: stocktake, quantity: 10)  # we counted the same amount
+  end
+
+  [
+    'closed',
+    'cancelled',
+    'open',
+    'processing'
+  ].each do |state|
+    it "does not calls the stocktake processor if the state is #{state}" do
+      stocktake.update(state: state)
+      expect(Stocktake).not_to receive(:process_stocktake)
+      StocktakeJob.new.perform(stocktake.id)
+    end
+  end
+
+  context 'for a stocktake awaiting processing' do
+    before do
+      stocktake.update(state: 'awaiting_process')
+    end
+
+    it "calls the stocktake processor if the state is awaiting_process" do
+      expect(Stocktake).to receive(:process_stocktake).once.with(stocktake).and_call_original
+      StocktakeJob.new.perform(stocktake.id)
+    end
+
+    it "creates inventory rows to correct the quantities" do
+      expect(Stocktake).to receive(:process_stocktake).once.with(stocktake).and_call_original
+
+      expect {
+        StocktakeJob.new.perform(stocktake.id)
+      }.to change(PackagesInventory, :count).by(2)
+
+      change_1, change_2 = PackagesInventory.last(2)
+      expect(change_1.package_id).to eq(package_1.id)
+      expect(change_1.quantity).to eq(2)
+      expect(change_2.package_id).to eq(package_2.id)
+      expect(change_2.quantity).to eq(-2)
+    end
+
+    it "closes the stocktake" do
+      expect {
+        StocktakeJob.new.perform(stocktake.id)
+      }.to change { stocktake.reload.state }.from('awaiting_process').to('closed')
+    end
+  end
+end

--- a/spec/models/concerns/stocktake_processor_spec.rb
+++ b/spec/models/concerns/stocktake_processor_spec.rb
@@ -73,6 +73,13 @@ context StocktakeProcessor do
       ).to eq(0)
     end
 
+    it 'sets the state to processing at startup, and closes after' do
+      expect(stocktake).to receive(:start_processing).ordered.and_call_original
+      expect(stocktake).to receive(:close).ordered.and_call_original
+      subject.process_stocktake(stocktake)
+      expect(stocktake.reload.state).to eq('closed')
+    end
+
     it 'closes the stocktake' do
       expect {
         subject.process_stocktake(stocktake)
@@ -123,6 +130,13 @@ context StocktakeProcessor do
         expect(stocktake_revision.reload.warning).to eq('')
         subject.process_stocktake(stocktake.reload)
         expect(stocktake_revision.reload.warning).to match(/please undesignate first/)
+      end
+
+      it 'restores the state back to open' do
+        expect(stocktake).to receive(:start_processing).ordered.and_call_original
+        expect(stocktake).to receive(:reopen).ordered.and_call_original
+        subject.process_stocktake(stocktake)
+        expect(stocktake.reload.state).to eq('open')
       end
     end
   end

--- a/spec/models/stocktake_revision_spec.rb
+++ b/spec/models/stocktake_revision_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe StocktakeRevision, type: :model do
 
       expect {
         stocktake_revision.update(quantity: 888)
-      }.to change { 
+      }.to change {
         stocktake_revision.reload.dirty
       }.from(true).to(false)
     end


### PR DESCRIPTION
# :zap: Sidekiq Stocktakes

## Changes

- Stocktakes have 2 new states:
  * `awaiting_process` -> This means they've been queued, used to avoid double-queuing
  * `processing` -> This means Sidekiq is actively working on the stocktake

- Endpoint `/stocktakes/:id/commit` now returns immediatly, with the state updated to `awaiting_process`

- New files: `jobs/stocktake_job.rb`