### PR TITLE
ADD: counted_by_ids to stocktake_revisions

### DIFF
--- a/app/controllers/api/v1/stocktake_revisions_controller.rb
+++ b/app/controllers/api/v1/stocktake_revisions_controller.rb
@@ -29,7 +29,7 @@ module Api
         @stocktake_revision.assign_attributes(stocktake_revision_params)
 
         if @stocktake_revision.quantity_changed? || @stocktake_revision.dirty_changed?
-          @stocktake_revision.counted_by_ids = [*@stocktake_revision.counted_by_ids, User.current_user.id].flatten
+          @stocktake_revision.counted_by_ids = [*@stocktake_revision.counted_by_ids, User.current_user.id].uniq
         end
 
         save_and_render_object_with_errors(@stocktake_revision)

--- a/app/controllers/api/v1/stocktake_revisions_controller.rb
+++ b/app/controllers/api/v1/stocktake_revisions_controller.rb
@@ -20,12 +20,18 @@ module Api
         raise Goodcity::DuplicateRecordError if exists.present?
 
         @stocktake_revision.created_by = current_user
+        @stocktake_revision.counted_by_ids = [current_user.id]
         save_and_render_object_with_errors(@stocktake_revision)
       end
 
       api :PUT, "/v1/stocktakes/:id", "Updates a revision"
       def update
         @stocktake_revision.assign_attributes(stocktake_revision_params)
+
+        if @stocktake_revision.quantity_changed? || @stocktake_revision.dirty_changed?
+          @stocktake_revision.counted_by_ids = [*@stocktake_revision.counted_by_ids, User.current_user.id].flatten
+        end
+
         save_and_render_object_with_errors(@stocktake_revision)
       end
 

--- a/app/serializers/api/v1/stocktake_revision_serializer.rb
+++ b/app/serializers/api/v1/stocktake_revision_serializer.rb
@@ -4,7 +4,7 @@ module Api
       embed :ids, include: true
 
       has_one :package, serializer: PackageSerializer
-      attributes :id, :stocktake_id, :package_id, :warning, :state, :quantity, :dirty, :processed_delta, :created_at, :updated_at
+      attributes :id, :stocktake_id, :package_id, :warning, :state, :quantity, :dirty, :processed_delta, :created_at, :updated_at, :counted_by_ids
     end
   end
 end

--- a/db/migrate/20210911024837_add_counted_by_ids_to_stocktake_revisions.rb
+++ b/db/migrate/20210911024837_add_counted_by_ids_to_stocktake_revisions.rb
@@ -1,0 +1,6 @@
+class AddCountedByIdsToStocktakeRevisions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stocktake_revisions, :counted_by_ids, :jsonb, default: []
+    add_index :stocktake_revisions, :counted_by_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_20_222418) do
+ActiveRecord::Schema.define(version: 2021_09_11_024837) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "btree_gin"
+  enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "addresses", id: :serial, force: :cascade do |t|
-    t.string "flat"
-    t.string "building"
-    t.string "street"
+    t.string "flat", limit: 255
+    t.string "building", limit: 255
+    t.string "street", limit: 255
     t.integer "district_id"
     t.integer "addressable_id"
-    t.string "addressable_type"
-    t.string "address_type"
+    t.string "addressable_type", limit: 255
+    t.string "address_type", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
 
   create_table "auth_tokens", id: :serial, force: :cascade do |t|
     t.datetime "otp_code_expiry"
-    t.string "otp_secret_key"
+    t.string "otp_secret_key", limit: 255
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "identifier"
-    t.index ["name_en", "name_zh_tw"], name: "index_booking_types_on_name_en_and_name_zh_tw", unique: true
+    t.index ["identifier"], name: "index_booking_types_on_identifier"
   end
 
   create_table "boxes", id: :serial, force: :cascade do |t|
@@ -162,8 +162,8 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "contacts", id: :serial, force: :cascade do |t|
-    t.string "name"
-    t.string "mobile"
+    t.string "name", limit: 255
+    t.string "mobile", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -186,8 +186,8 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "crossroads_transports", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cost"
@@ -199,7 +199,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "offer_id"
     t.integer "contact_id"
     t.integer "schedule_id"
-    t.string "delivery_type"
+    t.string "delivery_type", limit: 255
     t.datetime "start"
     t.datetime "finish"
     t.datetime "created_at"
