### PR TITLE
Fixed filtering of messages

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -104,9 +104,9 @@ module Api
       private
 
       def invalid_messageable_resource
-        render json: {
-          errors: "Please provide valid values for messageable_id and messageable_type"
-        }, status: 403
+        render json: Goodcity::InvalidParamsError.with_text(
+          'Please provide valid values for messageable_id and messageable_type'
+        ), status: 403
       end
 
       def apply_filters(messages, options)

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -37,6 +37,8 @@ module Api
       param :recipient_id, String, desc: "Specific user id to fetch the messages of"
       param :state, String, desc: "Message state (unread|read) to filter on"
       def index
+        return invalid_messageable_resource if params[:messageable_id].present? && params[:messageable_type].blank?
+
         @messages = apply_scope(@messages, params[:scope]) if params[:scope].present?
         @messages = apply_filters(@messages, params)
         @messages = @messages.with_state_for_user(current_user, params[:state].split(",")) if params[:state].present?
@@ -100,6 +102,12 @@ module Api
       end
 
       private
+
+      def invalid_messageable_resource
+        render json: {
+          errors: "Please provide valid values for messageable_id and messageable_type"
+        }, status: 403
+      end
 
       def apply_filters(messages, options)
         messages = messages.unscoped.where(is_private: bool_param(:is_private, false)) if options[:is_private].present?

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -145,6 +145,15 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
         expect(subject['messages'].map{|row| row["messageable_id"] }.uniq).to match_array([offer.id, offer2.id])
       end
 
+      it "invalid messageable params" do
+        3.times { create :subscription, state: 'unread', subscribable: offer, user: user, message: (create :message, messageable: offer) }
+        3.times { create :subscription, state: 'unread', subscribable: offer2, user: user, message: (create :message, messageable: offer2, is_private: false) }
+
+        get :index, params: { messageable_id: [offer.id,offer2.id] }
+
+        expect(subject["errors"]).to eq("Please provide valid values for messageable_id and messageable_type")
+      end
+
       it "for one order" do
         3.times { create :message, sender: reviewer, messageable: order }
         3.times { create :message, sender: reviewer, messageable: order2 }
@@ -544,7 +553,7 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
             .where(user: user, state: "unread", subscribable: package).first_or_create
         end
 
-        get :notifications, params: { messageable_type: ["package"], is_private: "true" }
+        get :notifications, params: { messageable_type: ["Package"], is_private: "true" }
 
         expect(response.status).to eq(200)
         expect(subject['messages'].length).to eq(1)
@@ -563,7 +572,7 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
             .where(user: user, state: "unread", subscribable: package).first_or_create
         end
 
-        get :notifications, params: { messageable_type: ["package"], is_private: "false" }
+        get :notifications, params: { messageable_type: ["Package"], is_private: "false" }
 
         expect(response.status).to eq(200)
         expect(subject['messages'].length).to eq(2)

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
 
         get :index, params: { messageable_id: [offer.id,offer2.id] }
 
-        expect(subject["errors"]).to eq("Please provide valid values for messageable_id and messageable_type")
+        expect(subject["error"]).to eq("Please provide valid values for messageable_id and messageable_type")
       end
 
       it "for one order" do


### PR DESCRIPTION
On fetching messages, `messageable_type` should be present along with `messageable_id` values.