### PR TITLE
Add FCM notification payload for Android

### DIFF
--- a/app/services/azure_notifications_service.rb
+++ b/app/services/azure_notifications_service.rb
@@ -163,6 +163,10 @@ class AzureNotificationsService
   #
   # {
   #   "message": {
+  #     "notification": {
+  #       "title": "#{notification_title}",
+  #       "body": "$(message)"
+  #     },
   #     "data": {
   #       "title": "#{notification_title}",
   #       "message": "$(message)",
@@ -182,7 +186,7 @@ class AzureNotificationsService
   #   }
   #  }
   def fcm_platform_xml(handle, tags)
-    template = "{\"message\":{\"data\":{\"title\":\"#{notification_title}\", \"message\":\"$(message)\", \"notId\": \"$(notId)\", \"style\":\"inbox\", \"summaryText\":\"There are %n% notifications.\", #{payload} } } }"
+    template = "{\"message\":{\"notification\":{\"title\":\"#{notification_title}\", \"body\":\"$(message)\"}, \"data\":{\"title\":\"#{notification_title}\", \"message\":\"$(message)\", \"notId\": \"$(notId)\", \"style\":\"inbox\", \"summaryText\":\"There are %n% notifications.\", #{payload} } } }"
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>
     <entry xmlns=\"http://www.w3.org/2005/Atom\">
       <content type=\"application/xml\">

--- a/spec/services/azure_notifications_service_spec.rb
+++ b/spec/services/azure_notifications_service_spec.rb
@@ -51,4 +51,33 @@ context AzureNotificationsService do
     end
 
   end
+
+  context "fcm_platform_xml" do
+    let(:handle) { "registration-token" }
+    let(:tags) { ["user_1"] }
+    let(:xml) { service.send(:fcm_platform_xml, handle, tags) }
+    let(:template) { xml.match(/<!\[CDATA\[(.*)\]\]>/m)[1] }
+    let(:payload) { JSON.parse(template) }
+
+    it "includes a notification block for system notifications" do
+      notification = payload.fetch("message").fetch("notification")
+
+      expect(notification).to include(
+        "title" => "S. GoodCity",
+        "body" => "$(message)"
+      )
+    end
+
+    it "keeps the data payload used by the app" do
+      data = payload.fetch("message").fetch("data")
+
+      expect(data).to include(
+        "title" => "S. GoodCity",
+        "message" => "$(message)",
+        "category" => "$(category)",
+        "offer_id" => "$(offer_id)",
+        "message_id" => "$(message_id)"
+      )
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

Adds a notification block to the FCM message template for Android push notifications. This is the standard way to trigger a system notification and does not rely on behaviour specific to Cordova plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced push notification structure for better delivery and compatibility with messaging services.

* **Tests**
  * Added test coverage for notification payload validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->