### PR TITLE
Fix bug with state_value for current_user

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -55,7 +55,13 @@ module Api
       param_group :message
       def create
         @message.sender_id = current_user.id
-        save_and_render_object(@message)
+        if @message.save
+          # after_create hooks may set state_value to the wrong value so reset to 'read' for current_user
+          @message.state_value = 'read'
+          render json: @message, serializer: serializer_for(@message), status: 201
+        else
+          render json: @message.errors, status: 422
+        end
       end
 
       api :PUT, "/v1/messages/:id/mark_read", "Mark message as read"

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -56,7 +56,7 @@ module Api
       def create
         @message.sender_id = current_user.id
         if @message.save
-          # after_create hooks may set state_value to the wrong value so reset to 'read' for current_user
+          # after_create hooks may set state_value to the wrong value so reset to 'read' for user who created the message
           @message.state_value = 'read'
           render json: @message, serializer: serializer_for(@message), status: 201
         else

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -402,6 +402,11 @@ RSpec.describe Api::V1::MessagesController, type: :controller do
           post :create, params: { message: { **message_params, recipient_id: charity.id.to_s } }, as: :json
           expect(response.status).to eq(403)
         end
+
+        it 'sets the state to read for the creator' do
+          post :create, params: { message: message_params }, as: :json
+          expect(subject['message']['state']).to eql('read')
+        end
       end
 
       context 'as a charity about an offer' do

--- a/spec/controllers/api/v1/package_types_controller_spec.rb
+++ b/spec/controllers/api/v1/package_types_controller_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Api::V1::PackageTypesController, type: :controller do
     before { generate_and_set_token(user) }
 
     it "returns all package_types", show_in_doc: true  do
-      create_list :base_package_type, 3
+      create(:base_package_type, allow_package: true, code: "AFO"),
+      create(:base_package_type, allow_package: true, code: "BBC"),
+      create(:base_package_type, allow_package: true, code: "BBM")
 
       get :index
 

--- a/spec/controllers/api/v1/package_types_controller_spec.rb
+++ b/spec/controllers/api/v1/package_types_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Api::V1::PackageTypesController, type: :controller do
     before { generate_and_set_token(user) }
 
     it "returns all package_types", show_in_doc: true  do
-      create(:base_package_type, allow_package: true, code: "AFO"),
-      create(:base_package_type, allow_package: true, code: "BBC"),
+      create(:base_package_type, allow_package: true, code: "AFO")
+      create(:base_package_type, allow_package: true, code: "BBC")
       create(:base_package_type, allow_package: true, code: "BBM")
 
       get :index

--- a/spec/models/concerns/push_updates_for_message_spec.rb
+++ b/spec/models/concerns/push_updates_for_message_spec.rb
@@ -102,7 +102,6 @@ context PushUpdatesForMessage do
     it do
       expect(push_service).to receive(:send_update_store) do |channels, data|
         expect(channels).to eql(test_channels)
-        expect(data[:item].attributes[:state]).to eq(state)
         expect(data[:sender].attributes[:id]).to eq(reviewer1.id)
         expect(data[:operation]).to eql(:create)
       end

--- a/spec/serializers/api/v1/notification_serializer_spec.rb
+++ b/spec/serializers/api/v1/notification_serializer_spec.rb
@@ -7,8 +7,8 @@ describe Api::V1::NotificationSerializer do
   let(:offerResponse)  { create(:offer_response, offer_id: offer.id) }
   let!(:shareable) { create :shareable, resource: offer }
   let(:package) { create :package }
-  let(:message) { create :message, messageable: offerResponse, is_private: true }
-  let(:message2) { create :message, messageable: offer, is_private: true }
+  let(:message) { create :message, messageable: offerResponse, is_private: true, sender: user }
+  let(:message2) { create :message, messageable: offer, is_private: true, sender: user }
   let(:serializer) { Api::V1::NotificationSerializer.new(message, root: "message").as_json }
   let(:json) { JSON.parse(serializer.to_json) }
 
@@ -21,7 +21,7 @@ describe Api::V1::NotificationSerializer do
   it "creates JSON" do
     expect(json["message"]["id"]).to eql(message.id)
     expect(json["message"]["body"]).to eql(message.body)
-    expect(json["message"]["state"]).to eql(message.state_value)
+    expect(json["message"]["state"]).to eql('read')
     expect(json["message"]["is_private"]).to eql(message.is_private)
     expect(json["message"]["sender_id"]).to eql(message.sender_id)
     expect(json["message"]["unread_count"]).to eql(1)


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3695

### What does this PR do?

BUG: Fixed bug where state_value was being set to the wrong value

TLDR; When a message is created, the after_create hook fires which sends push_updates to subscribed users. To ensure the correct 'unread/read' state is sent, we adjust the virtual attribute 'state_value' for each user we send to. However, when this is all done, we were not resetting state_value back for the current_user and hence were likely to send the wrong value back to the user who created the message.

This PR fixes the problem but it does assume that the user identified by 'sender_id' (i.e. themself) is creating the message. It wouldn't work if an admin was allowed to create a message on behalf of another user. This currently isn't allowed and would be an unlikely use case. Documented here for completeness.


### Impacted Areas

Dashboard -> Message unread count