@@ -213,8 +213,8 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "districts", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.integer "territory_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -224,8 +224,8 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "donor_conditions", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "visible_to_donor", default: true, null: false
@@ -250,7 +250,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
 
   create_table "gogovan_orders", id: :serial, force: :cascade do |t|
     t.integer "booking_id"
-    t.string "status"
+    t.string "status", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -264,8 +264,8 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "gogovan_transports", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "disabled", default: false
@@ -294,7 +294,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   create_table "holidays", id: :serial, force: :cascade do |t|
     t.datetime "holiday"
     t.integer "year"
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -308,7 +308,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "images", id: :serial, force: :cascade do |t|
-    t.string "cloudinary_id"
+    t.string "cloudinary_id", limit: 255
     t.boolean "favourite", default: false
     t.integer "item_id"
     t.datetime "created_at"
@@ -326,11 +326,11 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
 
   create_table "items", id: :serial, force: :cascade do |t|
     t.text "donor_description"
-    t.string "state"
+    t.string "state", limit: 255
     t.integer "offer_id", null: false
     t.integer "package_type_id"
     t.integer "rejection_reason_id"
-    t.string "reject_reason"
+    t.string "reject_reason", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "donor_condition_id"
@@ -347,8 +347,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.string "area"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["area"], name: "index_locations_on_area", opclass: :gin_trgm_ops, using: :gin
-    t.index ["building"], name: "index_locations_on_building", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "lookups", id: :serial, force: :cascade do |t|
@@ -384,7 +382,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "messageable_id"
     t.jsonb "lookup", default: {}
     t.integer "recipient_id"
-    t.index ["body"], name: "messages_body_search_idx", opclass: :gin_trgm_ops, using: :gin
     t.index ["lookup"], name: "index_messages_on_lookup", using: :gin
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
@@ -398,12 +395,12 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "offers", id: :serial, force: :cascade do |t|
-    t.string "language"
-    t.string "state"
-    t.string "origin"
+    t.string "language", limit: 255
+    t.string "state", limit: 255
+    t.string "origin", limit: 255
     t.boolean "stairs"
     t.boolean "parking"
-    t.string "estimated_size"
+    t.string "estimated_size", limit: 255
     t.text "notes"
     t.integer "created_by_id"
     t.datetime "created_at"
@@ -432,7 +429,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.index ["created_by_id"], name: "index_offers_on_created_by_id"
     t.index ["crossroads_transport_id"], name: "index_offers_on_crossroads_transport_id"
     t.index ["gogovan_transport_id"], name: "index_offers_on_gogovan_transport_id"
-    t.index ["notes"], name: "offers_notes_search_idx", opclass: :gin_trgm_ops, using: :gin
     t.index ["received_by_id"], name: "index_offers_on_received_by_id"
     t.index ["reviewed_by_id"], name: "index_offers_on_reviewed_by_id"
     t.index ["state"], name: "index_offers_on_state"
@@ -506,7 +502,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.index ["beneficiary_id"], name: "index_orders_on_beneficiary_id"
     t.index ["cancelled_by_id"], name: "index_orders_on_cancelled_by_id"
     t.index ["closed_by_id"], name: "index_orders_on_closed_by_id"
-    t.index ["code"], name: "orders_code_idx", opclass: :gin_trgm_ops, using: :gin
     t.index ["country_id"], name: "index_orders_on_country_id"
     t.index ["created_by_id"], name: "index_orders_on_created_by_id"
     t.index ["detail_id", "detail_type"], name: "index_orders_on_detail_id_and_detail_type"
@@ -634,22 +629,22 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "location_id"
     t.boolean "allow_requests", default: true
     t.boolean "allow_pieces", default: false
-    t.string "subform"
     t.boolean "allow_package", default: false
+    t.string "subform"
     t.boolean "allow_box", default: false
     t.boolean "allow_pallet", default: false
-    t.boolean "allow_expiry_date", default: false
     t.decimal "default_value_hk_dollar"
+    t.boolean "allow_expiry_date", default: false
+    t.text "description_en"
+    t.text "description_zh_tw"
     t.integer "length"
     t.integer "width"
     t.integer "height"
     t.string "department"
-    t.text "description_en"
-    t.text "description_zh_tw"
     t.index ["allow_requests"], name: "index_package_types_on_allow_requests"
+    t.index ["description_en"], name: "index_package_types_on_description_en"
+    t.index ["description_zh_tw"], name: "index_package_types_on_description_zh_tw"
     t.index ["location_id"], name: "index_package_types_on_location_id"
