### PR TITLE
Fixed merge user bug

### DIFF
--- a/lib/goodcity/user_utils.rb
+++ b/lib/goodcity/user_utils.rb
@@ -51,21 +51,21 @@ module Goodcity
     end
 
     def self.reassign_offers(master_user, other_user)
-      other_user.offers.update(created_by_id: master_user.id)
-      other_user.reviewed_offers.update(reviewed_by_id: master_user.id)
+      other_user.offers.unscope(where: :deleted_at).update(created_by_id: master_user.id)
+      other_user.reviewed_offers.unscope(where: :deleted_at).update(reviewed_by_id: master_user.id)
 
       offer_columns = %w[closed_by_id received_by_id]
 
       offer_columns.each do |column|
-        Offer.where(column.to_sym => other_user.id).update(column.to_sym => master_user.id)
+        Offer.where(column.to_sym => other_user.id).unscope(where: :deleted_at).update(column.to_sym => master_user.id)
       end
     end
 
     def self.reassign_messages(master_user, other_user)
-      other_user.messages.update(sender_id: master_user.id)
+      other_user.messages.unscope(where: :deleted_at).update(sender_id: master_user.id)
       other_user.subscriptions.update(user_id: master_user.id)
 
-      Message.where(recipient_id: other_user.id).update(recipient_id: master_user.id)
+      Message.where(recipient_id: other_user.id).unscope(where: :deleted_at).update(recipient_id: master_user.id)
     end
 
     def self.reassign_packages(master_user, other_user)
@@ -154,7 +154,7 @@ module Goodcity
 
     def self.remove_unused_records(other_user)
       AuthToken.where(user_id: other_user.id).delete_all
-      other_user.address.try(:destroy)
+      Address.where(addressable: other_user).unscope(where: :deleted_at).destroy_all
     end
 
     def self.reassign_versions(master_user, other_user)

--- a/spec/lib/goodcity/user_utils_spec.rb
+++ b/spec/lib/goodcity/user_utils_spec.rb
@@ -79,6 +79,18 @@ context Goodcity::UserUtils do
         expect(master_user.offers.count).to eq(10)
       end
 
+      it "reassign deleted offers created by other-user" do
+        count_of_offers = other_user.offers.size
+        other_user.offers.first.destroy
+        expect(other_user.offers.size).to eql(count_of_offers - 1)
+        expect(other_user.offers.unscope(where: :deleted_at).size).to eql(count_of_offers)
+
+        Goodcity::UserUtils.reassign_offers(master_user, other_user)
+
+        expect(other_user.offers.size).to eq(0)
+        expect(master_user.offers.unscope(where: :deleted_at).size).to eq(10)
+      end
+
       it "reassign reviewed offers of other-user to master-user" do
         Goodcity::UserUtils.reassign_offers(master_user, other_user)
 
@@ -110,6 +122,20 @@ context Goodcity::UserUtils do
 
         expect(other_user.messages.count).to eq(0)
         expect(master_user.messages.count).to eq(10)
+      end
+
+      it "reassign deleted message of other-user to master-user" do
+        create_list :message, 5, sender: other_user
+        create_list :message, 5, sender: master_user
+
+        count_of_messages = other_user.messages.size
+        other_user.messages.first.destroy
+        expect(other_user.messages.size).to eql(count_of_messages - 1)
+        expect(other_user.messages.unscope(where: :deleted_at).size).to eql(count_of_messages)
+
+        Goodcity::UserUtils.reassign_messages(master_user, other_user)
+        expect(other_user.messages.size).to eq(0)
+        expect(master_user.messages.unscope(where: :deleted_at).size).to eq(10)
       end
 
       it "reassign sent messages of other-user to master-user" do


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3747

### What does this PR do?

BUG: When some users were being merged, foreign key integrity would prevent the user from being deleted if they still had some 'soft deleted' messages in the messages table that referenced their sender_id.

Modified the user_utils class to ensure it can see soft deleted objects.

Audited other tables for the same bug. Added code for addresses and offers.

### Impacted Areas

Merge users in Stock screen