### PR TITLE
Bump up shoulda-matchers version from 4.5.1 to 5.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,8 +472,8 @@ GEM
     shellany (0.0.1)
     shoulda-callback-matchers (1.1.4)
       activesupport (>= 3)
-    shoulda-matchers (4.5.1)
-      activesupport (>= 4.2.0)
+    shoulda-matchers (5.2.0)
+      activesupport (>= 5.2.0)
     sidekiq (6.4.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -551,7 +551,7 @@ GEM
       activerecord (>= 4.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Issue https://github.com/crossroads/api.goodcity/issues/1322 [Hacktoberfest]

Update the `shoulda-matchers` version to the latest.
Verified above changes by running the entire specs locally.

cc @steveyken 