-    t.index ["name_en"], name: "package_types_name_en_search_idx", opclass: :gin_trgm_ops, using: :gin
-    t.index ["name_zh_tw"], name: "package_types_name_zh_tw_search_idx", opclass: :gin_trgm_ops, using: :gin
     t.index ["visible_in_selects"], name: "index_package_types_on_visible_in_selects"
   end
 
@@ -659,7 +654,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "height"
     t.text "notes", null: false
     t.integer "item_id"
-    t.string "state"
+    t.string "state", limit: 255
     t.datetime "received_at"
     t.datetime "rejected_at"
     t.integer "package_type_id"
@@ -686,18 +681,17 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.string "case_number"
     t.boolean "allow_web_publish"
     t.integer "received_quantity"
-    t.boolean "last_allow_web_published"
     t.integer "weight"
     t.integer "pieces"
     t.integer "detail_id"
     t.string "detail_type"
     t.integer "storage_type_id"
+    t.decimal "value_hk_dollar", null: false
     t.integer "available_quantity", default: 0
     t.integer "on_hand_quantity", default: 0
     t.integer "designated_quantity", default: 0
     t.integer "dispatched_quantity", default: 0
     t.date "expiry_date"
-    t.decimal "value_hk_dollar", null: false
     t.integer "package_set_id"
     t.integer "restriction_id"
     t.text "comment"
@@ -707,24 +701,19 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.index ["allow_web_publish"], name: "index_packages_on_allow_web_publish"
     t.index ["available_quantity"], name: "index_packages_on_available_quantity"
     t.index ["box_id"], name: "index_packages_on_box_id"
-    t.index ["case_number"], name: "index_packages_on_case_number", opclass: :gin_trgm_ops, using: :gin
     t.index ["designated_quantity"], name: "index_packages_on_designated_quantity"
-    t.index ["designation_name"], name: "index_packages_on_designation_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["detail_type", "detail_id"], name: "index_packages_on_detail_type_and_detail_id"
     t.index ["dispatched_quantity"], name: "index_packages_on_dispatched_quantity"
     t.index ["donor_condition_id"], name: "index_packages_on_donor_condition_id"
     t.index ["inventory_number"], name: "index_packages_on_inventory_number"
-    t.index ["inventory_number"], name: "inventory_numbers_search_idx", opclass: :gin_trgm_ops, using: :gin
     t.index ["item_id"], name: "index_packages_on_item_id"
     t.index ["location_id"], name: "index_packages_on_location_id"
-    t.index ["notes"], name: "index_packages_on_notes", opclass: :gin_trgm_ops, using: :gin
     t.index ["offer_id"], name: "index_packages_on_offer_id"
     t.index ["on_hand_quantity"], name: "index_packages_on_on_hand_quantity"
     t.index ["order_id"], name: "index_packages_on_order_id"
     t.index ["package_set_id"], name: "index_packages_on_package_set_id"
     t.index ["package_type_id"], name: "index_packages_on_package_type_id"
     t.index ["pallet_id"], name: "index_packages_on_pallet_id"
-    t.index ["state"], name: "index_packages_on_state", opclass: :gin_trgm_ops, using: :gin
     t.index ["stockit_designated_by_id"], name: "index_packages_on_stockit_designated_by_id"
     t.index ["stockit_moved_by_id"], name: "index_packages_on_stockit_moved_by_id"
     t.index ["stockit_sent_by_id"], name: "index_packages_on_stockit_sent_by_id"
@@ -778,7 +767,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "permissions", id: :serial, force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -823,10 +812,10 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "rejection_reasons", id: :serial, force: :cascade do |t|
-    t.string "name_en"
+    t.string "name_en", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "name_zh_tw"
+    t.string "name_zh_tw", limit: 255
   end
 
   create_table "requested_packages", id: :serial, force: :cascade do |t|
@@ -865,10 +854,10 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "schedules", id: :serial, force: :cascade do |t|
-    t.string "resource"
+    t.string "resource", limit: 255
     t.integer "slot"
-    t.string "slot_name"
-    t.string "zone"
+    t.string "slot_name", limit: 255
+    t.string "zone", limit: 255
     t.datetime "scheduled_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -908,10 +897,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["first_name"], name: "st_contacts_first_name_idx", opclass: :gin_trgm_ops, using: :gin
