### PR TITLE
Bump up timecop version from 0.9.4 to 0.9.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.10)
-    timecop (0.9.4)
+    timecop (0.9.5)
     traco (5.3.2)
       activerecord (>= 4.2)
     ttfunk (1.7.0)


### PR DESCRIPTION
Issue https://github.com/crossroads/api.goodcity/issues/1322 [Hacktoberfest]

Update the `timecop` version to the latest.
Verified above changes by running the entire specs locally.

cc @steveyken 