### PR TITLE
FIX: packages controller enforces location_id when inventory_number is set

### DIFF
--- a/app/models/packages_inventory.rb
+++ b/app/models/packages_inventory.rb
@@ -81,6 +81,10 @@ class PackagesInventory < ApplicationRecord
     last.present? && !last.uninventory?
   end
 
+  def self.uninventorized?(package)
+    !inventorized?(package)
+  end
+
   def incremental?
     return quantity.positive? if UNRESTRICTED_ACTIONS.include?(action)
     INCREMENTAL_ACTIONS.include?(action)


### PR DESCRIPTION
Issue: 

The packages_controller endpoint was used for stockit sync, and was therefore overly permissive.

We found issues which allowed the admin app to set inventory numbers on records without a location_id. That in turn prevented the actual inventory step to take place (in packages_inventory).

This PR adds a workaround: we prevent setting the inventory_number without also providing a location.

Note: This is not a proper fix, a proper fix would require to rewrite these endpoints properly, and make inventory an actual action we take on a package.
 