-    t.index ["last_name"], name: "st_contacts_last_name_idx", opclass: :gin_trgm_ops, using: :gin
-    t.index ["mobile_phone_number"], name: "st_contacts_mobile_phone_number_idx", opclass: :gin_trgm_ops, using: :gin
-    t.index ["phone_number"], name: "st_contacts_phone_number_idx", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "stockit_local_orders", id: :serial, force: :cascade do |t|
@@ -922,7 +907,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "purpose_of_goods"
-    t.index ["client_name"], name: "st_local_orders_client_name_idx", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "stockit_organisations", id: :serial, force: :cascade do |t|
@@ -930,7 +914,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "stockit_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "st_organisations_name_idx", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "stocktake_revisions", id: :serial, force: :cascade do |t|
@@ -944,6 +927,8 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "processed_delta", default: 0
+    t.jsonb "counted_by_ids", default: []
+    t.index ["counted_by_ids"], name: "index_stocktake_revisions_on_counted_by_ids"
     t.index ["package_id", "stocktake_id"], name: "index_stocktake_revisions_on_package_id_and_stocktake_id", unique: true
     t.index ["package_id"], name: "index_stocktake_revisions_on_package_id"
     t.index ["stocktake_id", "package_id"], name: "index_stocktake_revisions_on_stocktake_id_and_package_id", unique: true
@@ -979,15 +964,15 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.boolean "is_default", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["package_type_id", "package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
     t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id"
+    t.index ["package_type_id"], name: "index_subpackage_types_on_package_type_id_and_package_type_id"
     t.index ["subpackage_type_id"], name: "index_subpackage_types_on_subpackage_type_id"
   end
 
   create_table "subscriptions", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "message_id"
-    t.string "state"
+    t.string "state", limit: 255
     t.string "subscribable_type"
     t.integer "subscribable_id"
     t.index ["message_id"], name: "index_subscriptions_on_message_id"
@@ -996,15 +981,15 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "territories", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "timeslots", id: :serial, force: :cascade do |t|
-    t.string "name_en"
-    t.string "name_zh_tw"
+    t.string "name_en", limit: 255
+    t.string "name_zh_tw", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -1032,9 +1017,9 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
-    t.string "mobile"
+    t.string "first_name", limit: 255
+    t.string "last_name", limit: 255
+    t.string "mobile", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "image_id"
@@ -1072,7 +1057,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_222418) do
     t.integer "related_id"
     t.string "related_type"
     t.datetime "created_at"
-    t.index ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY ((ARRAY['create'::character varying, 'update'::character varying])::text[])) AND (object_changes ? 'location_id'::text))"
+    t.index ["created_at", "whodunnit"], name: "partial_index_recent_locations", where: "(((event)::text = ANY (ARRAY[('create'::character varying)::text, ('update'::character varying)::text])) AND (object_changes ? 'location_id'::text))"
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["event"], name: "index_versions_on_event"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"

--- a/spec/models/stocktake_revision_spec.rb
+++ b/spec/models/stocktake_revision_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe StocktakeRevision, type: :model do
     it { is_expected.to have_db_column(:quantity).of_type(:integer) }
     it { is_expected.to have_db_column(:dirty).of_type(:boolean) }
     it { is_expected.to have_db_column(:processed_delta).of_type(:integer) }
+    it { is_expected.to have_db_column(:counted_by_ids).of_type(:jsonb) }
   end
 
   describe "Validations" do

--- a/spec/serializers/api/v1/stocktake_revision_serializer_spec.rb
+++ b/spec/serializers/api/v1/stocktake_revision_serializer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Api::V1::StocktakeRevisionSerializer do
 
-  let(:record) { build(:stocktake_revision) }
+  let(:record) { build(:stocktake_revision, counted_by_ids: [1,2,3]) }
   let(:serializer) { Api::V1::StocktakeRevisionSerializer.new(record).as_json }
   let(:json) { JSON.parse( serializer.to_json ) }
 
@@ -11,6 +11,7 @@ describe Api::V1::StocktakeRevisionSerializer do
     expect(json['stocktake_revision']['package_id']).to eql(record.package_id)
     expect(json['stocktake_revision']['stocktake_id']).to eql(record.stocktake_id)
     expect(json['stocktake_revision']['quantity']).to eql(record.quantity)
+    expect(json['stocktake_revision']['counted_by_ids']).to eql(record.counted_by_ids)
   end
 
   it "Includes associations" do


### PR DESCRIPTION
Each revision of a stocktake now has a jsonb field called `counted_by_ids` which is an array of ids.
Whenever a user updates the quantity or the dirty flag, his/her id gets added to the list